### PR TITLE
bigquery: Add resource identity to `google_bigquery_table`

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -710,7 +710,7 @@ func ResourceBigQueryTable() *schema.Resource {
 			State: resourceBigQueryTableImport,
 		},
 		CustomizeDiff: customdiff.All(
-		          tpgresource.DefaultProviderDeletionPolicy("DELETE"),
+			tpgresource.DefaultProviderDeletionPolicy("DELETE"),
 			tpgresource.DefaultProviderProject,
 			resourceBigQueryTableSchemaCustomizeDiff,
 			tpgresource.SetLabelsDiff,

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -2487,7 +2487,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
     if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil{
         return err
     }
-
 	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
 		"project":    project,
 		"dataset_id": res.TableReference.DatasetId,

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -710,11 +710,30 @@ func ResourceBigQueryTable() *schema.Resource {
 			State: resourceBigQueryTableImport,
 		},
 		CustomizeDiff: customdiff.All(
-            tpgresource.DefaultProviderDeletionPolicy("DELETE"),
+		          tpgresource.DefaultProviderDeletionPolicy("DELETE"),
 			tpgresource.DefaultProviderProject,
 			resourceBigQueryTableSchemaCustomizeDiff,
 			tpgresource.SetLabelsDiff,
 		),
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"dataset_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"table_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
 		Schema: map[string]*schema.Schema{
 			// TableId: [Required] The ID of the table. The ID must contain only
 			// letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum
@@ -2468,7 +2487,14 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
     if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil{
         return err
     }
-    
+
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project":    project,
+		"dataset_id": res.TableReference.DatasetId,
+		"table_id":   res.TableReference.TableId,
+	}); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#28366

Adds the `Identity` block and `SetResourceIdentityAttributes` to `google_bigquery_table`, which is a prerequisite for the list resource implementation.

### Details

* Adds `Identity` block to `ResourceBigQueryTable()` schema with fields: `project`, `dataset_id`, `table_id`
* Adds `SetResourceIdentityAttributes` call in `resourceBigQueryTableRead`

### Release Note Template for Downstream PRs (will be copied)

```release-note:enhancement
bigquery: added identity support to `google_bigquery_table` for `terraform query` support
```