### PR TITLE
Promote GlobalVmExtensionPolicy and RolloutPlan to GA

### DIFF
--- a/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
+++ b/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
@@ -14,7 +14,6 @@
 ---
 name: 'GlobalVmExtensionPolicy'
 description: 'A Global VM Extension Policy.'
-min_version: 'beta'
 base_url: 'projects/{{project}}/global/vmExtensionPolicies'
 self_link: 'projects/{{project}}/global/vmExtensionPolicies/{{name}}'
 update_verb: 'PATCH'

--- a/mmv1/products/compute/RolloutPlan.yaml
+++ b/mmv1/products/compute/RolloutPlan.yaml
@@ -19,9 +19,8 @@ description: |
   into smaller increments, referred to as "waves". Each wave targets a specific
   portion of the overall affected area and defines criteria that must be met
   before progressing to the subsequent wave.
-min_version: 'beta'
 references:
-  api: 'https://cloud.google.com/compute/docs/reference/rest/beta/rolloutPlans'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/rolloutPlans'
 base_url: 'projects/{{project}}/global/rolloutPlans'
 has_self_link: true
 generate_list_resource: true

--- a/mmv1/templates/terraform/post_delete/global_vm_extension_policy.go.tmpl
+++ b/mmv1/templates/terraform/post_delete/global_vm_extension_policy.go.tmpl
@@ -33,7 +33,7 @@ if n, ok := d.GetOk("name"); ok {
 }
 
 if policyName != "" {
-	listUrl := fmt.Sprintf("https://compute.googleapis.com/compute/beta/projects/%s/global/rollouts?filter=rolloutEntity.orchestratedEntity.orchestrationSource%%20eq%%20%%22.*%s%%22", project, policyName)
+	listUrl := transport_tpg.BaseUrl(Product, config) + fmt.Sprintf("projects/%s/global/rollouts?filter=rolloutEntity.orchestratedEntity.orchestrationSource%%20eq%%20%%22.*%s%%22", project, policyName)
 	listRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    config,
 		Method:    "GET",
@@ -51,7 +51,7 @@ if policyName != "" {
 				if rollout, ok := item.(map[string]interface{}); ok {
 					if rolloutName, ok := rollout["name"].(string); ok && rolloutName != "" {
 						log.Printf("[DEBUG] Deleting historical rollout %q owned by policy %q to unlock referenced rollout plan", rolloutName, policyName)
-						deleteUrl := fmt.Sprintf("https://compute.googleapis.com/compute/beta/projects/%s/global/rollouts/%s", project, rolloutName)
+						deleteUrl := transport_tpg.BaseUrl(Product, config) + fmt.Sprintf("projects/%s/global/rollouts/%s", project, rolloutName)
 
 						res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 							Config:    config,

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_basic.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "global-ops-agent-vme-policy-%{random_suffix}"
   description = "A basic global VM extension policy"
   priority    = 10

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_custom_rollout.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_custom_rollout.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "global-ops-agent-vme-policy-%{random_suffix}"
   description = "A global VM extension policy with a custom rollout plan"
   priority    = 10
@@ -25,11 +24,9 @@ resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
 }
 
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_compute_rollout_plan" "custom_rollout" {
-  provider       = google-beta
   name           = "custom-rollout-plan-%{random_suffix}"
   location_scope = "ZONAL"
 

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "global-ops-agent-vme-policy-%{random_suffix}"
   description = "A basic global VM extension policy"
   priority    = 20

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update_rollout.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update_rollout.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "global-ops-agent-vme-policy-%{random_suffix}"
   description = "A basic global VM extension policy"
   priority    = 10

--- a/mmv1/templates/terraform/samples/services/compute/rollout_plan_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/rollout_plan_basic.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_rollout_plan" "{{ .PrimaryResourceId }}" {
-  provider       = google-beta
   name           = "tf-test-rollout-plan-%{random_suffix}"
   description    = "A test rollout plan"
   location_scope = "ZONAL"


### PR DESCRIPTION
This PR promotes `google_compute_global_vm_extension_policy` and `google_compute_rollout_plan` to general availability (GA) across the Google Terraform provider.
**Summary of changes:**
- Removed `min_version: beta` in both resource specifications (`GlobalVmExtensionPolicy.yaml` and `RolloutPlan.yaml`).
- Stripped explicit `provider = google-beta` usage blocks across sample configurations (`.tf.tmpl`).
- Updated post-delete historical rollout query paths to use dynamic `transport_tpg.BaseUrl(Product, config)`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_compute_global_vm_extension_policy` (ga)
```

```release-note:new-resource
`google_compute_rollout_plan` (ga)
```