### PR TITLE
Add traffic config support and diff suppress to Vertex AI ReasoningEngine

### DIFF
--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -1130,10 +1130,12 @@ properties:
     description: |-
       Optional. Traffic distribution configuration for the Reasoning Engine.
 
-      ~> **Note:** Because revision IDs do not exist before the resource is created, the best practice for initial deployment is to set `traffic_split_always_latest {}`. Once the resource is created, you can update the configuration to a manual split using the newly generated revision IDs or short names (e.g. `rev-1`).
+      ~> **Note:** Because revision IDs do not exist before the resource is created, the best practice for initial deployment is to set `traffic_split_always_latest {}`. Once the resource is created, you can update the configuration to a manual split using newly generated revision IDs, short names (e.g. `rev-1`), or keywords such as `LATEST` and `PREVIOUS`.
     properties:
       - name: 'trafficSplitManual'
         type: NestedObject
+        conflicts:
+          - 'traffic_config.0.traffic_split_always_latest'
         description: |-
           Optional. Manual traffic distribution configuration, where the user specifies the
           Runtime Revision IDs and the percentage of traffic to send to each.
@@ -1151,7 +1153,7 @@ properties:
                   diff_suppress_func: 'vertexAiReasoningEngineRuntimeRevisionNameDiffSuppress'
                   custom_expand: 'templates/terraform/custom_expand/vertex_ai_reasoning_engine_runtime_revision_name.go.tmpl'
                   description: |-
-                    Required. The Runtime Revision name to which to send this portion of traffic.
+                    Required. The Runtime Revision name to which to send this portion of traffic. Accepts revision IDs, short names (e.g. `rev-1`), or keywords such as `LATEST` and `PREVIOUS`. Note: Keywords like `LATEST` and `PREVIOUS` resolve at apply time to the concrete underlying revision ID and remain pinned until `traffic_config` is updated in Terraform.
                   required: true
                 - name: 'percent'
                   type: Integer
@@ -1160,6 +1162,8 @@ properties:
                   required: true
       - name: 'trafficSplitAlwaysLatest'
         type: NestedObject
+        conflicts:
+          - 'traffic_config.0.traffic_split_manual'
         description: |-
           Optional. Traffic distribution configuration, where all traffic is sent to the
           latest Runtime Revision.

--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -158,7 +158,18 @@ samples:
           name: 're-gran-ttl'
         ignore_read_extra:
           - 'deletion_policy'
+  - name: 'vertex_ai_reasoning_engine_traffic_config'
+    primary_resource_id: 'reasoning_engine'
+    min_version: beta
+    steps:
+      - name: 'vertex_ai_reasoning_engine_traffic_config'
+        min_version: beta
+        resource_id_vars:
+          name: 're-traffic-cfg'
+        ignore_read_extra:
+          - 'deletion_policy'
 custom_code:
+  constants: 'templates/terraform/constants/vertex_ai_reasoning_engine.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/reasoning_engine_deletion_policy.go.tmpl'
   post_update: 'templates/terraform/post_update/sleep_10s.go.tmpl'
   pre_update: 'templates/terraform/pre_update/vertex_ai_reasoning_engine.go.tmpl'
@@ -1118,6 +1129,8 @@ properties:
     default_from_api: true
     description: |-
       Optional. Traffic distribution configuration for the Reasoning Engine.
+
+      ~> **Note:** Because revision IDs do not exist before the resource is created, the best practice for initial deployment is to set `traffic_split_always_latest {}`. Once the resource is created, you can update the configuration to a manual split using the newly generated revision IDs or short names (e.g. `rev-1`).
     properties:
       - name: 'trafficSplitManual'
         type: NestedObject
@@ -1135,6 +1148,8 @@ properties:
               properties:
                 - name: 'runtimeRevisionName'
                   type: String
+                  diff_suppress_func: 'vertexAiReasoningEngineRuntimeRevisionNameDiffSuppress'
+                  custom_expand: 'templates/terraform/custom_expand/vertex_ai_reasoning_engine_runtime_revision_name.go.tmpl'
                   description: |-
                     Required. The Runtime Revision name to which to send this portion of traffic.
                   required: true

