### PR TITLE
redis: update maintenance_version in TestAccRedisCluster_redisClusterMaintenanceVersion

### DIFF
--- a/mmv1/third_party/terraform/services/redis/resource_redis_cluster_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_cluster_test.go
@@ -1418,7 +1418,7 @@ resource "google_redis_cluster" "cluster-ms" {
   node_type 				 = "REDIS_SHARED_CORE_NANO"
   transit_encryption_mode 	 = "TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION"
   authorization_mode 		 = "AUTH_MODE_DISABLED"
-  maintenance_version 		 = "REDISCLUSTER_20251008_00_00"
+  maintenance_version 		 = "REDISCLUSTER_20260626_00_01"
   redis_configs = { 
     maxmemory-policy		 = "volatile-ttl"
   }


### PR DESCRIPTION
Fix `TestAccRedisCluster_redisClusterMaintenanceVersion` failure caused by hardcoded version string (`REDISCLUSTER_20251008_00_00`) being older than default maintenance version assigned to newly provisioned clusters on GCP.

```release-note:none
```