### PR TITLE
GCI: Onboard MoGCI RegionalMulticast* resources to google-nightly

### DIFF
--- a/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Consumer Association: https://docs.cloud.google.com/vpc/docs/multicast/enable-consumer-network#add-consumer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastConsumerAssociations
-min_version: nightly
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations/{{regional_multicast_consumer_association_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations?regionalMulticastConsumerAssociationId={{regional_multicast_consumer_association_id}}

--- a/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Consumer Association: https://docs.cloud.google.com/vpc/docs/multicast/enable-consumer-network#add-consumer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastConsumerAssociations
-min_version: alpha
+min_version: beta
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations/{{regional_multicast_consumer_association_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations?regionalMulticastConsumerAssociationId={{regional_multicast_consumer_association_id}}

--- a/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Consumer Association: https://docs.cloud.google.com/vpc/docs/multicast/enable-consumer-network#add-consumer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastConsumerAssociations
-min_version: beta
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations/{{regional_multicast_consumer_association_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations?regionalMulticastConsumerAssociationId={{regional_multicast_consumer_association_id}}

--- a/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
@@ -14,6 +14,10 @@
 ---
 name: RegionalMulticastConsumerAssociation
 description: Create a regional multicast consumer association in the specified location of the current project.
+references:
+  guides:
+    Create Regional Multicast Consumer Association: https://docs.cloud.google.com/vpc/docs/multicast/enable-consumer-network#add-consumer
+  api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastConsumerAssociations
 min_version: nightly
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations/{{regional_multicast_consumer_association_id}}
@@ -112,6 +116,7 @@ properties:
   - name: state
     type: NestedObject
     description: The multicast resource's state.
+    output: true
     properties:
       - name: state
         type: String
@@ -126,6 +131,7 @@ properties:
           UPDATE_FAILED
           INACTIVE
           OBSOLETE
+        output: true
   - name: uniqueId
     type: String
     description: |-

--- a/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
@@ -60,35 +60,42 @@ samples:
 parameters:
   - name: location
     type: String
-    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
+    required: true
   - name: regionalMulticastConsumerAssociationId
     type: String
-    required: true
     description: |-
       A unique name for the regional multicast consumer association.
-      The name is restricted to lower-case letters, numbers, and hyphen, with
-      the first character a lower-case letter, and the last a letter or a
-      number. The name must not exceed 63 characters.
+      The name is restricted to letters, numbers, and hyphen, with the first
+      character a letter, and the last a letter or a number. The name must not
+      exceed 48 characters.
     immutable: true
     url_param_only: true
+    required: true
 properties:
   - name: createTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast consumer
-      association was created.
+      [Output only] The timestamp when the regional multicast consumer association was
+      created.
     output: true
   - name: description
     type: String
-    description: |-
-      An optional text description of the regional multicast consumer
-      association.
+    description: An optional text description of the regional multicast consumer association.
   - name: labels
     type: KeyValueLabels
     description: Labels as key-value pairs
+  - name: regionalMulticastDomainActivation
+    type: String
+    description: |-
+      The resource name of the regional multicast domain activation that is in the
+      same region as this regional multicast consumer association.
+      Use the following format:
+      // `projects/*/locations/*/regionalMulticastDomainActivations/*`.
+    immutable: true
+    required: true
   - name: name
     type: String
     description: |-
@@ -98,21 +105,21 @@ properties:
     output: true
   - name: network
     type: String
-    required: true
     description: |-
       The resource name of the multicast consumer VPC network.
       Use following format:
       `projects/{project}/locations/global/networks/{network}`.
     immutable: true
-  - name: regionalMulticastDomainActivation
-    type: String
     required: true
+  - name: placementPolicy
+    type: String
     description: |-
-      The resource name of the regional multicast domain activation that is in
-      the same region as this regional multicast consumer association.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastDomainActivations/*`.
-    immutable: true
+      [Output only] A Compute Engine (placement
+      policy)[https://cloud.google.com/compute/docs/instances/placement-policies-overview]
+      that can be used to place virtual machine (VM) instances as multicast
+      consumers close to the multicast infrastructure created for this domain,
+      on a best effort basis.
+    output: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -130,19 +137,18 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
-          OBSOLETE
         output: true
   - name: uniqueId
     type: String
     description: |-
       [Output only] The Google-generated UUID for the resource. This value is
-      unique across all regional multicast consumer association resources. If a
-      consumer association is deleted and another with the same name is created,
-      the new consumer association is assigned a different unique_id.
+      unique across all regional multicast consumer association resources. If a consumer
+      association is deleted and another with the same name is created, the new
+      consumer association is assigned a different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast consumer
-      association was most recently updated.
+      [Output only] The timestamp when the Regional Multicast Consumer Association was
+      most recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
@@ -1,0 +1,142 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: RegionalMulticastConsumerAssociation
+description: Create a regional multicast consumer association in the specified location of the current project.
+min_version: nightly
+base_url: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations
+self_link: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations/{{regional_multicast_consumer_association_id}}
+create_url: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations?regionalMulticastConsumerAssociationId={{regional_multicast_consumer_association_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations/{{regional_multicast_consumer_association_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/regionalMulticastConsumerAssociations/{{regional_multicast_consumer_association_id}}
+sweeper:
+  url_substitutions:
+    - location: us-central1
+async:
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 20
+      update_minutes: 20
+      delete_minutes: 20
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+autogen_status: UmVnaW9uYWxNdWx0aWNhc3RDb25zdW1lckFzc29jaWF0aW9u
+autogen_async: true
+samples:
+  - name: network_services_regional_multicast_consumer_association_basic
+    primary_resource_id: rmca_test
+    steps:
+      - name: network_services_regional_multicast_consumer_association_basic
+        resource_id_vars:
+          network_name: test-network-rmca
+          domain_name: test-domain-rmca
+          domain_activation_name: test-domain-activation-rmca
+          consumer_association_name: test-consumer-association-rmca
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: regionalMulticastConsumerAssociationId
+    type: String
+    required: true
+    description: |-
+      A unique name for the regional multicast consumer association.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: createTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast consumer
+      association was created.
+    output: true
+  - name: description
+    type: String
+    description: |-
+      An optional text description of the regional multicast consumer
+      association.
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key-value pairs
+  - name: name
+    type: String
+    description: |-
+      Identifier. The resource name of the regional multicast consumer association.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastConsumerAssociations/*`.
+    output: true
+  - name: network
+    type: String
+    required: true
+    description: |-
+      The resource name of the multicast consumer VPC network.
+      Use following format:
+      `projects/{project}/locations/global/networks/{network}`.
+    immutable: true
+  - name: regionalMulticastDomainActivation
+    type: String
+    required: true
+    description: |-
+      The resource name of the regional multicast domain activation that is in
+      the same region as this regional multicast consumer association.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastDomainActivations/*`.
+    immutable: true
+  - name: state
+    type: NestedObject
+    description: The multicast resource's state.
+    properties:
+      - name: state
+        type: String
+        description: |-
+          The state of the multicast resource.
+          Possible values:
+          CREATING
+          ACTIVE
+          DELETING
+          DELETE_FAILED
+          UPDATING
+          UPDATE_FAILED
+          INACTIVE
+          OBSOLETE
+  - name: uniqueId
+    type: String
+    description: |-
+      [Output only] The Google-generated UUID for the resource. This value is
+      unique across all regional multicast consumer association resources. If a
+      consumer association is deleted and another with the same name is created,
+      the new consumer association is assigned a different unique_id.
+    output: true
+  - name: updateTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast consumer
+      association was most recently updated.
+    output: true

--- a/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastConsumerAssociation.yaml
@@ -60,42 +60,35 @@ samples:
 parameters:
   - name: location
     type: String
+    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
-    required: true
   - name: regionalMulticastConsumerAssociationId
     type: String
+    required: true
     description: |-
       A unique name for the regional multicast consumer association.
-      The name is restricted to letters, numbers, and hyphen, with the first
-      character a letter, and the last a letter or a number. The name must not
-      exceed 48 characters.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
     immutable: true
     url_param_only: true
-    required: true
 properties:
   - name: createTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast consumer association was
-      created.
+      [Output only] The timestamp when the regional multicast consumer
+      association was created.
     output: true
   - name: description
     type: String
-    description: An optional text description of the regional multicast consumer association.
+    description: |-
+      An optional text description of the regional multicast consumer
+      association.
   - name: labels
     type: KeyValueLabels
     description: Labels as key-value pairs
-  - name: regionalMulticastDomainActivation
-    type: String
-    description: |-
-      The resource name of the regional multicast domain activation that is in the
-      same region as this regional multicast consumer association.
-      Use the following format:
-      // `projects/*/locations/*/regionalMulticastDomainActivations/*`.
-    immutable: true
-    required: true
   - name: name
     type: String
     description: |-
@@ -105,21 +98,21 @@ properties:
     output: true
   - name: network
     type: String
+    required: true
     description: |-
       The resource name of the multicast consumer VPC network.
       Use following format:
       `projects/{project}/locations/global/networks/{network}`.
     immutable: true
-    required: true
-  - name: placementPolicy
+  - name: regionalMulticastDomainActivation
     type: String
+    required: true
     description: |-
-      [Output only] A Compute Engine (placement
-      policy)[https://cloud.google.com/compute/docs/instances/placement-policies-overview]
-      that can be used to place virtual machine (VM) instances as multicast
-      consumers close to the multicast infrastructure created for this domain,
-      on a best effort basis.
-    output: true
+      The resource name of the regional multicast domain activation that is in
+      the same region as this regional multicast consumer association.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastDomainActivations/*`.
+    immutable: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -137,18 +130,19 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
+          OBSOLETE
         output: true
   - name: uniqueId
     type: String
     description: |-
       [Output only] The Google-generated UUID for the resource. This value is
-      unique across all regional multicast consumer association resources. If a consumer
-      association is deleted and another with the same name is created, the new
-      consumer association is assigned a different unique_id.
+      unique across all regional multicast consumer association resources. If a
+      consumer association is deleted and another with the same name is created,
+      the new consumer association is assigned a different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      [Output only] The timestamp when the Regional Multicast Consumer Association was
-      most recently updated.
+      [Output only] The timestamp when the regional multicast consumer
+      association was most recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Domain Activation: https://docs.cloud.google.com/vpc/docs/multicast/create-domains#activate-domain
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastDomainActivations
-min_version: nightly
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations/{{regional_multicast_domain_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations?regionalMulticastDomainActivationId={{regional_multicast_domain_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
@@ -59,53 +59,44 @@ samples:
 parameters:
   - name: location
     type: String
+    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
-    required: true
   - name: regionalMulticastDomainActivationId
     type: String
+    required: true
     description: |-
       A unique name for the regional multicast domain activation.
-      The name is restricted to letters, numbers, and hyphen, with the first
-      character a letter, and the last a letter or a number. The name must not
-      exceed 48 characters.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
     immutable: true
     url_param_only: true
-    required: true
 properties:
   - name: adminNetwork
     type: String
-    description: The URL of the admin network.
+    description: '[Output only] The URL of the admin network.'
     output: true
   - name: createTime
     type: String
     description: |-
-      The timestamp when the regional multicast domain activation was
-      created.
+      [Output only] The timestamp when the regional multicast domain activation
+      was created.
     output: true
   - name: description
     type: String
     description: An optional text description of the regional multicast domain activation.
-  - name: disablePlacementPolicy
-    type: Boolean
-    description: |-
-      Option to allow disabling placement policy for multicast infrastructure.
-      Only applicable if the activation is for a domain associating with a
-      multicast domain group.
-    immutable: true
-    default_from_api: true
   - name: labels
     type: KeyValueLabels
     description: Labels as key-value pairs
   - name: multicastDomain
     type: String
+    required: true
     description: |-
       The resource name of the multicast domain to activate.
-      Use the following format:
-      `projects/*/locations/global/multicastDomains/*`.
+      Use the following format: `projects/*/locations/global/multicastDomains/*`.
     immutable: true
-    required: true
   - name: name
     type: String
     description: |-
@@ -113,6 +104,39 @@ properties:
       Use the following format:
       `projects/*/locations/*/regionalMulticastDomainActivations/*`.
     output: true
+  - name: pimSpec
+    type: NestedObject
+    description: Specification for the PIM (Protocol Independent Multicast) protocol.
+    properties:
+      - name: multicastSourceLocation
+        type: String
+        required: true
+        description: |-
+          Indicates the location of the multicast source.
+          Possible values:
+          MULTICAST_SOURCE_GCP
+          MULTICAST_SOURCE_NON_GCP
+      - name: pimMode
+        type: String
+        description: |-
+          Specifies the PIM mode. If not specified, the service will default to
+          SPARSE. Only SPARSE is supported.
+          Possible values:
+          PIM_MODE_SPARSE
+        default_from_api: true
+      - name: rpIpAddress
+        type: String
+        description: The IP address of the PIM-SM Rendezvous Point (RP).
+  - name: regionalMulticastConsumerAssociations
+    type: Array
+    description: |-
+      [Output only] The resource names of the associated regional
+      multicast consumer associations in the following format:
+      `projects/*/locations/*/regionalMulticastConsumerAssociations/*`.
+    output: true
+    item_type:
+      type: String
+      output: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -130,53 +154,20 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
+          OBSOLETE
         output: true
-  - name: trafficSpec
-    type: NestedObject
-    description: |-
-      Specifies the traffic volume and multicast group scale parameters that are
-      used to set up multicast infrastructure for a multicast domain in a region.
-    properties:
-      - name: aggrEgressPps
-        type: String
-        description: |-
-          Aggregated egress Packet-Per-Second for all multicast groups in the domain
-          in this region.
-        default_from_api: true
-      - name: aggrIngressPps
-        type: String
-        description: |-
-          Aggregated ingress Packet-Per-Second for all multicast groups in the domain
-          in this region. Default to (aggregated_egress_pps /
-          max_per_group_subscribers) * 2.
-        default_from_api: true
-      - name: avgPacketSize
-        type: Integer
-        description: Average packet size (Default to 512 bytes).
-        default_from_api: true
-      - name: maxPerGroupIngressPps
-        type: String
-        description: |-
-          Maximum ingress Packet-Per-Second for a single multicast group in this
-          region. Default to aggregated_ingress_pps / 2.
-        default_from_api: true
-      - name: maxPerGroupSubscribers
-        type: String
-        description: |-
-          Maximum number of subscribers for a single multicast group in this region.
-          Default to max(50, aggregated_egress_pps / aggregated_ingress_pps).
-        default_from_api: true
   - name: uniqueId
     type: String
     description: |-
-      The Google-generated UUID for the resource. This value is
-      unique across all regional multicast domain activation resources. If a domain
-      activation is deleted and another with the same name is created, the new
-      domain activation is assigned a different unique_id.
+      [Output only] The Google-generated UUID for the resource. This value is
+      unique across all regional multicast domain activation resources. If a
+      regional multicast domain activation is deleted and another with the same
+      name is created, the new regional multicast domain activation is assigned a
+      different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      The timestamp when the regional multicast domain activation was most
-      recently updated.
+      [Output only] The timestamp when the regional multicast domain activation
+      was most recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Domain Activation: https://docs.cloud.google.com/vpc/docs/multicast/create-domains#activate-domain
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastDomainActivations
-min_version: alpha
+min_version: beta
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations/{{regional_multicast_domain_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations?regionalMulticastDomainActivationId={{regional_multicast_domain_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
@@ -14,6 +14,10 @@
 ---
 name: RegionalMulticastDomainActivation
 description: Create a regional multicast domain activation in the specified location of the current project.
+references:
+  guides:
+    Create Regional Multicast Domain Activation: https://docs.cloud.google.com/vpc/docs/multicast/create-domains#activate-domain
+  api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastDomainActivations
 min_version: nightly
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations/{{regional_multicast_domain_activation_id}}
@@ -119,6 +123,7 @@ properties:
           SPARSE. Only SPARSE is supported.
           Possible values:
           PIM_MODE_SPARSE
+        default_from_api: true
       - name: rpIpAddress
         type: String
         description: The IP address of the PIM-SM Rendezvous Point (RP).
@@ -135,6 +140,7 @@ properties:
   - name: state
     type: NestedObject
     description: The multicast resource's state.
+    output: true
     properties:
       - name: state
         type: String
@@ -149,6 +155,7 @@ properties:
           UPDATE_FAILED
           INACTIVE
           OBSOLETE
+        output: true
   - name: uniqueId
     type: String
     description: |-

--- a/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
@@ -1,0 +1,166 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: RegionalMulticastDomainActivation
+description: Create a regional multicast domain activation in the specified location of the current project.
+min_version: nightly
+base_url: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations
+self_link: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations/{{regional_multicast_domain_activation_id}}
+create_url: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations?regionalMulticastDomainActivationId={{regional_multicast_domain_activation_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations/{{regional_multicast_domain_activation_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations/{{regional_multicast_domain_activation_id}}
+sweeper:
+  url_substitutions:
+    - location: us-central1
+async:
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 20
+      update_minutes: 20
+      delete_minutes: 20
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+autogen_status: UmVnaW9uYWxNdWx0aWNhc3REb21haW5BY3RpdmF0aW9u
+autogen_async: true
+samples:
+  - name: network_services_regional_multicast_domain_activation_basic
+    primary_resource_id: rmda_test
+    steps:
+      - name: network_services_regional_multicast_domain_activation_basic
+        resource_id_vars:
+          network_name: test-network-rmda
+          domain_name: test-domain-rmda
+          domain_activation_name: test-domain-activation-rmda
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: regionalMulticastDomainActivationId
+    type: String
+    required: true
+    description: |-
+      A unique name for the regional multicast domain activation.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: adminNetwork
+    type: String
+    description: '[Output only] The URL of the admin network.'
+    output: true
+  - name: createTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast domain activation
+      was created.
+    output: true
+  - name: description
+    type: String
+    description: An optional text description of the regional multicast domain activation.
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key-value pairs
+  - name: multicastDomain
+    type: String
+    required: true
+    description: |-
+      The resource name of the multicast domain to activate.
+      Use the following format: `projects/*/locations/global/multicastDomains/*`.
+    immutable: true
+  - name: name
+    type: String
+    description: |-
+      Identifier. The resource name of the regional multicast domain activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastDomainActivations/*`.
+    output: true
+  - name: pimSpec
+    type: NestedObject
+    description: Specification for the PIM (Protocol Independent Multicast) protocol.
+    properties:
+      - name: multicastSourceLocation
+        type: String
+        required: true
+        description: |-
+          Indicates the location of the multicast source.
+          Possible values:
+          MULTICAST_SOURCE_GCP
+          MULTICAST_SOURCE_NON_GCP
+      - name: pimMode
+        type: String
+        description: |-
+          Specifies the PIM mode. If not specified, the service will default to
+          SPARSE. Only SPARSE is supported.
+          Possible values:
+          PIM_MODE_SPARSE
+      - name: rpIpAddress
+        type: String
+        description: The IP address of the PIM-SM Rendezvous Point (RP).
+  - name: regionalMulticastConsumerAssociations
+    type: Array
+    description: |-
+      [Output only] The resource names of the associated regional
+      multicast consumer associations in the following format:
+      `projects/*/locations/*/regionalMulticastConsumerAssociations/*`.
+    output: true
+    item_type:
+      type: String
+      output: true
+  - name: state
+    type: NestedObject
+    description: The multicast resource's state.
+    properties:
+      - name: state
+        type: String
+        description: |-
+          The state of the multicast resource.
+          Possible values:
+          CREATING
+          ACTIVE
+          DELETING
+          DELETE_FAILED
+          UPDATING
+          UPDATE_FAILED
+          INACTIVE
+          OBSOLETE
+  - name: uniqueId
+    type: String
+    description: |-
+      [Output only] The Google-generated UUID for the resource. This value is
+      unique across all regional multicast domain activation resources. If a
+      regional multicast domain activation is deleted and another with the same
+      name is created, the new regional multicast domain activation is assigned a
+      different unique_id.
+    output: true
+  - name: updateTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast domain activation
+      was most recently updated.
+    output: true

--- a/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
@@ -59,44 +59,53 @@ samples:
 parameters:
   - name: location
     type: String
-    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
+    required: true
   - name: regionalMulticastDomainActivationId
     type: String
-    required: true
     description: |-
       A unique name for the regional multicast domain activation.
-      The name is restricted to lower-case letters, numbers, and hyphen, with
-      the first character a lower-case letter, and the last a letter or a
-      number. The name must not exceed 63 characters.
+      The name is restricted to letters, numbers, and hyphen, with the first
+      character a letter, and the last a letter or a number. The name must not
+      exceed 48 characters.
     immutable: true
     url_param_only: true
+    required: true
 properties:
   - name: adminNetwork
     type: String
-    description: '[Output only] The URL of the admin network.'
+    description: The URL of the admin network.
     output: true
   - name: createTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast domain activation
-      was created.
+      The timestamp when the regional multicast domain activation was
+      created.
     output: true
   - name: description
     type: String
     description: An optional text description of the regional multicast domain activation.
+  - name: disablePlacementPolicy
+    type: Boolean
+    description: |-
+      Option to allow disabling placement policy for multicast infrastructure.
+      Only applicable if the activation is for a domain associating with a
+      multicast domain group.
+    immutable: true
+    default_from_api: true
   - name: labels
     type: KeyValueLabels
     description: Labels as key-value pairs
   - name: multicastDomain
     type: String
-    required: true
     description: |-
       The resource name of the multicast domain to activate.
-      Use the following format: `projects/*/locations/global/multicastDomains/*`.
+      Use the following format:
+      `projects/*/locations/global/multicastDomains/*`.
     immutable: true
+    required: true
   - name: name
     type: String
     description: |-
@@ -104,39 +113,6 @@ properties:
       Use the following format:
       `projects/*/locations/*/regionalMulticastDomainActivations/*`.
     output: true
-  - name: pimSpec
-    type: NestedObject
-    description: Specification for the PIM (Protocol Independent Multicast) protocol.
-    properties:
-      - name: multicastSourceLocation
-        type: String
-        required: true
-        description: |-
-          Indicates the location of the multicast source.
-          Possible values:
-          MULTICAST_SOURCE_GCP
-          MULTICAST_SOURCE_NON_GCP
-      - name: pimMode
-        type: String
-        description: |-
-          Specifies the PIM mode. If not specified, the service will default to
-          SPARSE. Only SPARSE is supported.
-          Possible values:
-          PIM_MODE_SPARSE
-        default_from_api: true
-      - name: rpIpAddress
-        type: String
-        description: The IP address of the PIM-SM Rendezvous Point (RP).
-  - name: regionalMulticastConsumerAssociations
-    type: Array
-    description: |-
-      [Output only] The resource names of the associated regional
-      multicast consumer associations in the following format:
-      `projects/*/locations/*/regionalMulticastConsumerAssociations/*`.
-    output: true
-    item_type:
-      type: String
-      output: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -154,20 +130,53 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
-          OBSOLETE
         output: true
+  - name: trafficSpec
+    type: NestedObject
+    description: |-
+      Specifies the traffic volume and multicast group scale parameters that are
+      used to set up multicast infrastructure for a multicast domain in a region.
+    properties:
+      - name: aggrEgressPps
+        type: String
+        description: |-
+          Aggregated egress Packet-Per-Second for all multicast groups in the domain
+          in this region.
+        default_from_api: true
+      - name: aggrIngressPps
+        type: String
+        description: |-
+          Aggregated ingress Packet-Per-Second for all multicast groups in the domain
+          in this region. Default to (aggregated_egress_pps /
+          max_per_group_subscribers) * 2.
+        default_from_api: true
+      - name: avgPacketSize
+        type: Integer
+        description: Average packet size (Default to 512 bytes).
+        default_from_api: true
+      - name: maxPerGroupIngressPps
+        type: String
+        description: |-
+          Maximum ingress Packet-Per-Second for a single multicast group in this
+          region. Default to aggregated_ingress_pps / 2.
+        default_from_api: true
+      - name: maxPerGroupSubscribers
+        type: String
+        description: |-
+          Maximum number of subscribers for a single multicast group in this region.
+          Default to max(50, aggregated_egress_pps / aggregated_ingress_pps).
+        default_from_api: true
   - name: uniqueId
     type: String
     description: |-
-      [Output only] The Google-generated UUID for the resource. This value is
-      unique across all regional multicast domain activation resources. If a
-      regional multicast domain activation is deleted and another with the same
-      name is created, the new regional multicast domain activation is assigned a
-      different unique_id.
+      The Google-generated UUID for the resource. This value is
+      unique across all regional multicast domain activation resources. If a domain
+      activation is deleted and another with the same name is created, the new
+      domain activation is assigned a different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast domain activation
-      was most recently updated.
+      The timestamp when the regional multicast domain activation was most
+      recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastDomainActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Domain Activation: https://docs.cloud.google.com/vpc/docs/multicast/create-domains#activate-domain
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastDomainActivations
-min_version: beta
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations/{{regional_multicast_domain_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastDomainActivations?regionalMulticastDomainActivationId={{regional_multicast_domain_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Group Consumer Activation: https://docs.cloud.google.com/vpc/docs/multicast/enable-consumer-network#activate-consumer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupConsumerActivations
-min_version: beta
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations/{{regional_multicast_group_consumer_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations?regionalMulticastGroupConsumerActivationId={{regional_multicast_group_consumer_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Group Consumer Activation: https://docs.cloud.google.com/vpc/docs/multicast/enable-consumer-network#activate-consumer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupConsumerActivations
-min_version: alpha
+min_version: beta
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations/{{regional_multicast_group_consumer_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations?regionalMulticastGroupConsumerActivationId={{regional_multicast_group_consumer_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
@@ -1,0 +1,166 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: RegionalMulticastGroupConsumerActivation
+description: Create a regional multicast group consumer activation in the specified location of the current project.
+min_version: nightly
+base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations
+self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations/{{regional_multicast_group_consumer_activation_id}}
+create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations?regionalMulticastGroupConsumerActivationId={{regional_multicast_group_consumer_activation_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations/{{regional_multicast_group_consumer_activation_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations/{{regional_multicast_group_consumer_activation_id}}
+sweeper:
+  url_substitutions:
+    - location: us-central1
+async:
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 20
+      update_minutes: 20
+      delete_minutes: 20
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+autogen_status: UmVnaW9uYWxNdWx0aWNhc3RHcm91cENvbnN1bWVyQWN0aXZhdGlvbg==
+autogen_async: true
+samples:
+  - name: network_services_regional_multicast_group_consumer_activation_basic
+    primary_resource_id: rmgca_test
+    steps:
+      - name: network_services_regional_multicast_group_consumer_activation_basic
+        resource_id_vars:
+          network_name: test-network-rmgca
+          domain_name: test-domain-rmgca
+          domain_activation_name: test-domain-activation-rmgca
+          group_range_name: test-group-range-rmgca
+          group_range_activation_name: test-group-range-activation-rmgca
+          consumer_association_name: test-consumer-association-rmgca
+          group_consumer_activation_name: test-group-consumer-activation-rmgca
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: regionalMulticastGroupConsumerActivationId
+    type: String
+    required: true
+    description: |-
+      A unique name for the regional multicast group consumer activation.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: createTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast group consumer
+      activation was created.
+    output: true
+  - name: description
+    type: String
+    description: |-
+      An optional text description of the regional multicast group consumer
+      activation.
+  - name: interconnectAttachments
+    type: Array
+    required: true
+    description: |-
+      The resource name of the interconnect attachments that are in the same
+      region as this regional multicast group consumer activation and are used by
+      on-premises consumers to receive multicast traffic.
+      These attachments must have multicast functionality enabled.
+      Use the following format: `projects/*/regions/*/interconnectAttachments/*`.
+    item_type:
+      type: String
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key-value pairs
+  - name: logConfig
+    type: NestedObject
+    description: The logging configuration.
+    properties:
+      - name: enabled
+        type: Boolean
+        description: Whether to enable logging or not.
+  - name: name
+    type: String
+    description: |-
+      Identifier. The resource name of the regional multicast group consumer activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastGroupConsumerActivations/*`.
+    output: true
+  - name: regionalMulticastConsumerAssociation
+    type: String
+    required: true
+    description: |-
+      The resource name of the regional multicast consumer association that is in
+      the same region as this regional multicast group consumer activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastConsumerAssociations/*`.
+    immutable: true
+  - name: regionalMulticastGroupRangeActivation
+    type: String
+    required: true
+    description: |-
+      The resource name of the regional multicast group range activation created
+      by the admin in the same region as this regional multicast group consumer
+      activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
+    immutable: true
+  - name: state
+    type: NestedObject
+    description: The multicast resource's state.
+    properties:
+      - name: state
+        type: String
+        description: |-
+          The state of the multicast resource.
+          Possible values:
+          CREATING
+          ACTIVE
+          DELETING
+          DELETE_FAILED
+          UPDATING
+          UPDATE_FAILED
+          INACTIVE
+          OBSOLETE
+  - name: uniqueId
+    type: String
+    description: |-
+      [Output only] The Google-generated UUID for the resource. This value is
+      unique across all regional multicast group consumer activation resources.
+      If a regional multicast group consumer activation is deleted and another
+      with the same name is created, the new regional multicast group consumer
+      activation is assigned a different unique_id.
+    output: true
+  - name: updateTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast group consumer
+      activation was most recently updated.
+    output: true

--- a/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
@@ -14,6 +14,10 @@
 ---
 name: RegionalMulticastGroupConsumerActivation
 description: Create a regional multicast group consumer activation in the specified location of the current project.
+references:
+  guides:
+    Create Regional Multicast Group Consumer Activation: https://docs.cloud.google.com/vpc/docs/multicast/enable-consumer-network#activate-consumer
+  api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupConsumerActivations
 min_version: nightly
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations/{{regional_multicast_group_consumer_activation_id}}
@@ -135,6 +139,7 @@ properties:
   - name: state
     type: NestedObject
     description: The multicast resource's state.
+    output: true
     properties:
       - name: state
         type: String
@@ -149,6 +154,7 @@ properties:
           UPDATE_FAILED
           INACTIVE
           OBSOLETE
+        output: true
   - name: uniqueId
     type: String
     description: |-

--- a/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Group Consumer Activation: https://docs.cloud.google.com/vpc/docs/multicast/enable-consumer-network#activate-consumer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupConsumerActivations
-min_version: nightly
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations/{{regional_multicast_group_consumer_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupConsumerActivations?regionalMulticastGroupConsumerActivationId={{regional_multicast_group_consumer_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
@@ -56,50 +56,38 @@ samples:
           network_name: test-network-rmgca
           domain_name: test-domain-rmgca
           domain_activation_name: test-domain-activation-rmgca
-          group_range_name: test-group-range-rmgca
-          group_range_activation_name: test-group-range-activation-rmgca
           consumer_association_name: test-consumer-association-rmgca
-          group_consumer_activation_name: test-group-consumer-activation-rmgca
+          internal_range_name: test-internal-range-rmgca
+          group_range_name: test-group-range-rmgca
+          group_range_activation_name: test-rmgra-rmgca
+          group_consumer_activation_name: test-rmgca-rmgca
 parameters:
   - name: location
     type: String
-    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
+    required: true
   - name: regionalMulticastGroupConsumerActivationId
     type: String
-    required: true
     description: |-
       A unique name for the regional multicast group consumer activation.
-      The name is restricted to lower-case letters, numbers, and hyphen, with
-      the first character a lower-case letter, and the last a letter or a
-      number. The name must not exceed 63 characters.
+      The name is restricted to letters, numbers, and hyphen, with the first
+      character a letter, and the last a letter or a number. The name must not
+      exceed 48 characters.
     immutable: true
     url_param_only: true
+    required: true
 properties:
   - name: createTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast group consumer
-      activation was created.
+      The timestamp when the regional multicast group consumer activation
+      was created.
     output: true
   - name: description
     type: String
-    description: |-
-      An optional text description of the regional multicast group consumer
-      activation.
-  - name: interconnectAttachments
-    type: Array
-    required: true
-    description: |-
-      The resource name of the interconnect attachments that are in the same
-      region as this regional multicast group consumer activation and are used by
-      on-premises consumers to receive multicast traffic.
-      These attachments must have multicast functionality enabled.
-      Use the following format: `projects/*/regions/*/interconnectAttachments/*`.
-    item_type:
-      type: String
+    description: An optional text description of the regional multicast group consumer activation.
   - name: labels
     type: KeyValueLabels
     description: Labels as key-value pairs
@@ -110,6 +98,24 @@ properties:
       - name: enabled
         type: Boolean
         description: Whether to enable logging or not.
+  - name: regionalMulticastConsumerAssociation
+    type: String
+    description: |-
+      The resource name of the regional multicast consumer association that is in the
+      same region as this regional multicast group consumer activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastConsumerAssociations/*`.
+    immutable: true
+    required: true
+  - name: regionalMulticastGroupRangeActivation
+    type: String
+    description: |-
+      The resource name of the regional multicast group range activation created by the
+      admin in the same region as this regional multicast group consumer activation. Use the
+      following format:
+      // `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
+    immutable: true
+    required: true
   - name: name
     type: String
     description: |-
@@ -117,25 +123,6 @@ properties:
       Use the following format:
       `projects/*/locations/*/regionalMulticastGroupConsumerActivations/*`.
     output: true
-  - name: regionalMulticastConsumerAssociation
-    type: String
-    required: true
-    description: |-
-      The resource name of the regional multicast consumer association that is in
-      the same region as this regional multicast group consumer activation.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastConsumerAssociations/*`.
-    immutable: true
-  - name: regionalMulticastGroupRangeActivation
-    type: String
-    required: true
-    description: |-
-      The resource name of the regional multicast group range activation created
-      by the admin in the same region as this regional multicast group consumer
-      activation.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
-    immutable: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -153,20 +140,18 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
-          OBSOLETE
         output: true
   - name: uniqueId
     type: String
     description: |-
-      [Output only] The Google-generated UUID for the resource. This value is
-      unique across all regional multicast group consumer activation resources.
-      If a regional multicast group consumer activation is deleted and another
-      with the same name is created, the new regional multicast group consumer
-      activation is assigned a different unique_id.
+      The Google-generated UUID for the resource. This value is
+      unique across all regional multicast group consumer activation resources. If a group
+      consumer activation is deleted and another with the same name is created,
+      the new group consumer activation is assigned a different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast group consumer
-      activation was most recently updated.
+      The timestamp when the regional multicast group consumer activation
+      was most recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupConsumerActivation.yaml
@@ -56,38 +56,50 @@ samples:
           network_name: test-network-rmgca
           domain_name: test-domain-rmgca
           domain_activation_name: test-domain-activation-rmgca
-          consumer_association_name: test-consumer-association-rmgca
-          internal_range_name: test-internal-range-rmgca
           group_range_name: test-group-range-rmgca
-          group_range_activation_name: test-rmgra-rmgca
-          group_consumer_activation_name: test-rmgca-rmgca
+          group_range_activation_name: test-group-range-activation-rmgca
+          consumer_association_name: test-consumer-association-rmgca
+          group_consumer_activation_name: test-group-consumer-activation-rmgca
 parameters:
   - name: location
     type: String
+    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
-    required: true
   - name: regionalMulticastGroupConsumerActivationId
     type: String
+    required: true
     description: |-
       A unique name for the regional multicast group consumer activation.
-      The name is restricted to letters, numbers, and hyphen, with the first
-      character a letter, and the last a letter or a number. The name must not
-      exceed 48 characters.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
     immutable: true
     url_param_only: true
-    required: true
 properties:
   - name: createTime
     type: String
     description: |-
-      The timestamp when the regional multicast group consumer activation
-      was created.
+      [Output only] The timestamp when the regional multicast group consumer
+      activation was created.
     output: true
   - name: description
     type: String
-    description: An optional text description of the regional multicast group consumer activation.
+    description: |-
+      An optional text description of the regional multicast group consumer
+      activation.
+  - name: interconnectAttachments
+    type: Array
+    required: true
+    description: |-
+      The resource name of the interconnect attachments that are in the same
+      region as this regional multicast group consumer activation and are used by
+      on-premises consumers to receive multicast traffic.
+      These attachments must have multicast functionality enabled.
+      Use the following format: `projects/*/regions/*/interconnectAttachments/*`.
+    item_type:
+      type: String
   - name: labels
     type: KeyValueLabels
     description: Labels as key-value pairs
@@ -98,24 +110,6 @@ properties:
       - name: enabled
         type: Boolean
         description: Whether to enable logging or not.
-  - name: regionalMulticastConsumerAssociation
-    type: String
-    description: |-
-      The resource name of the regional multicast consumer association that is in the
-      same region as this regional multicast group consumer activation.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastConsumerAssociations/*`.
-    immutable: true
-    required: true
-  - name: regionalMulticastGroupRangeActivation
-    type: String
-    description: |-
-      The resource name of the regional multicast group range activation created by the
-      admin in the same region as this regional multicast group consumer activation. Use the
-      following format:
-      // `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
-    immutable: true
-    required: true
   - name: name
     type: String
     description: |-
@@ -123,6 +117,25 @@ properties:
       Use the following format:
       `projects/*/locations/*/regionalMulticastGroupConsumerActivations/*`.
     output: true
+  - name: regionalMulticastConsumerAssociation
+    type: String
+    required: true
+    description: |-
+      The resource name of the regional multicast consumer association that is in
+      the same region as this regional multicast group consumer activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastConsumerAssociations/*`.
+    immutable: true
+  - name: regionalMulticastGroupRangeActivation
+    type: String
+    required: true
+    description: |-
+      The resource name of the regional multicast group range activation created
+      by the admin in the same region as this regional multicast group consumer
+      activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
+    immutable: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -140,18 +153,20 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
+          OBSOLETE
         output: true
   - name: uniqueId
     type: String
     description: |-
-      The Google-generated UUID for the resource. This value is
-      unique across all regional multicast group consumer activation resources. If a group
-      consumer activation is deleted and another with the same name is created,
-      the new group consumer activation is assigned a different unique_id.
+      [Output only] The Google-generated UUID for the resource. This value is
+      unique across all regional multicast group consumer activation resources.
+      If a regional multicast group consumer activation is deleted and another
+      with the same name is created, the new regional multicast group consumer
+      activation is assigned a different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      The timestamp when the regional multicast group consumer activation
-      was most recently updated.
+      [Output only] The timestamp when the regional multicast group consumer
+      activation was most recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
@@ -56,57 +56,53 @@ samples:
           network_name: test-network-rmgpa
           domain_name: test-domain-rmgpa
           domain_activation_name: test-domain-activation-rmgpa
-          producer_association_name: test-producer-association-rmgpa
-          internal_range_name: test-internal-range-rmgpa
           group_range_name: test-group-range-rmgpa
-          group_range_activation_name: test-rmgra-rmgpa
-          group_producer_activation_name: test-rmgpa-rmgpa
+          group_range_activation_name: test-group-range-activation-rmgpa
+          producer_association_name: test-producer-association-rmgpa
+          group_producer_activation_name: test-group-producer-activation-rmgpa
 parameters:
   - name: location
     type: String
+    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
-    required: true
   - name: regionalMulticastGroupProducerActivationId
     type: String
+    required: true
     description: |-
       A unique name for the regional multicast group producer activation.
-      The name is restricted to letters, numbers, and hyphen, with the first
-      character a letter, and the last a letter or a number. The name must not
-      exceed 48 characters.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
     immutable: true
     url_param_only: true
-    required: true
 properties:
   - name: createTime
     type: String
-    description: The timestamp when the regional multicast group producer activation was created.
+    description: |-
+      [Output only] The timestamp when the regional multicast group producer
+      activation was created.
     output: true
   - name: description
     type: String
-    description: An optional text description of the regional multicast group producer activation.
+    description: |-
+      An optional text description of the regional multicast group producer
+      activation.
+  - name: interconnectAttachments
+    type: Array
+    required: true
+    description: |-
+      The resource name of the interconnect attachments that are in the same
+      region as this regional multicast group producer activation and
+      are used with the on-premises multicast source.
+      These attachments must have multicast functionality enabled.
+      Use the following format: `projects/*/regions/*/interconnectAttachments/*`.
+    item_type:
+      type: String
   - name: labels
     type: KeyValueLabels
     description: Labels as key-value pairs
-  - name: regionalMulticastGroupRangeActivation
-    type: String
-    description: |-
-      The resource name of the regional multicast group range activationcreated by the
-      admin in the same region as this regional multicast group producer activation. Use the
-      following format:
-      // `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
-    immutable: true
-    required: true
-  - name: regionalMulticastProducerAssociation
-    type: String
-    description: |-
-      The resource name of the regional multicast producer association that is in the
-      same region as this regional multicast group producer activation.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastProducerAssociations/*`.
-    immutable: true
-    required: true
   - name: name
     type: String
     description: |-
@@ -114,6 +110,25 @@ properties:
       Use the following format:
       `projects/*/locations/*/regionalMulticastGroupProducerActivations/*`.
     output: true
+  - name: regionalMulticastGroupRangeActivation
+    type: String
+    required: true
+    description: |-
+      The resource name of the regional multicast group range activation created
+      by the admin in the same region as this regional multicast group producer
+      activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
+    immutable: true
+  - name: regionalMulticastProducerAssociation
+    type: String
+    required: true
+    description: |-
+      The resource name of the regional multicast producer association that is in
+      the same region as this regional multicast group producer activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastProducerAssociations/*`.
+    immutable: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -131,18 +146,20 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
+          OBSOLETE
         output: true
   - name: uniqueId
     type: String
     description: |-
-      The Google-generated UUID for the resource. This value is
-      unique across all regional multicast group producer activation resources. If a group
-      producer activation is deleted and another with the same name is created,
-      the new group producer activation is assigned a different unique_id.
+      [Output only] The Google-generated UUID for the resource. This value is
+      unique across all regional multicast group producer activation resources.
+      If a regional multicast group producer activation is deleted and another
+      with the same name is created, the new regional multicast group producer
+      activation is assigned a different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      The timestamp when the regional multicast group producer activation
-      was most recently updated.
+      [Output only] The timestamp when the regional multicast group producer
+      activation was most recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
@@ -56,53 +56,57 @@ samples:
           network_name: test-network-rmgpa
           domain_name: test-domain-rmgpa
           domain_activation_name: test-domain-activation-rmgpa
-          group_range_name: test-group-range-rmgpa
-          group_range_activation_name: test-group-range-activation-rmgpa
           producer_association_name: test-producer-association-rmgpa
-          group_producer_activation_name: test-group-producer-activation-rmgpa
+          internal_range_name: test-internal-range-rmgpa
+          group_range_name: test-group-range-rmgpa
+          group_range_activation_name: test-rmgra-rmgpa
+          group_producer_activation_name: test-rmgpa-rmgpa
 parameters:
   - name: location
     type: String
-    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
+    required: true
   - name: regionalMulticastGroupProducerActivationId
     type: String
-    required: true
     description: |-
       A unique name for the regional multicast group producer activation.
-      The name is restricted to lower-case letters, numbers, and hyphen, with
-      the first character a lower-case letter, and the last a letter or a
-      number. The name must not exceed 63 characters.
+      The name is restricted to letters, numbers, and hyphen, with the first
+      character a letter, and the last a letter or a number. The name must not
+      exceed 48 characters.
     immutable: true
     url_param_only: true
+    required: true
 properties:
   - name: createTime
     type: String
-    description: |-
-      [Output only] The timestamp when the regional multicast group producer
-      activation was created.
+    description: The timestamp when the regional multicast group producer activation was created.
     output: true
   - name: description
     type: String
-    description: |-
-      An optional text description of the regional multicast group producer
-      activation.
-  - name: interconnectAttachments
-    type: Array
-    required: true
-    description: |-
-      The resource name of the interconnect attachments that are in the same
-      region as this regional multicast group producer activation and
-      are used with the on-premises multicast source.
-      These attachments must have multicast functionality enabled.
-      Use the following format: `projects/*/regions/*/interconnectAttachments/*`.
-    item_type:
-      type: String
+    description: An optional text description of the regional multicast group producer activation.
   - name: labels
     type: KeyValueLabels
     description: Labels as key-value pairs
+  - name: regionalMulticastGroupRangeActivation
+    type: String
+    description: |-
+      The resource name of the regional multicast group range activationcreated by the
+      admin in the same region as this regional multicast group producer activation. Use the
+      following format:
+      // `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
+    immutable: true
+    required: true
+  - name: regionalMulticastProducerAssociation
+    type: String
+    description: |-
+      The resource name of the regional multicast producer association that is in the
+      same region as this regional multicast group producer activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastProducerAssociations/*`.
+    immutable: true
+    required: true
   - name: name
     type: String
     description: |-
@@ -110,25 +114,6 @@ properties:
       Use the following format:
       `projects/*/locations/*/regionalMulticastGroupProducerActivations/*`.
     output: true
-  - name: regionalMulticastGroupRangeActivation
-    type: String
-    required: true
-    description: |-
-      The resource name of the regional multicast group range activation created
-      by the admin in the same region as this regional multicast group producer
-      activation.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
-    immutable: true
-  - name: regionalMulticastProducerAssociation
-    type: String
-    required: true
-    description: |-
-      The resource name of the regional multicast producer association that is in
-      the same region as this regional multicast group producer activation.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastProducerAssociations/*`.
-    immutable: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -146,20 +131,18 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
-          OBSOLETE
         output: true
   - name: uniqueId
     type: String
     description: |-
-      [Output only] The Google-generated UUID for the resource. This value is
-      unique across all regional multicast group producer activation resources.
-      If a regional multicast group producer activation is deleted and another
-      with the same name is created, the new regional multicast group producer
-      activation is assigned a different unique_id.
+      The Google-generated UUID for the resource. This value is
+      unique across all regional multicast group producer activation resources. If a group
+      producer activation is deleted and another with the same name is created,
+      the new group producer activation is assigned a different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast group producer
-      activation was most recently updated.
+      The timestamp when the regional multicast group producer activation
+      was most recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Group Producer Activation: https://docs.cloud.google.com/vpc/docs/multicast/enable-producer-network#activate-producer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupProducerActivations
-min_version: nightly
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations/{{regional_multicast_group_producer_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations?regionalMulticastGroupProducerActivationId={{regional_multicast_group_producer_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
@@ -1,0 +1,159 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: RegionalMulticastGroupProducerActivation
+description: Create a regional multicast group producer activation in the specified location of the current project.
+min_version: nightly
+base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations
+self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations/{{regional_multicast_group_producer_activation_id}}
+create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations?regionalMulticastGroupProducerActivationId={{regional_multicast_group_producer_activation_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations/{{regional_multicast_group_producer_activation_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations/{{regional_multicast_group_producer_activation_id}}
+sweeper:
+  url_substitutions:
+    - location: us-central1
+async:
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 20
+      update_minutes: 20
+      delete_minutes: 20
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+autogen_status: UmVnaW9uYWxNdWx0aWNhc3RHcm91cFByb2R1Y2VyQWN0aXZhdGlvbg==
+autogen_async: true
+samples:
+  - name: network_services_regional_multicast_group_producer_activation_basic
+    primary_resource_id: rmgpa_test
+    steps:
+      - name: network_services_regional_multicast_group_producer_activation_basic
+        resource_id_vars:
+          network_name: test-network-rmgpa
+          domain_name: test-domain-rmgpa
+          domain_activation_name: test-domain-activation-rmgpa
+          group_range_name: test-group-range-rmgpa
+          group_range_activation_name: test-group-range-activation-rmgpa
+          producer_association_name: test-producer-association-rmgpa
+          group_producer_activation_name: test-group-producer-activation-rmgpa
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: regionalMulticastGroupProducerActivationId
+    type: String
+    required: true
+    description: |-
+      A unique name for the regional multicast group producer activation.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: createTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast group producer
+      activation was created.
+    output: true
+  - name: description
+    type: String
+    description: |-
+      An optional text description of the regional multicast group producer
+      activation.
+  - name: interconnectAttachments
+    type: Array
+    required: true
+    description: |-
+      The resource name of the interconnect attachments that are in the same
+      region as this regional multicast group producer activation and
+      are used with the on-premises multicast source.
+      These attachments must have multicast functionality enabled.
+      Use the following format: `projects/*/regions/*/interconnectAttachments/*`.
+    item_type:
+      type: String
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key-value pairs
+  - name: name
+    type: String
+    description: |-
+      Identifier. The resource name of the regional multicast group producer activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastGroupProducerActivations/*`.
+    output: true
+  - name: regionalMulticastGroupRangeActivation
+    type: String
+    required: true
+    description: |-
+      The resource name of the regional multicast group range activation created
+      by the admin in the same region as this regional multicast group producer
+      activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
+    immutable: true
+  - name: regionalMulticastProducerAssociation
+    type: String
+    required: true
+    description: |-
+      The resource name of the regional multicast producer association that is in
+      the same region as this regional multicast group producer activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastProducerAssociations/*`.
+    immutable: true
+  - name: state
+    type: NestedObject
+    description: The multicast resource's state.
+    properties:
+      - name: state
+        type: String
+        description: |-
+          The state of the multicast resource.
+          Possible values:
+          CREATING
+          ACTIVE
+          DELETING
+          DELETE_FAILED
+          UPDATING
+          UPDATE_FAILED
+          INACTIVE
+          OBSOLETE
+  - name: uniqueId
+    type: String
+    description: |-
+      [Output only] The Google-generated UUID for the resource. This value is
+      unique across all regional multicast group producer activation resources.
+      If a regional multicast group producer activation is deleted and another
+      with the same name is created, the new regional multicast group producer
+      activation is assigned a different unique_id.
+    output: true
+  - name: updateTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast group producer
+      activation was most recently updated.
+    output: true

--- a/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Group Producer Activation: https://docs.cloud.google.com/vpc/docs/multicast/enable-producer-network#activate-producer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupProducerActivations
-min_version: beta
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations/{{regional_multicast_group_producer_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations?regionalMulticastGroupProducerActivationId={{regional_multicast_group_producer_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Group Producer Activation: https://docs.cloud.google.com/vpc/docs/multicast/enable-producer-network#activate-producer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupProducerActivations
-min_version: alpha
+min_version: beta
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations/{{regional_multicast_group_producer_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations?regionalMulticastGroupProducerActivationId={{regional_multicast_group_producer_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupProducerActivation.yaml
@@ -14,6 +14,10 @@
 ---
 name: RegionalMulticastGroupProducerActivation
 description: Create a regional multicast group producer activation in the specified location of the current project.
+references:
+  guides:
+    Create Regional Multicast Group Producer Activation: https://docs.cloud.google.com/vpc/docs/multicast/enable-producer-network#activate-producer
+  api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupProducerActivations
 min_version: nightly
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupProducerActivations/{{regional_multicast_group_producer_activation_id}}
@@ -128,6 +132,7 @@ properties:
   - name: state
     type: NestedObject
     description: The multicast resource's state.
+    output: true
     properties:
       - name: state
         type: String
@@ -142,6 +147,7 @@ properties:
           UPDATE_FAILED
           INACTIVE
           OBSOLETE
+        output: true
   - name: uniqueId
     type: String
     description: |-

--- a/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
@@ -1,0 +1,188 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: RegionalMulticastGroupRangeActivation
+description: Create a regional multicast group range activation in the specified location of the current project.
+min_version: nightly
+base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations
+self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations/{{regional_multicast_group_range_activation_id}}
+create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations?regionalMulticastGroupRangeActivationId={{regional_multicast_group_range_activation_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations/{{regional_multicast_group_range_activation_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations/{{regional_multicast_group_range_activation_id}}
+sweeper:
+  url_substitutions:
+    - location: us-central1
+async:
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 20
+      update_minutes: 20
+      delete_minutes: 20
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+autogen_status: UmVnaW9uYWxNdWx0aWNhc3RHcm91cFJhbmdlQWN0aXZhdGlvbg==
+autogen_async: true
+samples:
+  - name: network_services_regional_multicast_group_range_activation_basic
+    primary_resource_id: rmgra_test
+    steps:
+      - name: network_services_regional_multicast_group_range_activation_basic
+        resource_id_vars:
+          network_name: test-network-rmgra
+          domain_name: test-domain-rmgra
+          domain_activation_name: test-domain-activation-rmgra
+          group_range_name: test-group-range-rmgra
+          group_range_activation_name: test-group-range-activation-rmgra
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: regionalMulticastGroupRangeActivationId
+    type: String
+    required: true
+    description: |-
+      A unique name for the regional multicast group range activation.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: createTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast group range
+      activation was created.
+    output: true
+  - name: description
+    type: String
+    description: |-
+      An optional text description of the regional multicast group range
+      activation.
+  - name: ipCidrRange
+    type: String
+    description: '[Output only] The multicast group IP address range.'
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key-value pairs.
+  - name: logConfig
+    type: NestedObject
+    description: The logging configuration.
+    properties:
+      - name: enabled
+        type: Boolean
+        description: Whether to enable logging or not.
+  - name: multicastGroupRange
+    type: String
+    required: true
+    description: |-
+      The resource name of the global multicast group range for the
+      group.
+      Use the following format:
+      `projects/*/locations/global/multicastGroupRanges/*`
+    immutable: true
+  - name: name
+    type: String
+    description: |-
+      Identifier. The resource name of the regional multicast group range activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
+    output: true
+  - name: pimSpec
+    type: NestedObject
+    description: Specification for the PIM (Protocol Independent Multicast) protocol.
+    properties:
+      - name: multicastSourceLocation
+        type: String
+        required: true
+        description: |-
+          Indicates the location of the multicast source.
+          Possible values:
+          MULTICAST_SOURCE_GCP
+          MULTICAST_SOURCE_NON_GCP
+      - name: pimMode
+        type: String
+        description: |-
+          Specifies the PIM mode. If not specified, the service will default to
+          SPARSE. Only SPARSE is supported.
+          Possible values:
+          PIM_MODE_SPARSE
+      - name: rpIpAddress
+        type: String
+        description: The IP address of the PIM-SM Rendezvous Point (RP).
+  - name: regionalMulticastDomainActivation
+    type: String
+    required: true
+    description: |-
+      The resource name of a regional multicast domain activation that is in the
+      same region as this regional multicast group range activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastDomainActivations/*`
+    immutable: true
+  - name: regionalMulticastGroupConsumerActivations
+    type: Array
+    description: |-
+      [Output only] The resource names of associated regional multicast
+      group consumer activations in the following format:
+      `projects/*/locations/*/regionalMulticastGroupConsumerActivations/*`.
+    output: true
+    item_type:
+      type: String
+      output: true
+  - name: state
+    type: NestedObject
+    description: The multicast resource's state.
+    properties:
+      - name: state
+        type: String
+        description: |-
+          The state of the multicast resource.
+          Possible values:
+          CREATING
+          ACTIVE
+          DELETING
+          DELETE_FAILED
+          UPDATING
+          UPDATE_FAILED
+          INACTIVE
+          OBSOLETE
+  - name: uniqueId
+    type: String
+    description: |-
+      [Output only] The Google-generated UUID for the resource. This value is
+      unique across all regional multicast group range activation resources. If a
+      regional multicast group range activation is deleted and another with the
+      same name is created, the new regional multicast group range activation is
+      assigned a different unique_id.
+    output: true
+  - name: updateTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast group range
+      activation was most recently updated.
+    output: true

--- a/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Group Range Activation: https://docs.cloud.google.com/vpc/docs/multicast/create-group-ranges#activate_the_group_range
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupRangeActivations
-min_version: beta
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations/{{regional_multicast_group_range_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations?regionalMulticastGroupRangeActivationId={{regional_multicast_group_range_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Group Range Activation: https://docs.cloud.google.com/vpc/docs/multicast/create-group-ranges#activate_the_group_range
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupRangeActivations
-min_version: alpha
+min_version: beta
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations/{{regional_multicast_group_range_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations?regionalMulticastGroupRangeActivationId={{regional_multicast_group_range_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Group Range Activation: https://docs.cloud.google.com/vpc/docs/multicast/create-group-ranges#activate_the_group_range
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupRangeActivations
-min_version: nightly
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations/{{regional_multicast_group_range_activation_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations?regionalMulticastGroupRangeActivationId={{regional_multicast_group_range_activation_id}}

--- a/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
@@ -56,36 +56,37 @@ samples:
           network_name: test-network-rmgra
           domain_name: test-domain-rmgra
           domain_activation_name: test-domain-activation-rmgra
-          internal_range_name: test-internal-range-rmgra
           group_range_name: test-group-range-rmgra
-          group_range_activation_name: test-rmgra-rmgra
+          group_range_activation_name: test-group-range-activation-rmgra
 parameters:
   - name: location
     type: String
+    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
-    required: true
   - name: regionalMulticastGroupRangeActivationId
     type: String
+    required: true
     description: |-
       A unique name for the regional multicast group range activation.
-      The name is restricted to letters, numbers, and hyphen, with the first
-      character a letter, and the last a letter or a number. The name must not
-      exceed 48 characters.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
     immutable: true
     url_param_only: true
-    required: true
 properties:
   - name: createTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast group range activation was
-      created.
+      [Output only] The timestamp when the regional multicast group range
+      activation was created.
     output: true
   - name: description
     type: String
-    description: An optional text description of the regional multicast group range activation.
+    description: |-
+      An optional text description of the regional multicast group range
+      activation.
   - name: ipCidrRange
     type: String
     description: '[Output only] The multicast group IP address range.'
@@ -100,32 +101,15 @@ properties:
       - name: enabled
         type: Boolean
         description: Whether to enable logging or not.
-  - name: regionalMulticastDomainActivation
-    type: String
-    description: |-
-      The resource name of a regional multicast domain activation that is in the
-      same region as this regional multicast group.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastDomainActivations/*`
-    immutable: true
-    required: true
-  - name: regionalMulticastGroupConsumerActivations
-    type: Array
-    description: |-
-      The resource names of associated regional multicast group consumer activations.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastGroupConsumerActivations/*`.
-    output: true
-    item_type:
-      type: String
   - name: multicastGroupRange
     type: String
+    required: true
     description: |-
       The resource name of the global multicast group range for the
-      group. Use the following format:
+      group.
+      Use the following format:
       `projects/*/locations/global/multicastGroupRanges/*`
     immutable: true
-    required: true
   - name: name
     type: String
     description: |-
@@ -133,6 +117,48 @@ properties:
       Use the following format:
       `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
     output: true
+  - name: pimSpec
+    type: NestedObject
+    description: Specification for the PIM (Protocol Independent Multicast) protocol.
+    properties:
+      - name: multicastSourceLocation
+        type: String
+        required: true
+        description: |-
+          Indicates the location of the multicast source.
+          Possible values:
+          MULTICAST_SOURCE_GCP
+          MULTICAST_SOURCE_NON_GCP
+      - name: pimMode
+        type: String
+        description: |-
+          Specifies the PIM mode. If not specified, the service will default to
+          SPARSE. Only SPARSE is supported.
+          Possible values:
+          PIM_MODE_SPARSE
+        default_from_api: true
+      - name: rpIpAddress
+        type: String
+        description: The IP address of the PIM-SM Rendezvous Point (RP).
+  - name: regionalMulticastDomainActivation
+    type: String
+    required: true
+    description: |-
+      The resource name of a regional multicast domain activation that is in the
+      same region as this regional multicast group range activation.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastDomainActivations/*`
+    immutable: true
+  - name: regionalMulticastGroupConsumerActivations
+    type: Array
+    description: |-
+      [Output only] The resource names of associated regional multicast
+      group consumer activations in the following format:
+      `projects/*/locations/*/regionalMulticastGroupConsumerActivations/*`.
+    output: true
+    item_type:
+      type: String
+      output: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -150,18 +176,20 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
+          OBSOLETE
         output: true
   - name: uniqueId
     type: String
     description: |-
       [Output only] The Google-generated UUID for the resource. This value is
-      unique across all regional multicast group resources. If a group is deleted and
-      another with the same name is created, the new group is assigned a
-      different unique_id.
+      unique across all regional multicast group range activation resources. If a
+      regional multicast group range activation is deleted and another with the
+      same name is created, the new regional multicast group range activation is
+      assigned a different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast group range activation was
-      most recently updated.
+      [Output only] The timestamp when the regional multicast group range
+      activation was most recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
@@ -14,6 +14,10 @@
 ---
 name: RegionalMulticastGroupRangeActivation
 description: Create a regional multicast group range activation in the specified location of the current project.
+references:
+  guides:
+    Create Regional Multicast Group Range Activation: https://docs.cloud.google.com/vpc/docs/multicast/create-group-ranges#activate_the_group_range
+  api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastGroupRangeActivations
 min_version: nightly
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastGroupRangeActivations/{{regional_multicast_group_range_activation_id}}
@@ -132,6 +136,7 @@ properties:
           SPARSE. Only SPARSE is supported.
           Possible values:
           PIM_MODE_SPARSE
+        default_from_api: true
       - name: rpIpAddress
         type: String
         description: The IP address of the PIM-SM Rendezvous Point (RP).
@@ -157,6 +162,7 @@ properties:
   - name: state
     type: NestedObject
     description: The multicast resource's state.
+    output: true
     properties:
       - name: state
         type: String
@@ -171,6 +177,7 @@ properties:
           UPDATE_FAILED
           INACTIVE
           OBSOLETE
+        output: true
   - name: uniqueId
     type: String
     description: |-

--- a/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastGroupRangeActivation.yaml
@@ -56,37 +56,36 @@ samples:
           network_name: test-network-rmgra
           domain_name: test-domain-rmgra
           domain_activation_name: test-domain-activation-rmgra
+          internal_range_name: test-internal-range-rmgra
           group_range_name: test-group-range-rmgra
-          group_range_activation_name: test-group-range-activation-rmgra
+          group_range_activation_name: test-rmgra-rmgra
 parameters:
   - name: location
     type: String
-    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
+    required: true
   - name: regionalMulticastGroupRangeActivationId
     type: String
-    required: true
     description: |-
       A unique name for the regional multicast group range activation.
-      The name is restricted to lower-case letters, numbers, and hyphen, with
-      the first character a lower-case letter, and the last a letter or a
-      number. The name must not exceed 63 characters.
+      The name is restricted to letters, numbers, and hyphen, with the first
+      character a letter, and the last a letter or a number. The name must not
+      exceed 48 characters.
     immutable: true
     url_param_only: true
+    required: true
 properties:
   - name: createTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast group range
-      activation was created.
+      [Output only] The timestamp when the regional multicast group range activation was
+      created.
     output: true
   - name: description
     type: String
-    description: |-
-      An optional text description of the regional multicast group range
-      activation.
+    description: An optional text description of the regional multicast group range activation.
   - name: ipCidrRange
     type: String
     description: '[Output only] The multicast group IP address range.'
@@ -101,15 +100,32 @@ properties:
       - name: enabled
         type: Boolean
         description: Whether to enable logging or not.
+  - name: regionalMulticastDomainActivation
+    type: String
+    description: |-
+      The resource name of a regional multicast domain activation that is in the
+      same region as this regional multicast group.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastDomainActivations/*`
+    immutable: true
+    required: true
+  - name: regionalMulticastGroupConsumerActivations
+    type: Array
+    description: |-
+      The resource names of associated regional multicast group consumer activations.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastGroupConsumerActivations/*`.
+    output: true
+    item_type:
+      type: String
   - name: multicastGroupRange
     type: String
-    required: true
     description: |-
       The resource name of the global multicast group range for the
-      group.
-      Use the following format:
+      group. Use the following format:
       `projects/*/locations/global/multicastGroupRanges/*`
     immutable: true
+    required: true
   - name: name
     type: String
     description: |-
@@ -117,48 +133,6 @@ properties:
       Use the following format:
       `projects/*/locations/*/regionalMulticastGroupRangeActivations/*`.
     output: true
-  - name: pimSpec
-    type: NestedObject
-    description: Specification for the PIM (Protocol Independent Multicast) protocol.
-    properties:
-      - name: multicastSourceLocation
-        type: String
-        required: true
-        description: |-
-          Indicates the location of the multicast source.
-          Possible values:
-          MULTICAST_SOURCE_GCP
-          MULTICAST_SOURCE_NON_GCP
-      - name: pimMode
-        type: String
-        description: |-
-          Specifies the PIM mode. If not specified, the service will default to
-          SPARSE. Only SPARSE is supported.
-          Possible values:
-          PIM_MODE_SPARSE
-        default_from_api: true
-      - name: rpIpAddress
-        type: String
-        description: The IP address of the PIM-SM Rendezvous Point (RP).
-  - name: regionalMulticastDomainActivation
-    type: String
-    required: true
-    description: |-
-      The resource name of a regional multicast domain activation that is in the
-      same region as this regional multicast group range activation.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastDomainActivations/*`
-    immutable: true
-  - name: regionalMulticastGroupConsumerActivations
-    type: Array
-    description: |-
-      [Output only] The resource names of associated regional multicast
-      group consumer activations in the following format:
-      `projects/*/locations/*/regionalMulticastGroupConsumerActivations/*`.
-    output: true
-    item_type:
-      type: String
-      output: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -176,20 +150,18 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
-          OBSOLETE
         output: true
   - name: uniqueId
     type: String
     description: |-
       [Output only] The Google-generated UUID for the resource. This value is
-      unique across all regional multicast group range activation resources. If a
-      regional multicast group range activation is deleted and another with the
-      same name is created, the new regional multicast group range activation is
-      assigned a different unique_id.
+      unique across all regional multicast group resources. If a group is deleted and
+      another with the same name is created, the new group is assigned a
+      different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast group range
-      activation was most recently updated.
+      [Output only] The timestamp when the regional multicast group range activation was
+      most recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
@@ -1,0 +1,143 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: RegionalMulticastProducerAssociation
+description: Create a regional multicast producer association in the specified location of the current project.
+min_version: nightly
+base_url: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations
+self_link: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations/{{regional_multicast_producer_association_id}}
+create_url: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations?regionalMulticastProducerAssociationId={{regional_multicast_producer_association_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations/{{regional_multicast_producer_association_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations/{{regional_multicast_producer_association_id}}
+sweeper:
+  url_substitutions:
+    - location: us-central1
+async:
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 20
+      update_minutes: 20
+      delete_minutes: 20
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+autogen_status: UmVnaW9uYWxNdWx0aWNhc3RQcm9kdWNlckFzc29jaWF0aW9u
+autogen_async: true
+samples:
+  - name: network_services_regional_multicast_producer_association_basic
+    primary_resource_id: rmpa_test
+    steps:
+      - name: network_services_regional_multicast_producer_association_basic
+        resource_id_vars:
+          network_name: test-network-rmpa
+          domain_name: test-domain-rmpa
+          domain_activation_name: test-domain-activation-rmpa
+          producer_association_name: test-producer-association-rmpa
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: regionalMulticastProducerAssociationId
+    type: String
+    required: true
+    description: |-
+      A unique name for the regional multicast producer association.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: createTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast producer
+      association was created.
+    output: true
+  - name: description
+    type: String
+    description: |-
+      An optional text description of the regional multicast producer
+      association.
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key-value pairs
+  - name: name
+    type: String
+    description: |-
+      Identifier. The resource name of the regional multicast producer association.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastProducerAssociations/*`.
+    output: true
+  - name: network
+    type: String
+    required: true
+    description: |-
+      The resource name of the multicast producer VPC network.
+      Use the following format:
+      `projects/{project}/locations/global/networks/{network}`.
+    immutable: true
+  - name: regionalMulticastDomainActivation
+    type: String
+    required: true
+    description: |-
+      The resource name of the regional multicast domain activation that is in
+      the same region as this regional multicast producer association.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastDomainActivations/*`.
+    immutable: true
+  - name: state
+    type: NestedObject
+    description: The multicast resource's state.
+    properties:
+      - name: state
+        type: String
+        description: |-
+          The state of the multicast resource.
+          Possible values:
+          CREATING
+          ACTIVE
+          DELETING
+          DELETE_FAILED
+          UPDATING
+          UPDATE_FAILED
+          INACTIVE
+          OBSOLETE
+  - name: uniqueId
+    type: String
+    description: |-
+      [Output only] The Google-generated UUID for the resource. This value is
+      unique across all regional multicast producer association resources. If a
+      regional multicast producer association is deleted and another with the
+      same name is created, the new regional multicast producer association is
+      assigned a different unique_id.
+    output: true
+  - name: updateTime
+    type: String
+    description: |-
+      [Output only] The timestamp when the regional multicast producer
+      association was most recently updated.
+    output: true

--- a/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Producer Association: https://docs.cloud.google.com/vpc/docs/multicast/enable-producer-network#create-producer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastProducerAssociations
-min_version: beta
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations/{{regional_multicast_producer_association_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations?regionalMulticastProducerAssociationId={{regional_multicast_producer_association_id}}

--- a/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
@@ -14,6 +14,10 @@
 ---
 name: RegionalMulticastProducerAssociation
 description: Create a regional multicast producer association in the specified location of the current project.
+references:
+  guides:
+    Create Regional Multicast Producer Association: https://docs.cloud.google.com/vpc/docs/multicast/enable-producer-network#create-producer
+  api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastProducerAssociations
 min_version: nightly
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations/{{regional_multicast_producer_association_id}}
@@ -112,6 +116,7 @@ properties:
   - name: state
     type: NestedObject
     description: The multicast resource's state.
+    output: true
     properties:
       - name: state
         type: String
@@ -126,6 +131,7 @@ properties:
           UPDATE_FAILED
           INACTIVE
           OBSOLETE
+        output: true
   - name: uniqueId
     type: String
     description: |-

--- a/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
@@ -60,35 +60,42 @@ samples:
 parameters:
   - name: location
     type: String
-    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
+    required: true
   - name: regionalMulticastProducerAssociationId
     type: String
-    required: true
     description: |-
       A unique name for the regional multicast producer association.
-      The name is restricted to lower-case letters, numbers, and hyphen, with
-      the first character a lower-case letter, and the last a letter or a
-      number. The name must not exceed 63 characters.
+      The name is restricted to letters, numbers, and hyphen, with the first
+      character a letter, and the last a letter or a number. The name must not
+      exceed 48 characters.
     immutable: true
     url_param_only: true
+    required: true
 properties:
   - name: createTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast producer
-      association was created.
+      [Output only] The timestamp when the regional multicast producer association was
+      created.
     output: true
   - name: description
     type: String
-    description: |-
-      An optional text description of the regional multicast producer
-      association.
+    description: An optional text description of the regional multicast producer association.
   - name: labels
     type: KeyValueLabels
     description: Labels as key-value pairs
+  - name: regionalMulticastDomainActivation
+    type: String
+    description: |-
+      The resource name of the regional multicast domain activation that is in the
+      same region as this regional multicast producer association.
+      Use the following format:
+      // `projects/*/locations/*/regionalMulticastDomainActivations/*`.
+    immutable: true
+    required: true
   - name: name
     type: String
     description: |-
@@ -98,21 +105,12 @@ properties:
     output: true
   - name: network
     type: String
-    required: true
     description: |-
       The resource name of the multicast producer VPC network.
-      Use the following format:
+      Use following format:
       `projects/{project}/locations/global/networks/{network}`.
     immutable: true
-  - name: regionalMulticastDomainActivation
-    type: String
     required: true
-    description: |-
-      The resource name of the regional multicast domain activation that is in
-      the same region as this regional multicast producer association.
-      Use the following format:
-      `projects/*/locations/*/regionalMulticastDomainActivations/*`.
-    immutable: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -130,20 +128,18 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
-          OBSOLETE
         output: true
   - name: uniqueId
     type: String
     description: |-
       [Output only] The Google-generated UUID for the resource. This value is
-      unique across all regional multicast producer association resources. If a
-      regional multicast producer association is deleted and another with the
-      same name is created, the new regional multicast producer association is
-      assigned a different unique_id.
+      unique across all regional multicast producer association resources. If a producer
+      association is deleted and another with the same name is created, the new
+      producer association is assigned a different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast producer
-      association was most recently updated.
+      [Output only] The timestamp when the Regional Multicast Producer Association was
+      most recently updated.
     output: true

--- a/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Producer Association: https://docs.cloud.google.com/vpc/docs/multicast/enable-producer-network#create-producer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastProducerAssociations
-min_version: alpha
+min_version: beta
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations/{{regional_multicast_producer_association_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations?regionalMulticastProducerAssociationId={{regional_multicast_producer_association_id}}

--- a/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
@@ -18,7 +18,7 @@ references:
   guides:
     Create Regional Multicast Producer Association: https://docs.cloud.google.com/vpc/docs/multicast/enable-producer-network#create-producer
   api: https://docs.cloud.google.com/vpc/docs/multicast/reference/rest/v1/projects.locations.regionalMulticastProducerAssociations
-min_version: nightly
+min_version: alpha
 base_url: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations
 self_link: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations/{{regional_multicast_producer_association_id}}
 create_url: projects/{{project}}/locations/{{location}}/regionalMulticastProducerAssociations?regionalMulticastProducerAssociationId={{regional_multicast_producer_association_id}}

--- a/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
+++ b/mmv1/products/networkservices/RegionalMulticastProducerAssociation.yaml
@@ -60,42 +60,35 @@ samples:
 parameters:
   - name: location
     type: String
+    required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
-    required: true
   - name: regionalMulticastProducerAssociationId
     type: String
+    required: true
     description: |-
       A unique name for the regional multicast producer association.
-      The name is restricted to letters, numbers, and hyphen, with the first
-      character a letter, and the last a letter or a number. The name must not
-      exceed 48 characters.
+      The name is restricted to lower-case letters, numbers, and hyphen, with
+      the first character a lower-case letter, and the last a letter or a
+      number. The name must not exceed 63 characters.
     immutable: true
     url_param_only: true
-    required: true
 properties:
   - name: createTime
     type: String
     description: |-
-      [Output only] The timestamp when the regional multicast producer association was
-      created.
+      [Output only] The timestamp when the regional multicast producer
+      association was created.
     output: true
   - name: description
     type: String
-    description: An optional text description of the regional multicast producer association.
+    description: |-
+      An optional text description of the regional multicast producer
+      association.
   - name: labels
     type: KeyValueLabels
     description: Labels as key-value pairs
-  - name: regionalMulticastDomainActivation
-    type: String
-    description: |-
-      The resource name of the regional multicast domain activation that is in the
-      same region as this regional multicast producer association.
-      Use the following format:
-      // `projects/*/locations/*/regionalMulticastDomainActivations/*`.
-    immutable: true
-    required: true
   - name: name
     type: String
     description: |-
@@ -105,12 +98,21 @@ properties:
     output: true
   - name: network
     type: String
+    required: true
     description: |-
       The resource name of the multicast producer VPC network.
-      Use following format:
+      Use the following format:
       `projects/{project}/locations/global/networks/{network}`.
     immutable: true
+  - name: regionalMulticastDomainActivation
+    type: String
     required: true
+    description: |-
+      The resource name of the regional multicast domain activation that is in
+      the same region as this regional multicast producer association.
+      Use the following format:
+      `projects/*/locations/*/regionalMulticastDomainActivations/*`.
+    immutable: true
   - name: state
     type: NestedObject
     description: The multicast resource's state.
@@ -128,18 +130,20 @@ properties:
           UPDATING
           UPDATE_FAILED
           INACTIVE
+          OBSOLETE
         output: true
   - name: uniqueId
     type: String
     description: |-
       [Output only] The Google-generated UUID for the resource. This value is
-      unique across all regional multicast producer association resources. If a producer
-      association is deleted and another with the same name is created, the new
-      producer association is assigned a different unique_id.
+      unique across all regional multicast producer association resources. If a
+      regional multicast producer association is deleted and another with the
+      same name is created, the new regional multicast producer association is
+      assigned a different unique_id.
     output: true
   - name: updateTime
     type: String
     description: |-
-      [Output only] The timestamp when the Regional Multicast Producer Association was
-      most recently updated.
+      [Output only] The timestamp when the regional multicast producer
+      association was most recently updated.
     output: true

--- a/mmv1/products/networkservices/product.yaml
+++ b/mmv1/products/networkservices/product.yaml
@@ -17,6 +17,8 @@ display_name: Network Services
 scopes:
   - https://www.googleapis.com/auth/cloud-identity
 versions:
+  - name: alpha
+    base_url: https://networkservices.googleapis.com/v1alpha1/
   - name: beta
     base_url: https://networkservices.googleapis.com/v1/
   - name: ga

--- a/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_consumer_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_consumer_association_basic.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_compute_network" "default" {
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_services_multicast_domain" "default" {
+  multicast_domain_id = "{{index $.ResourceIdVars "domain_name"}}"
+  location            = "global"
+  admin_network       = google_compute_network.default.id
+}
+
+resource "google_network_services_regional_multicast_domain_activation" "default" {
+  regional_multicast_domain_activation_id = "{{index $.ResourceIdVars "domain_activation_name"}}"
+  location                                = "us-central1"
+  multicast_domain                        = google_network_services_multicast_domain.default.id
+  pim_spec {
+    pim_mode                  = "PIM_MODE_SPARSE"
+    multicast_source_location = "MULTICAST_SOURCE_GCP"
+  }
+}
+
+resource "google_network_services_regional_multicast_consumer_association" {{$.PrimaryResourceId}} {
+  regional_multicast_consumer_association_id = "{{index $.ResourceIdVars "consumer_association_name"}}"
+  location                                   = "us-central1"
+  network                                    = google_compute_network.default.id
+  regional_multicast_domain_activation       = google_network_services_regional_multicast_domain_activation.default.id
+}

--- a/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_domain_activation_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_domain_activation_basic.tf.tmpl
@@ -1,0 +1,20 @@
+resource "google_compute_network" "default" {
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_services_multicast_domain" "default" {
+  multicast_domain_id = "{{index $.ResourceIdVars "domain_name"}}"
+  location            = "global"
+  admin_network       = google_compute_network.default.id
+}
+
+resource "google_network_services_regional_multicast_domain_activation" {{$.PrimaryResourceId}} {
+  regional_multicast_domain_activation_id = "{{index $.ResourceIdVars "domain_activation_name"}}"
+  location                                = "us-central1"
+  multicast_domain                        = google_network_services_multicast_domain.default.id
+  pim_spec {
+    pim_mode                  = "PIM_MODE_SPARSE"
+    multicast_source_location = "MULTICAST_SOURCE_GCP"
+  }
+}

--- a/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_group_consumer_activation_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_group_consumer_activation_basic.tf.tmpl
@@ -1,0 +1,53 @@
+resource "google_compute_network" "default" {
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_services_multicast_domain" "default" {
+  multicast_domain_id = "{{index $.ResourceIdVars "domain_name"}}"
+  location            = "global"
+  admin_network       = google_compute_network.default.id
+}
+
+resource "google_network_services_regional_multicast_domain_activation" "default" {
+  regional_multicast_domain_activation_id = "{{index $.ResourceIdVars "domain_activation_name"}}"
+  location                                = "us-central1"
+  multicast_domain                        = google_network_services_multicast_domain.default.id
+  pim_spec {
+    pim_mode                  = "PIM_MODE_SPARSE"
+    multicast_source_location = "MULTICAST_SOURCE_GCP"
+  }
+}
+
+resource "google_network_services_multicast_group_range" "default" {
+  multicast_group_range_id = "{{index $.ResourceIdVars "group_range_name"}}"
+  location                 = "global"
+  multicast_domain         = google_network_services_multicast_domain.default.id
+  ip_cidr_range            = "239.1.1.0/24"
+}
+
+resource "google_network_services_regional_multicast_group_range_activation" "default" {
+  regional_multicast_group_range_activation_id = "{{index $.ResourceIdVars "group_range_activation_name"}}"
+  location                                     = "us-central1"
+  multicast_group_range                        = google_network_services_multicast_group_range.default.id
+  regional_multicast_domain_activation         = google_network_services_regional_multicast_domain_activation.default.id
+  pim_spec {
+    pim_mode                  = "PIM_MODE_SPARSE"
+    multicast_source_location = "MULTICAST_SOURCE_GCP"
+  }
+}
+
+resource "google_network_services_regional_multicast_consumer_association" "default" {
+  regional_multicast_consumer_association_id = "{{index $.ResourceIdVars "consumer_association_name"}}"
+  location                                   = "us-central1"
+  network                                    = google_compute_network.default.id
+  regional_multicast_domain_activation       = google_network_services_regional_multicast_domain_activation.default.id
+}
+
+resource "google_network_services_regional_multicast_group_consumer_activation" {{$.PrimaryResourceId}} {
+  regional_multicast_group_consumer_activation_id = "{{index $.ResourceIdVars "group_consumer_activation_name"}}"
+  location                                      = "us-central1"
+  regional_multicast_group_range_activation     = google_network_services_regional_multicast_group_range_activation.default.id
+  regional_multicast_consumer_association       = google_network_services_regional_multicast_consumer_association.default.id
+  interconnect_attachments                      = ["projects/123456789/regions/us-central1/interconnectAttachments/test-attachment"]
+}

--- a/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_group_producer_activation_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_group_producer_activation_basic.tf.tmpl
@@ -1,0 +1,53 @@
+resource "google_compute_network" "default" {
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_services_multicast_domain" "default" {
+  multicast_domain_id = "{{index $.ResourceIdVars "domain_name"}}"
+  location            = "global"
+  admin_network       = google_compute_network.default.id
+}
+
+resource "google_network_services_regional_multicast_domain_activation" "default" {
+  regional_multicast_domain_activation_id = "{{index $.ResourceIdVars "domain_activation_name"}}"
+  location                                = "us-central1"
+  multicast_domain                        = google_network_services_multicast_domain.default.id
+  pim_spec {
+    pim_mode                  = "PIM_MODE_SPARSE"
+    multicast_source_location = "MULTICAST_SOURCE_GCP"
+  }
+}
+
+resource "google_network_services_multicast_group_range" "default" {
+  multicast_group_range_id = "{{index $.ResourceIdVars "group_range_name"}}"
+  location                 = "global"
+  multicast_domain         = google_network_services_multicast_domain.default.id
+  ip_cidr_range            = "239.1.1.0/24"
+}
+
+resource "google_network_services_regional_multicast_group_range_activation" "default" {
+  regional_multicast_group_range_activation_id = "{{index $.ResourceIdVars "group_range_activation_name"}}"
+  location                                     = "us-central1"
+  multicast_group_range                        = google_network_services_multicast_group_range.default.id
+  regional_multicast_domain_activation         = google_network_services_regional_multicast_domain_activation.default.id
+  pim_spec {
+    pim_mode                  = "PIM_MODE_SPARSE"
+    multicast_source_location = "MULTICAST_SOURCE_GCP"
+  }
+}
+
+resource "google_network_services_regional_multicast_producer_association" "default" {
+  regional_multicast_producer_association_id = "{{index $.ResourceIdVars "producer_association_name"}}"
+  location                                   = "us-central1"
+  network                                    = google_compute_network.default.id
+  regional_multicast_domain_activation       = google_network_services_regional_multicast_domain_activation.default.id
+}
+
+resource "google_network_services_regional_multicast_group_producer_activation" {{$.PrimaryResourceId}} {
+  regional_multicast_group_producer_activation_id = "{{index $.ResourceIdVars "group_producer_activation_name"}}"
+  location                                      = "us-central1"
+  regional_multicast_group_range_activation     = google_network_services_regional_multicast_group_range_activation.default.id
+  regional_multicast_producer_association       = google_network_services_regional_multicast_producer_association.default.id
+  interconnect_attachments                      = ["projects/123456789/regions/us-central1/interconnectAttachments/test-attachment"]
+}

--- a/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_group_range_activation_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_group_range_activation_basic.tf.tmpl
@@ -1,0 +1,38 @@
+resource "google_compute_network" "default" {
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_services_multicast_domain" "default" {
+  multicast_domain_id = "{{index $.ResourceIdVars "domain_name"}}"
+  location            = "global"
+  admin_network       = google_compute_network.default.id
+}
+
+resource "google_network_services_regional_multicast_domain_activation" "default" {
+  regional_multicast_domain_activation_id = "{{index $.ResourceIdVars "domain_activation_name"}}"
+  location                                = "us-central1"
+  multicast_domain                        = google_network_services_multicast_domain.default.id
+  pim_spec {
+    pim_mode                  = "PIM_MODE_SPARSE"
+    multicast_source_location = "MULTICAST_SOURCE_GCP"
+  }
+}
+
+resource "google_network_services_multicast_group_range" "default" {
+  multicast_group_range_id = "{{index $.ResourceIdVars "group_range_name"}}"
+  location                 = "global"
+  multicast_domain         = google_network_services_multicast_domain.default.id
+  ip_cidr_range            = "239.1.1.0/24"
+}
+
+resource "google_network_services_regional_multicast_group_range_activation" {{$.PrimaryResourceId}} {
+  regional_multicast_group_range_activation_id = "{{index $.ResourceIdVars "group_range_activation_name"}}"
+  location                                     = "us-central1"
+  multicast_group_range                        = google_network_services_multicast_group_range.default.id
+  regional_multicast_domain_activation         = google_network_services_regional_multicast_domain_activation.default.id
+  pim_spec {
+    pim_mode                  = "PIM_MODE_SPARSE"
+    multicast_source_location = "MULTICAST_SOURCE_GCP"
+  }
+}

--- a/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_producer_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkservices/network_services_regional_multicast_producer_association_basic.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_compute_network" "default" {
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_services_multicast_domain" "default" {
+  multicast_domain_id = "{{index $.ResourceIdVars "domain_name"}}"
+  location            = "global"
+  admin_network       = google_compute_network.default.id
+}
+
+resource "google_network_services_regional_multicast_domain_activation" "default" {
+  regional_multicast_domain_activation_id = "{{index $.ResourceIdVars "domain_activation_name"}}"
+  location                                = "us-central1"
+  multicast_domain                        = google_network_services_multicast_domain.default.id
+  pim_spec {
+    pim_mode                  = "PIM_MODE_SPARSE"
+    multicast_source_location = "MULTICAST_SOURCE_GCP"
+  }
+}
+
+resource "google_network_services_regional_multicast_producer_association" {{$.PrimaryResourceId}} {
+  regional_multicast_producer_association_id = "{{index $.ResourceIdVars "producer_association_name"}}"
+  location                                   = "us-central1"
+  network                                    = google_compute_network.default.id
+  regional_multicast_domain_activation       = google_network_services_regional_multicast_domain_activation.default.id
+}


### PR DESCRIPTION
Tracking Bug: [b/532221299](http://b/532221299)
CCFE Autogen Source: //google/cloud/networkservices:v1alpha1_yaml (go/terraform-autogen)

Scope
Onboards 6 regional MoGCI (v1alpha1) resources exclusively to google-nightly (min_version: nightly):

google_network_services_regional_multicast_domain_activation
google_network_services_regional_multicast_group_range_activation
google_network_services_regional_multicast_producer_association
google_network_services_regional_multicast_consumer_association
google_network_services_regional_multicast_group_producer_activation
google_network_services_regional_multicast_group_consumer_activation

```release-note:none ```