### PR TITLE
`mmv1/list`: Support `default_value` for optional list scope properties

### DIFF
--- a/mmv1/templates/terraform/list_resource.go.tmpl
+++ b/mmv1/templates/terraform/list_resource.go.tmpl
@@ -88,6 +88,11 @@ func (listR *{{ $.ResourceName -}}ListResource) List(ctx context.Context, listRe
 {{- range $scope := $.ListScopeProperties }}
 {{- if or (eq $scope.Name "project") (eq $scope.Name "region") (eq $scope.Name "zone") (eq $scope.Name "location") }}
 	{{ $scope.CamelizeProperty }} := listR.Get{{ $scope.TitlelizeProperty }}(data.{{ $scope.TitlelizeProperty }})
+{{- else if $scope.DefaultValue }}
+	{{ $scope.CamelizeProperty }} := data.{{ $scope.TitlelizeProperty }}.ValueString()
+	if {{ $scope.CamelizeProperty }} == "" {
+		{{ $scope.CamelizeProperty }} = "{{ $scope.DefaultValue }}"
+	}
 {{- else }}
 	{{ $scope.CamelizeProperty }} := data.{{ $scope.TitlelizeProperty }}.ValueString()
 {{- end }}

--- a/mmv1/templates/terraform/list_resource_method.go.tmpl
+++ b/mmv1/templates/terraform/list_resource_method.go.tmpl
@@ -21,11 +21,23 @@ func List{{ $.ResourceName }}s(config *transport_tpg.Config,
 ) error {
 	resourceData := Resource{{ $.ResourceName }}().Data(&terraform.InstanceState{})
 {{- range $scope := $.ListScopeProperties }}
+{{- if $scope.DefaultValue }}
+	{
+		v := {{ $scope.CamelizeProperty }}
+		if v == "" {
+			v = "{{ $scope.DefaultValue }}"
+		}
+		if err := resourceData.Set("{{ underscore $scope.Name }}", v); err != nil {
+			return fmt.Errorf("error setting {{ underscore $scope.Name }} on temporary resource data: %w", err)
+		}
+	}
+{{- else }}
 	if {{ $scope.CamelizeProperty }} != "" {
 		if err := resourceData.Set("{{ underscore $scope.Name }}", {{ $scope.CamelizeProperty }}); err != nil {
 			return fmt.Errorf("error setting {{ underscore $scope.Name }} on temporary resource data: %w", err)
 		}
 	}
+{{- end }}
 {{- end }}
 
 	url, err := tpgresource.ReplaceVars{{if $.LegacyLongFormProject -}}ForId{{ end -}}(resourceData, config, "{{"{{"}}{{$.ProductMetadata.Name}}BasePath{{"}}"}}{{$.BaseUrl}}")

--- a/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
@@ -114,7 +114,7 @@ func TestAcc{{ $.ResourceName }}ListQuery_generated(t *testing.T) {
 					),
 					listScope.Capture(map[string]string{
 					{{- range $scope := $.ListScopeProperties }}
-						{{- if $scope.Required }}
+						{{- if or $scope.Required $scope.DefaultValue }}
 							{{- $n := underscore $scope.Name }}
 						"{{ $n }}": "{{ $sample.ResourceType $.TerraformName }}.{{ $sample.PrimaryResourceId }}",
 						{{- end }}
@@ -142,7 +142,7 @@ func TestAcc{{ $.ResourceName }}ListQuery_generated(t *testing.T) {
 func testAcc{{ $step.TestStepSlug $.ProductMetadata.Name $.Name }}ListQuery(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 {{- range $scope := $.ListScopeProperties }}
-	{{- if $scope.Required }}
+	{{- if or $scope.Required $scope.DefaultValue }}
 		{{- $n := underscore $scope.Name }}
 variable "{{ $n }}" { type = string }
 	{{- end }}
@@ -152,7 +152,7 @@ list "{{ $sample.ResourceType $.TerraformName }}" "list_query" {
 	limit = 10000
     config {
 {{- range $scope := $.ListScopeProperties }}
-        {{- if $scope.Required }}
+        {{- if or $scope.Required $scope.DefaultValue }}
             {{- $n := underscore $scope.Name }}
         {{ $n }} = var.{{ $n }}
         {{- end }}


### PR DESCRIPTION
When a url_param_only parameter in a resource's collection URL is optional but has a default_value, the list resource machinery was previously treating an empty/omitted value as a blank string, resulting in malformed URLs like `collections//engines/...`.

Fix this in three places:

- list_resource.go.tmpl: fall back to the field's default_value when the user does not supply a value for an optional scope property
- list_resource_method.go.tmpl: same fallback when setting the property on the temporary ResourceData used to build the list URL
- query_test_file.go.tmpl: include optional fields that have a default_value in the generated list query test (capture + variable declaration + config) so the default is propagated to the list block

This unblocks generate_list_resource: true for resources like google_discovery_engine_control and google_discovery_engine_widget_config whose collectionId parameter defaults to "default_collection".

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
