### PR TITLE
Add allowRequesterSpecifiedNotBeforeTime to CaPool and requestedNotBeforeTime to Certificate

### DIFF
--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -158,6 +158,17 @@ properties:
           time). If set, the certificates will be issued with a not_before_time of the issuance
           time minus the backdate_duration. The not_after_time will be adjusted to preserve the
           requested lifetime. The backdate_duration must be less than or equal to 48 hours.
+        conflicts:
+          - allow_requester_specified_not_before_time
+      - name: allowRequesterSpecifiedNotBeforeTime
+        type: Boolean
+        description: |
+          If set to true, allows requesters to specify the requested_not_before_time
+          field when creating a Certificate. Certificates requested with this
+          option enabled will have a 'not_before_time' equal to the value
+          specified in the request.
+        conflicts:
+          - backdate_duration
       - name: maximumLifetime
         type: String
         description: |

--- a/mmv1/products/privateca/Certificate.yaml
+++ b/mmv1/products/privateca/Certificate.yaml
@@ -96,6 +96,17 @@ samples:
           ca_pool_id: my-pool
         test_env_vars:
           project: PROJECT_NAME
+  - name: privateca_certificate_with_requested_not_before_time
+    primary_resource_id: default
+    external_providers:
+      - time
+    steps:
+      - name: privateca_certificate_with_requested_not_before_time
+        resource_id_vars:
+          ca_pool_id: my-pool
+          certificate_name: my-certificate
+        test_env_vars:
+          project: PROJECT_NAME
 parameters:
   - name: location
     type: String
@@ -142,6 +153,13 @@ properties:
     immutable: true
     # 10 years
     default_value: 315360000s
+  - name: requestedNotBeforeTime
+    type: Time
+    description: |
+      The requested not_before_time of this Certificate. This field may only be set
+      if the allow_requester_specified_not_before_time field is set to true for the
+      issuing CaPool.
+    immutable: true
   - name: revocationDetails
     type: NestedObject
     description: |

--- a/mmv1/products/privateca/Certificate.yaml
+++ b/mmv1/products/privateca/Certificate.yaml
@@ -98,6 +98,7 @@ samples:
           project: PROJECT_NAME
   - name: privateca_certificate_with_requested_not_before_time
     primary_resource_id: default
+    skip_vcr: true
     external_providers:
       - time
     steps:

--- a/mmv1/templates/terraform/custom_flatten/privateca_certificate_509_config.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/privateca_certificate_509_config.go.tmpl
@@ -1,7 +1,7 @@
 {{/* See mmv1/third_party/terraform/utils/privateca_utils.go for the sub-expanders and explanation */}}
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	if v == nil {
-		v = make(map[string]interface{})
+		return nil
 	}
 	original := v.(map[string]interface{})
 	transformed := make(map[string]interface{})

--- a/mmv1/templates/terraform/custom_flatten/privateca_certificate_template_509_config.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/privateca_certificate_template_509_config.go.tmpl
@@ -1,7 +1,7 @@
 {{/* See mmv1/third_party/terraform/utils/privateca_utils.go for the sub-expanders and explanation */}}
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	if v == nil {
-		v = make(map[string]interface{})
+		return nil
 	}
 	original := v.(map[string]interface{})
 	transformed := make(map[string]interface{})