--- a/mmv1/templates/terraform/constants/vertex_ai_reasoning_engine.go.tmpl
+++ b/mmv1/templates/terraform/constants/vertex_ai_reasoning_engine.go.tmpl
@@ -7,12 +7,25 @@ func vertexAiReasoningEngineRuntimeRevisionNameDiffSuppress(k, old, new string, 
 	}
 
 	// Short name suffix matching (e.g., "rev-1" or "1" against full URI "projects/.../runtimeRevisions/rev-1")
-	if strings.HasSuffix(old, "/"+new) {
+	if strings.HasSuffix(old, "/"+new) || strings.HasSuffix(old, "/rev-"+new) {
 		return true
 	}
 
 	// Keyword matching for LATEST or PREVIOUS
 	if new == "LATEST" || new == "PREVIOUS" {
+		if d != nil {
+			if d.HasChange("spec") {
+				return false
+			}
+			oldTargets, newTargets := d.GetChange("traffic_config.0.traffic_split_manual.0.targets")
+			if oldSlice, ok1 := oldTargets.([]interface{}); ok1 {
+				if newSlice, ok2 := newTargets.([]interface{}); ok2 {
+					if len(oldSlice) != len(newSlice) {
+						return false
+					}
+				}
+			}
+		}
 		if len(old) > 0 {
 			return true
 		}

--- a/mmv1/templates/terraform/constants/vertex_ai_reasoning_engine.go.tmpl
+++ b/mmv1/templates/terraform/constants/vertex_ai_reasoning_engine.go.tmpl
@@ -1,0 +1,22 @@
+func vertexAiReasoningEngineRuntimeRevisionNameDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if old == new {
+		return true
+	}
+	if old == "" || new == "" {
+		return false
+	}
+
+	// Short name suffix matching (e.g., "rev-1" or "1" against full URI "projects/.../runtimeRevisions/rev-1")
+	if strings.HasSuffix(old, "/"+new) {
+		return true
+	}
+
+	// Keyword matching for LATEST or PREVIOUS
+	if new == "LATEST" || new == "PREVIOUS" {
+		if len(old) > 0 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/mmv1/templates/terraform/custom_expand/vertex_ai_reasoning_engine_runtime_revision_name.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/vertex_ai_reasoning_engine_runtime_revision_name.go.tmpl
@@ -1,0 +1,56 @@
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return v, nil
+	}
+
+	// Keyword resolution for LATEST or PREVIOUS from state
+	if s == "LATEST" || s == "PREVIOUS" {
+		var tcData interface{}
+		if rd, ok := d.(interface{ GetChange(string) (interface{}, interface{}) }); ok {
+			tcData, _ = rd.GetChange("traffic_config")
+		} else if tc, ok := d.GetOk("traffic_config"); ok {
+			tcData = tc
+		}
+		if tcList, ok := tcData.([]interface{}); ok && len(tcList) > 0 && tcList[0] != nil {
+			tcMap := tcList[0].(map[string]interface{})
+			if tsm, ok := tcMap["traffic_split_manual"]; ok {
+				if tsmList, ok := tsm.([]interface{}); ok && len(tsmList) > 0 && tsmList[0] != nil {
+					tsmMap := tsmList[0].(map[string]interface{})
+					if targets, ok := tsmMap["targets"]; ok {
+						if targetsList, ok := targets.([]interface{}); ok {
+							var revs []string
+							for _, target := range targetsList {
+								if tMap, ok := target.(map[string]interface{}); ok {
+									if rev, ok := tMap["runtime_revision_name"].(string); ok && rev != "" && rev != "LATEST" && rev != "PREVIOUS" {
+										revs = append(revs, rev)
+									}
+								}
+							}
+							if s == "LATEST" && len(revs) > 0 {
+								s = revs[len(revs)-1]
+							} else if s == "PREVIOUS" && len(revs) > 1 {
+								s = revs[len(revs)-2]
+							} else if s == "PREVIOUS" && len(revs) == 1 {
+								s = revs[0]
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Expand short revision names into full resource URIs
+	if !strings.HasPrefix(s, "projects/") && !strings.Contains(s, "/runtimeRevisions/") {
+		resName, err := tpgresource.ReplaceVars(d, config, "projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}region{{"}}"}}/reasoningEngines/{{"{{"}}name{{"}}"}}")
+		if err == nil && resName != "" {
+			return fmt.Sprintf("%s/runtimeRevisions/%s", resName, s), nil
+		}
+	}
+
+	return s, nil
+}

--- a/mmv1/templates/terraform/custom_expand/vertex_ai_reasoning_engine_runtime_revision_name.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/vertex_ai_reasoning_engine_runtime_revision_name.go.tmpl
@@ -7,49 +7,110 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 		return v, nil
 	}
 
-	// Keyword resolution for LATEST or PREVIOUS from state
+	// Keyword resolution for LATEST or PREVIOUS by querying live API runtimeRevisions
 	if s == "LATEST" || s == "PREVIOUS" {
-		var tcData interface{}
-		if rd, ok := d.(interface{ GetChange(string) (interface{}, interface{}) }); ok {
-			tcData, _ = rd.GetChange("traffic_config")
-		} else if tc, ok := d.GetOk("traffic_config"); ok {
-			tcData = tc
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}VertexAIBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}region{{"}}"}}/reasoningEngines/{{"{{"}}name{{"}}"}}/runtimeRevisions")
+		if err != nil || strings.Contains(url, "{{"{{"}}name{{"}}"}}") {
+			return nil, fmt.Errorf("cannot resolve keyword %q: reasoning engine resource name is not yet available (deploy using 'traffic_split_always_latest {}' first)", s)
 		}
-		if tcList, ok := tcData.([]interface{}); ok && len(tcList) > 0 && tcList[0] != nil {
-			tcMap := tcList[0].(map[string]interface{})
-			if tsm, ok := tcMap["traffic_split_manual"]; ok {
-				if tsmList, ok := tsm.([]interface{}); ok && len(tsmList) > 0 && tsmList[0] != nil {
-					tsmMap := tsmList[0].(map[string]interface{})
-					if targets, ok := tsmMap["targets"]; ok {
-						if targetsList, ok := targets.([]interface{}); ok {
-							var revs []string
-							for _, target := range targetsList {
-								if tMap, ok := target.(map[string]interface{}); ok {
-									if rev, ok := tMap["runtime_revision_name"].(string); ok && rev != "" && rev != "LATEST" && rev != "PREVIOUS" {
-										revs = append(revs, rev)
-									}
-								}
-							}
-							if s == "LATEST" && len(revs) > 0 {
-								s = revs[len(revs)-1]
-							} else if s == "PREVIOUS" && len(revs) > 1 {
-								s = revs[len(revs)-2]
-							} else if s == "PREVIOUS" && len(revs) == 1 {
-								s = revs[0]
-							}
-						}
+		userAgent, uErr := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+		project, pErr := tpgresource.GetProject(d, config)
+
+		var res map[string]interface{}
+		var reqErr error
+		if uErr != nil {
+			reqErr = uErr
+		} else if pErr != nil {
+			reqErr = pErr
+		} else {
+			res, reqErr = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+			})
+		}
+
+		var revs []struct {
+			name       string
+			createTime string
+		}
+		var rawRevs []interface{}
+		if res != nil {
+			if r, ok := res["runtimeRevisions"].([]interface{}); ok && len(r) > 0 {
+				rawRevs = r
+			} else if r, ok := res["reasoningEngineRuntimeRevisions"].([]interface{}); ok && len(r) > 0 {
+				rawRevs = r
+			}
+		}
+
+		if len(rawRevs) > 0 {
+			for _, r := range rawRevs {
+				if rMap, ok := r.(map[string]interface{}); ok {
+					rName, _ := rMap["name"].(string)
+					rTime, _ := rMap["createTime"].(string)
+					if rName != "" {
+						revs = append(revs, struct {
+							name       string
+							createTime string
+						}{name: rName, createTime: rTime})
 					}
 				}
 			}
+		}
+
+		if len(revs) > 0 {
+			// Helper to extract numeric revision ID for sorting fallback (e.g. "rev-10" -> 10)
+			extractRevisionNumber := func(name string) int {
+				base := name
+				if idx := strings.LastIndex(name, "/"); idx != -1 {
+					base = name[idx+1:]
+				}
+				trimmed := strings.TrimPrefix(base, "rev-")
+				if n, err := strconv.Atoi(trimmed); err == nil {
+					return n
+				}
+				return 0
+			}
+
+			// Sort revisions by createTime ascending, falling back to numeric revision ID comparison
+			sort.Slice(revs, func(i, j int) bool {
+				t1, err1 := time.Parse(time.RFC3339Nano, revs[i].createTime)
+				t2, err2 := time.Parse(time.RFC3339Nano, revs[j].createTime)
+				if err1 == nil && err2 == nil && !t1.Equal(t2) {
+					return t1.Before(t2)
+				}
+				num1 := extractRevisionNumber(revs[i].name)
+				num2 := extractRevisionNumber(revs[j].name)
+				if num1 != 0 && num2 != 0 && num1 != num2 {
+					return num1 < num2
+				}
+				return revs[i].name < revs[j].name
+			})
+			if s == "LATEST" {
+				s = revs[len(revs)-1].name
+			} else if s == "PREVIOUS" {
+				if len(revs) > 1 {
+					s = revs[len(revs)-2].name
+				} else {
+					return nil, fmt.Errorf("cannot resolve keyword %q: no previous runtime revision exists for this ReasoningEngine", s)
+				}
+			}
+		} else if reqErr != nil {
+			return nil, fmt.Errorf("error querying runtime revisions from GCP API to resolve keyword %q: %w", s, reqErr)
+		} else {
+			return nil, fmt.Errorf("cannot resolve keyword %q: no runtime revisions returned by GCP API for this ReasoningEngine", s)
 		}
 	}
 
 	// Expand short revision names into full resource URIs
 	if !strings.HasPrefix(s, "projects/") && !strings.Contains(s, "/runtimeRevisions/") {
 		resName, err := tpgresource.ReplaceVars(d, config, "projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}region{{"}}"}}/reasoningEngines/{{"{{"}}name{{"}}"}}")
-		if err == nil && resName != "" {
-			return fmt.Sprintf("%s/runtimeRevisions/%s", resName, s), nil
+		if err != nil || strings.Contains(resName, "{{"{{"}}name{{"}}"}}") {
+			return nil, fmt.Errorf("cannot use revision short name or keyword %q during initial creation: reasoning engine resource must be created first using 'traffic_split_always_latest {}'", s)
 		}
+		return fmt.Sprintf("%s/runtimeRevisions/%s", resName, s), nil
 	}
 
 	return s, nil

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_traffic_config.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_traffic_config.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
+  display_name = "{{index $.ResourceIdVars "name"}}"
+  description  = "Reasoning engine with traffic config"
+  region       = "us-central1"
+  provider     = google-beta
+
+  spec {
+    agent_framework = "langchain"
+  }
+
+  traffic_config {
+    traffic_split_always_latest {}
+  }
+}

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -33,7 +33,7 @@ func TestAccVertexAIReasoningEngine_vertexAiReasoningEngineUpdate(t *testing.T) 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVertexAIEndpointDestroyProducer(t),
+		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
 		},
@@ -66,7 +66,7 @@ func TestAccVertexAIReasoningEngine_vertexAiReasoningEngineSourceUpdate(t *testi
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVertexAIEndpointDestroyProducer(t),
+		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
 		},
@@ -588,7 +588,7 @@ func TestAccVertexAIReasoningEngine_vertexAiReasoningEngineIdentityTypeUpdate(t 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVertexAIEndpointDestroyProducer(t),
+		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVertexAIReasoningEngine_identityTypeServiceAccount(context),
@@ -653,7 +653,7 @@ func TestAccVertexAIReasoningEngine_vertexAiReasoningEngineImageSpecUpdate(t *te
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVertexAIEndpointDestroyProducer(t),
+		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVertexAIReasoningEngine_vertexAiReasoningEngineImageSpecExample(context),
@@ -725,7 +725,7 @@ func TestAccVertexAIReasoningEngine_apiParity(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy:             testAccCheckVertexAIEndpointDestroyProducer(t),
+		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVertexAIReasoningEngine_apiParity(context),
@@ -808,7 +808,7 @@ func TestAccVertexAIReasoningEngine_apiParityExternal(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVertexAIEndpointDestroyProducer(t),
+		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVertexAIReasoningEngine_apiParityExternal(context),
@@ -861,7 +861,7 @@ func TestAccVertexAIReasoningEngine_trafficSplitUpdate(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVertexAIEndpointDestroyProducer(t),
+		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVertexAIReasoningEngine_trafficSplitAlwaysLatest(context),
@@ -874,6 +874,33 @@ func TestAccVertexAIReasoningEngine_trafficSplitUpdate(t *testing.T) {
 			},
 			{
 				Config: testAccVertexAIReasoningEngine_trafficSplitManual(context),
+			},
+			{
+				ResourceName:            "google_vertex_ai_reasoning_engine.reasoning_engine",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "location", "region", "labels", "terraform_labels", "spec.0.source_code_spec.0.inline_source"},
+			},
+			{
+				Config: testAccVertexAIReasoningEngine_trafficSplitLatest(context),
+			},
+			{
+				ResourceName:            "google_vertex_ai_reasoning_engine.reasoning_engine",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "location", "region", "labels", "terraform_labels", "spec.0.source_code_spec.0.inline_source"},
+			},
+			{
+				Config: testAccVertexAIReasoningEngine_trafficSplitPrevious(context),
+			},
+			{
+				ResourceName:            "google_vertex_ai_reasoning_engine.reasoning_engine",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "location", "region", "labels", "terraform_labels", "spec.0.source_code_spec.0.inline_source"},
+			},
+			{
+				Config: testAccVertexAIReasoningEngine_trafficSplitPartial(context),
 			},
 			{
 				ResourceName:            "google_vertex_ai_reasoning_engine.reasoning_engine",
@@ -937,6 +964,127 @@ resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
       targets {
         runtime_revision_name = "1"
         percent               = 100
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccVertexAIReasoningEngine_trafficSplitLatest(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
+  display_name = "tf-test-reasoning-engine-%{random_suffix}"
+  region       = "us-central1"
+
+  spec {
+    source_code_spec {
+      inline_source {
+        source_archive = filebase64("./test-fixtures/source.tar.gz")
+      }
+
+      python_spec {
+        entrypoint_module = "simple_agent"
+        entrypoint_object = "fixed_name_generator"
+        version           = "3.11"
+      }
+    }
+
+    deployment_spec {
+      env {
+        name  = "REVISION"
+        value = "2"
+      }
+    }
+  }
+
+  traffic_config {
+    traffic_split_manual {
+      targets {
+        runtime_revision_name = "LATEST"
+        percent               = 100
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccVertexAIReasoningEngine_trafficSplitPrevious(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
+  display_name = "tf-test-reasoning-engine-%{random_suffix}"
+  region       = "us-central1"
+
+  spec {
+    source_code_spec {
+      inline_source {
+        source_archive = filebase64("./test-fixtures/source.tar.gz")
+      }
+
+      python_spec {
+        entrypoint_module = "simple_agent"
+        entrypoint_object = "fixed_name_generator"
+        version           = "3.11"
+      }
+    }
+
+    deployment_spec {
+      env {
+        name  = "REVISION"
+        value = "2"
+      }
+    }
+  }
+
+  traffic_config {
+    traffic_split_manual {
+      targets {
+        runtime_revision_name = "PREVIOUS"
+        percent               = 100
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccVertexAIReasoningEngine_trafficSplitPartial(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
+  display_name = "tf-test-reasoning-engine-%{random_suffix}"
+  region       = "us-central1"
+
+  spec {
+    source_code_spec {
+      inline_source {
+        source_archive = filebase64("./test-fixtures/source.tar.gz")
+      }
+
+      python_spec {
+        entrypoint_module = "simple_agent"
+        entrypoint_object = "fixed_name_generator"
+        version           = "3.11"
+      }
+    }
+
+    deployment_spec {
+      env {
+        name  = "REVISION"
+        value = "2"
+      }
+    }
+  }
+
+  traffic_config {
+    traffic_split_manual {
+      targets {
+        runtime_revision_name = "LATEST"
+        percent               = 80
+      }
+      targets {
+        runtime_revision_name = "PREVIOUS"
+        percent               = 20
       }
     }
   }

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -850,3 +850,96 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 }
 `, context)
 }
+
+func TestAccVertexAIReasoningEngine_trafficSplitUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVertexAIEndpointDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIReasoningEngine_trafficSplitAlwaysLatest(context),
+			},
+			{
+				ResourceName:            "google_vertex_ai_reasoning_engine.reasoning_engine",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "location", "region", "labels", "terraform_labels", "spec.0.source_code_spec.0.inline_source"},
+			},
+			{
+				Config: testAccVertexAIReasoningEngine_trafficSplitManual(context),
+			},
+			{
+				ResourceName:            "google_vertex_ai_reasoning_engine.reasoning_engine",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "location", "region", "labels", "terraform_labels", "spec.0.source_code_spec.0.inline_source"},
+			},
+		},
+	})
+}
+
+func testAccVertexAIReasoningEngine_trafficSplitAlwaysLatest(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
+  display_name = "tf-test-reasoning-engine-%{random_suffix}"
+  region       = "us-central1"
+
+  spec {
+    source_code_spec {
+      inline_source {
+        source_archive = filebase64("./test-fixtures/source.tar.gz")
+      }
+
+      python_spec {
+        entrypoint_module = "simple_agent"
+        entrypoint_object = "fixed_name_generator"
+        version           = "3.11"
+      }
+    }
+  }
+
+  traffic_config {
+    traffic_split_always_latest {}
+  }
+}
+`, context)
+}
+
+func testAccVertexAIReasoningEngine_trafficSplitManual(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
+  display_name = "tf-test-reasoning-engine-%{random_suffix}"
+  region       = "us-central1"
+
+  spec {
+    source_code_spec {
+      inline_source {
+        source_archive = filebase64("./test-fixtures/source.tar.gz")
+      }
+
+      python_spec {
+        entrypoint_module = "simple_agent"
+        entrypoint_object = "fixed_name_generator"
+        version           = "3.11"
+      }
+    }
+  }
+
+  traffic_config {
+    traffic_split_manual {
+      targets {
+        runtime_revision_name = "1"
+        percent               = 100
+      }
+    }
+  }
+}
+`, context)
+}


### PR DESCRIPTION
Enables traffic distribution configuration (`traffic_config`) and live traffic split updates for the `google_vertex_ai_reasoning_engine` resource.

- Adds `traffic_config` property with support for `traffic_split_manual` and `traffic_split_always_latest` modes.
- Adds custom expander (`custom_expand`) to expand user-provided short revision names (e.g., `rev-1`, `1`) into full API resource URIs (`projects/.../locations/.../reasoningEngines/.../runtimeRevisions/...`).
- Adds custom `diff_suppress_func` to handle suffix matching for short revision names and `LATEST` / `PREVIOUS` keywords, preventing false plan drift.
- Adds acceptance test `TestAccVertexAIReasoningEngine_trafficSplitUpdate` validating live traffic split updates on deployed Agent Engine resources.

```release-note:enhancement
vertexai: added `traffic_config` field and live traffic split update support to `google_vertex_ai_reasoning_engine`
```