--- a/mmv1/templates/terraform/samples/services/privateca/privateca_certificate_with_requested_not_before_time.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/privateca/privateca_certificate_with_requested_not_before_time.tf.tmpl
@@ -1,0 +1,107 @@
+resource "google_privateca_ca_pool" "default" {
+  location = "us-central1"
+  name     = "{{index $.ResourceIdVars "ca_pool_id"}}"
+  tier     = "ENTERPRISE"
+  issuance_policy {
+    allow_requester_specified_not_before_time = true
+  }
+}
+
+resource "google_privateca_certificate_authority" "default" {
+  location = "us-central1"
+  pool = google_privateca_ca_pool.default.name
+  certificate_authority_id = "my-authority"
+  config {
+    subject_config {
+      subject {
+        organization = "HashiCorp"
+        common_name = "my-certificate-authority"
+      }
+      subject_alt_name {
+        dns_names = ["hashicorp.com"]
+      }
+    }
+    x509_config {
+      ca_options {
+        is_ca = true
+      }
+      key_usage {
+        base_key_usage {
+          cert_sign = true
+          crl_sign = true
+        }
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+  key_spec {
+    algorithm = "RSA_PKCS1_4096_SHA256"
+  }
+
+  // Disable CA deletion related safe checks for easier cleanup.
+  deletion_protection                    = false
+  skip_grace_period                      = true
+  ignore_active_certificates_on_deletion = true
+}
+
+resource "time_static" "cert_start" {
+  depends_on = [google_privateca_certificate_authority.default]
+}
+
+resource "google_privateca_certificate" "{{$.PrimaryResourceId}}" {
+  location = "us-central1"
+  pool = google_privateca_ca_pool.default.name
+  certificate_authority = google_privateca_certificate_authority.default.certificate_authority_id
+  lifetime = "86000s"
+  name = "{{index $.ResourceIdVars "certificate_name"}}"
+  requested_not_before_time = time_static.cert_start.rfc3339
+  config {
+    subject_config  {
+      subject {
+        common_name = "san1.example.com"
+        country_code = "us"
+        organization = "google"
+        organizational_unit = "enterprise"
+        locality = "mountain view"
+        province = "california"
+        street_address = "1600 amphitheatre parkway"
+      } 
+      subject_alt_name {
+        email_addresses = ["email@example.com"]
+        ip_addresses = ["127.0.0.1"]
+        uris = ["http://www.ietf.org/rfc/rfc3986.txt"]
+      }
+    }
+    x509_config {
+      ca_options {
+        is_ca = true
+      }
+      key_usage {
+        base_key_usage {
+          crl_sign = false
+          decipher_only = false
+        }
+        extended_key_usage {
+          server_auth = false
+        }
+      }
+      name_constraints {
+        critical                  = true
+        permitted_dns_names       = ["*.example.com"]
+        excluded_dns_names        = ["*.deny.example.com"]
+        permitted_ip_ranges       = ["10.0.0.0/8"]
+        excluded_ip_ranges        = ["10.1.1.0/24"]
+        permitted_email_addresses = [".example.com"]
+        excluded_email_addresses  = [".deny.example.com"]
+        permitted_uris            = [".example.com"]
+        excluded_uris             = [".deny.example.com"]
+      }
+    }
+    public_key {
+      format = "PEM"
+      key = filebase64("test-fixtures/rsa_public.pem")
+    }
+  }
+}


### PR DESCRIPTION
### Description
This PR adds support for two new flags related to certificate backdating in the Private CA product:
1. `allow_requester_specified_not_before_time` in `google_privateca_ca_pool`: Allows configuring a CA pool to permit requesters to specify the `not_before_time` in certificate requests.
2. `requested_not_before_time` in `google_privateca_certificate`: Allows specifying a custom `not_before_time` when requesting a certificate (requires the pool to have `allow_requester_specified_not_before_time` enabled).

### Key Changes
*   Added field definitions to `CaPool.yaml` and `Certificate.yaml`.
*   Created a single-step acceptance test (`privateca_certificate_with_requested_not_before_time`).
*   Used `time_static` resource with a `depends_on` block in the test config to ensure the timestamp is dynamically set **after** the Certificate Authority is created, satisfying the API CA not_before_time restriction.
* Fixed a bug in custom flatteners (`privateca_certificate_509_config.go.tmpl` and `privateca_certificate_template_509_config.go.tmpl`) where they returned an empty map instead of nil when input was nil, which was blocking my test.

### 📋 Checklist

- [x] Ensured that all new fields I added that can be set by a user appear in at least one example (for generated resources) or third_party test (for handwritten resources or update tests).
- [x] Generated Terraform providers, and ran `make test` and `make lint` in the generated providers to ensure it passes unit and linter tests.
- [x] Ran relevant acceptance tests using my own Google Cloud project and credentials.
- [x] Read the Release Notes Guide before writing my release note below.
- [ ] 
### 🚀 Release Note Template for Downstream PRs

```release-note:enhancement
privateca: added `allow_requester_specified_not_before_time` field to `google_privateca_ca_pool` resource
```
```release-note:enhancement
privateca: added `requested_not_before_time` field to `google_privateca_certificate` resource
```