### PR TITLE
Add google_compute_service_attachments plural data source

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments.go
@@ -1,0 +1,196 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleComputeServiceAttachments() *schema.Resource {
+	return &schema.Resource{
+		Read: datasourceGoogleComputeServiceAttachmentsRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"service_attachments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"self_link": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"target_service": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"connection_preference": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nat_subnets": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"enable_proxy_protocol": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"domain_names": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"fingerprint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceGoogleComputeServiceAttachmentsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	region, err := tpgresource.GetRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	params := make(map[string]string)
+	if filter, ok := d.GetOk("filter"); ok {
+		params["filter"] = filter.(string)
+	}
+
+	serviceAttachments := make([]map[string]interface{}, 0)
+
+	for {
+		url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/serviceAttachments")
+		if err != nil {
+			return err
+		}
+
+		url, err = transport_tpg.AddQueryParams(url, params)
+		if err != nil {
+			return err
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return fmt.Errorf("error retrieving service attachments: %s", err)
+		}
+
+		pageItems := flattenDatasourceGoogleComputeServiceAttachmentsList(res["items"])
+		serviceAttachments = append(serviceAttachments, pageItems...)
+
+		pToken, ok := res["nextPageToken"]
+		if ok && pToken != nil && pToken.(string) != "" {
+			params["pageToken"] = pToken.(string)
+		} else {
+			break
+		}
+	}
+
+	if err := d.Set("service_attachments", serviceAttachments); err != nil {
+		return fmt.Errorf("error setting service_attachments: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("projects/%s/regions/%s/serviceAttachments", project, region))
+
+	return nil
+}
+
+func flattenDatasourceGoogleComputeServiceAttachmentsList(v interface{}) []map[string]interface{} {
+	if v == nil {
+		return make([]map[string]interface{}, 0)
+	}
+
+	ls := v.([]interface{})
+	serviceAttachments := make([]map[string]interface{}, 0, len(ls))
+	for _, raw := range ls {
+		p := raw.(map[string]interface{})
+
+		var natSubnets []interface{}
+		if ns, ok := p["natSubnets"]; ok && ns != nil {
+			natSubnets = ns.([]interface{})
+		}
+
+		var domainNames []interface{}
+		if dn, ok := p["domainNames"]; ok && dn != nil {
+			domainNames = dn.([]interface{})
+		}
+
+		var enableProxyProtocol bool
+		if epp, ok := p["enableProxyProtocol"]; ok && epp != nil {
+			enableProxyProtocol = epp.(bool)
+		}
+
+		serviceAttachments = append(serviceAttachments, map[string]interface{}{
+			"name":                  p["name"],
+			"description":           p["description"],
+			"self_link":             p["selfLink"],
+			"target_service":        p["targetService"],
+			"connection_preference": p["connectionPreference"],
+			"nat_subnets":           natSubnets,
+			"enable_proxy_protocol": enableProxyProtocol,
+			"domain_names":          domainNames,
+			"fingerprint":           p["fingerprint"],
+			"region":                p["region"],
+		})
+	}
+
+	return serviceAttachments
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_compute_service_attachments",
+		ProductName: "compute",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceGoogleComputeServiceAttachments(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments.go
@@ -54,77 +54,84 @@ func datasourceGoogleComputeServiceAttachmentsRead(d *schema.ResourceData, meta 
 		return err
 	}
 
+	billingProject := project
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
 	id := fmt.Sprintf("projects/%s/regions/%s/serviceAttachments", project, region)
 	d.SetId(id)
 
-	call := NewClient(config, userAgent).ServiceAttachments.List(project, region)
-	if filter, ok := d.GetOk("filter"); ok {
-		call = call.Filter(filter.(string))
+	baseURL, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/serviceAttachments")
+	if err != nil {
+		return err
 	}
 
 	serviceAttachments := make([]map[string]interface{}, 0)
+	pageToken := ""
 
 	for {
-		list, err := call.Do()
+		params := map[string]string{}
+		if filter, ok := d.GetOk("filter"); ok {
+			params["filter"] = filter.(string)
+		}
+		if pageToken != "" {
+			params["pageToken"] = pageToken
+		}
+
+		url, err := transport_tpg.AddQueryParams(baseURL, params)
+		if err != nil {
+			return err
+		}
+
+		resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   billingProject,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
 		if err != nil {
 			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Service Attachments Not Found in project %s, region %s", project, region))
 		}
 
-		for _, sa := range list.Items {
-			consumerAcceptLists := make([]map[string]interface{}, 0, len(sa.ConsumerAcceptLists))
-			for _, cal := range sa.ConsumerAcceptLists {
-				consumerAcceptLists = append(consumerAcceptLists, map[string]interface{}{
-					"project_id_or_num": cal.ProjectIdOrNum,
-					"connection_limit":  cal.ConnectionLimit,
-					"network_url":       cal.NetworkUrl,
-				})
-			}
-
-			connectedEndpoints := make([]map[string]interface{}, 0, len(sa.ConnectedEndpoints))
-			for _, ce := range sa.ConnectedEndpoints {
-				connectedEndpoints = append(connectedEndpoints, map[string]interface{}{
-					"endpoint":          ce.Endpoint,
-					"status":            ce.Status,
-					"psc_connection_id": ce.PscConnectionId,
-					"consumer_network":  ce.ConsumerNetwork,
-				})
-			}
-
-			var pscId []map[string]interface{}
-			if sa.PscServiceAttachmentId != nil {
-				pscId = []map[string]interface{}{
-					{
-						"high": fmt.Sprintf("%d", sa.PscServiceAttachmentId.High),
-						"low":  fmt.Sprintf("%d", sa.PscServiceAttachmentId.Low),
-					},
+		if items, ok := resp["items"].([]interface{}); ok {
+			for _, raw := range items {
+				sa, ok := raw.(map[string]interface{})
+				if !ok {
+					continue
 				}
-			}
 
-			mapped := map[string]interface{}{
-				"name":                        sa.Name,
-				"description":                 sa.Description,
-				"self_link":                   sa.SelfLink,
-				"target_service":              sa.TargetService,
-				"connection_preference":       sa.ConnectionPreference,
-				"nat_subnets":                 sa.NatSubnets,
-				"enable_proxy_protocol":       sa.EnableProxyProtocol,
-				"domain_names":                sa.DomainNames,
-				"fingerprint":                 sa.Fingerprint,
-				"region":                      sa.Region,
-				"reconcile_connections":       sa.ReconcileConnections,
-				"propagated_connection_limit": sa.PropagatedConnectionLimit,
-				"consumer_reject_lists":       sa.ConsumerRejectLists,
-				"consumer_accept_lists":       consumerAcceptLists,
-				"connected_endpoints":         connectedEndpoints,
-				"psc_service_attachment_id":   pscId,
+				consumerAcceptLists := flattenServiceAttachmentConsumerAcceptLists(sa["consumerAcceptLists"])
+				connectedEndpoints := flattenServiceAttachmentConnectedEndpoints(sa["connectedEndpoints"])
+				pscId := flattenServiceAttachmentPscServiceAttachmentId(sa["pscServiceAttachmentId"])
+
+				mapped := map[string]interface{}{
+					"name":                        sa["name"],
+					"description":                 sa["description"],
+					"self_link":                   sa["selfLink"],
+					"target_service":              sa["targetService"],
+					"connection_preference":       sa["connectionPreference"],
+					"nat_subnets":                 sa["natSubnets"],
+					"enable_proxy_protocol":       sa["enableProxyProtocol"],
+					"domain_names":                sa["domainNames"],
+					"fingerprint":                 sa["fingerprint"],
+					"region":                      sa["region"],
+					"reconcile_connections":       sa["reconcileConnections"],
+					"propagated_connection_limit": flattenInt64FromFloat(sa["propagatedConnectionLimit"]),
+					"consumer_reject_lists":       sa["consumerRejectLists"],
+					"consumer_accept_lists":       consumerAcceptLists,
+					"connected_endpoints":         connectedEndpoints,
+					"psc_service_attachment_id":   pscId,
+				}
+				serviceAttachments = append(serviceAttachments, mapped)
 			}
-			serviceAttachments = append(serviceAttachments, mapped)
 		}
 
-		if list.NextPageToken == "" {
+		pageToken, _ = resp["nextPageToken"].(string)
+		if pageToken == "" {
 			break
 		}
-		call = call.PageToken(list.NextPageToken)
 	}
 
 	if err := d.Set("service_attachments", serviceAttachments); err != nil {
@@ -140,6 +147,79 @@ func datasourceGoogleComputeServiceAttachmentsRead(d *schema.ResourceData, meta 
 	}
 
 	return nil
+}
+
+func flattenServiceAttachmentConsumerAcceptLists(v interface{}) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	items, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, raw := range items {
+		cal, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		result = append(result, map[string]interface{}{
+			"project_id_or_num": cal["projectIdOrNum"],
+			"connection_limit":  flattenInt64FromFloat(cal["connectionLimit"]),
+			"network_url":       cal["networkUrl"],
+		})
+	}
+	return result
+}
+
+func flattenServiceAttachmentConnectedEndpoints(v interface{}) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	items, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, raw := range items {
+		ce, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		result = append(result, map[string]interface{}{
+			"endpoint":          ce["endpoint"],
+			"status":            ce["status"],
+			"psc_connection_id": ce["pscConnectionId"],
+			"consumer_network":  ce["consumerNetwork"],
+		})
+	}
+	return result
+}
+
+func flattenServiceAttachmentPscServiceAttachmentId(v interface{}) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	psc, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"high": psc["high"],
+			"low":  psc["low"],
+		},
+	}
+}
+
+func flattenInt64FromFloat(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+	if f, ok := v.(float64); ok {
+		return int(f)
+	}
+	return v
 }
 
 func init() {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments.go
@@ -94,8 +94,8 @@ func datasourceGoogleComputeServiceAttachmentsRead(d *schema.ResourceData, meta 
 			if sa.PscServiceAttachmentId != nil {
 				pscId = []map[string]interface{}{
 					{
-						"high": sa.PscServiceAttachmentId.High,
-						"low":  sa.PscServiceAttachmentId.Low,
+						"high": fmt.Sprintf("%d", sa.PscServiceAttachmentId.High),
+						"low":  fmt.Sprintf("%d", sa.PscServiceAttachmentId.Low),
 					},
 				}
 			}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -29,50 +30,7 @@ func DataSourceGoogleComputeServiceAttachments() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"description": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"self_link": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"target_service": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"connection_preference": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"nat_subnets": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"enable_proxy_protocol": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
-						"domain_names": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"fingerprint": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"region": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
+					Schema: tpgresource.DatasourceSchemaFromResourceSchema(ResourceComputeServiceAttachment().Schema),
 				},
 			},
 		},
@@ -96,94 +54,92 @@ func datasourceGoogleComputeServiceAttachmentsRead(d *schema.ResourceData, meta 
 		return err
 	}
 
-	params := make(map[string]string)
+	id := fmt.Sprintf("projects/%s/regions/%s/serviceAttachments", project, region)
+	d.SetId(id)
+
+	call := NewClient(config, userAgent).ServiceAttachments.List(project, region)
 	if filter, ok := d.GetOk("filter"); ok {
-		params["filter"] = filter.(string)
+		call = call.Filter(filter.(string))
 	}
 
 	serviceAttachments := make([]map[string]interface{}, 0)
 
 	for {
-		url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/serviceAttachments")
+		list, err := call.Do()
 		if err != nil {
-			return err
+			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Service Attachments Not Found in project %s, region %s", project, region))
 		}
 
-		url, err = transport_tpg.AddQueryParams(url, params)
-		if err != nil {
-			return err
+		for _, sa := range list.Items {
+			consumerAcceptLists := make([]map[string]interface{}, 0, len(sa.ConsumerAcceptLists))
+			for _, cal := range sa.ConsumerAcceptLists {
+				consumerAcceptLists = append(consumerAcceptLists, map[string]interface{}{
+					"project_id_or_num": cal.ProjectIdOrNum,
+					"connection_limit":  cal.ConnectionLimit,
+					"network_url":       cal.NetworkUrl,
+				})
+			}
+
+			connectedEndpoints := make([]map[string]interface{}, 0, len(sa.ConnectedEndpoints))
+			for _, ce := range sa.ConnectedEndpoints {
+				connectedEndpoints = append(connectedEndpoints, map[string]interface{}{
+					"endpoint":          ce.Endpoint,
+					"status":            ce.Status,
+					"psc_connection_id": ce.PscConnectionId,
+					"consumer_network":  ce.ConsumerNetwork,
+				})
+			}
+
+			var pscId []map[string]interface{}
+			if sa.PscServiceAttachmentId != nil {
+				pscId = []map[string]interface{}{
+					{
+						"high": sa.PscServiceAttachmentId.High,
+						"low":  sa.PscServiceAttachmentId.Low,
+					},
+				}
+			}
+
+			mapped := map[string]interface{}{
+				"name":                        sa.Name,
+				"description":                 sa.Description,
+				"self_link":                   sa.SelfLink,
+				"target_service":              sa.TargetService,
+				"connection_preference":       sa.ConnectionPreference,
+				"nat_subnets":                 sa.NatSubnets,
+				"enable_proxy_protocol":       sa.EnableProxyProtocol,
+				"domain_names":                sa.DomainNames,
+				"fingerprint":                 sa.Fingerprint,
+				"region":                      sa.Region,
+				"reconcile_connections":       sa.ReconcileConnections,
+				"propagated_connection_limit": sa.PropagatedConnectionLimit,
+				"consumer_reject_lists":       sa.ConsumerRejectLists,
+				"consumer_accept_lists":       consumerAcceptLists,
+				"connected_endpoints":         connectedEndpoints,
+				"psc_service_attachment_id":   pscId,
+			}
+			serviceAttachments = append(serviceAttachments, mapped)
 		}
 
-		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-			Config:    config,
-			Method:    "GET",
-			RawURL:    url,
-			UserAgent: userAgent,
-		})
-		if err != nil {
-			return fmt.Errorf("error retrieving service attachments: %s", err)
-		}
-
-		pageItems := flattenDatasourceGoogleComputeServiceAttachmentsList(res["items"])
-		serviceAttachments = append(serviceAttachments, pageItems...)
-
-		pToken, ok := res["nextPageToken"]
-		if ok && pToken != nil && pToken.(string) != "" {
-			params["pageToken"] = pToken.(string)
-		} else {
+		if list.NextPageToken == "" {
 			break
 		}
+		call = call.PageToken(list.NextPageToken)
 	}
 
 	if err := d.Set("service_attachments", serviceAttachments); err != nil {
 		return fmt.Errorf("error setting service_attachments: %s", err)
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/regions/%s/serviceAttachments", project, region))
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("error setting project: %s", err)
+	}
+
+	if err := d.Set("region", region); err != nil {
+		return fmt.Errorf("error setting region: %s", err)
+	}
 
 	return nil
-}
-
-func flattenDatasourceGoogleComputeServiceAttachmentsList(v interface{}) []map[string]interface{} {
-	if v == nil {
-		return make([]map[string]interface{}, 0)
-	}
-
-	ls := v.([]interface{})
-	serviceAttachments := make([]map[string]interface{}, 0, len(ls))
-	for _, raw := range ls {
-		p := raw.(map[string]interface{})
-
-		var natSubnets []interface{}
-		if ns, ok := p["natSubnets"]; ok && ns != nil {
-			natSubnets = ns.([]interface{})
-		}
-
-		var domainNames []interface{}
-		if dn, ok := p["domainNames"]; ok && dn != nil {
-			domainNames = dn.([]interface{})
-		}
-
-		var enableProxyProtocol bool
-		if epp, ok := p["enableProxyProtocol"]; ok && epp != nil {
-			enableProxyProtocol = epp.(bool)
-		}
-
-		serviceAttachments = append(serviceAttachments, map[string]interface{}{
-			"name":                  p["name"],
-			"description":           p["description"],
-			"self_link":             p["selfLink"],
-			"target_service":        p["targetService"],
-			"connection_preference": p["connectionPreference"],
-			"nat_subnets":           natSubnets,
-			"enable_proxy_protocol": enableProxyProtocol,
-			"domain_names":          domainNames,
-			"fingerprint":           p["fingerprint"],
-			"region":                p["region"],
-		})
-	}
-
-	return serviceAttachments
 }
 
 func init() {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments.go
@@ -118,7 +118,7 @@ func datasourceGoogleComputeServiceAttachmentsRead(d *schema.ResourceData, meta 
 					"fingerprint":                 sa["fingerprint"],
 					"region":                      sa["region"],
 					"reconcile_connections":       sa["reconcileConnections"],
-					"propagated_connection_limit": flattenInt64FromFloat(sa["propagatedConnectionLimit"]),
+					"propagated_connection_limit": flattenInt64(sa["propagatedConnectionLimit"]),
 					"consumer_reject_lists":       sa["consumerRejectLists"],
 					"consumer_accept_lists":       consumerAcceptLists,
 					"connected_endpoints":         connectedEndpoints,
@@ -165,7 +165,7 @@ func flattenServiceAttachmentConsumerAcceptLists(v interface{}) []map[string]int
 		}
 		result = append(result, map[string]interface{}{
 			"project_id_or_num": cal["projectIdOrNum"],
-			"connection_limit":  flattenInt64FromFloat(cal["connectionLimit"]),
+			"connection_limit":  flattenInt64(cal["connectionLimit"]),
 			"network_url":       cal["networkUrl"],
 		})
 	}
@@ -212,14 +212,20 @@ func flattenServiceAttachmentPscServiceAttachmentId(v interface{}) []map[string]
 	}
 }
 
-func flattenInt64FromFloat(v interface{}) interface{} {
-	if v == nil {
-		return nil
+func flattenInt64(v interface{}) interface{} {
+	// Handles the string fixed64 format.
+	if strVal, ok := v.(string); ok {
+		if intVal, err := tpgresource.StringToFixed64(strVal); err == nil {
+			return intVal
+		}
 	}
-	if f, ok := v.(float64); ok {
-		return int(f)
+
+	// Number values are represented as float64.
+	if floatVal, ok := v.(float64); ok {
+		return int(floatVal)
 	}
-	return v
+
+	return v // let Terraform Core handle it otherwise
 }
 
 func init() {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachments_test.go
@@ -1,0 +1,100 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccDataSourceGoogleComputeServiceAttachments_basic(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	region := envvar.GetTestRegionFromEnv()
+	randomSuffix := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleComputeServiceAttachments_basic(project, region, randomSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_compute_service_attachments.all", "service_attachments.#"),
+					resource.TestCheckResourceAttr("data.google_compute_service_attachments.all", "service_attachments.0.name", fmt.Sprintf("tf-test-sa-%s", randomSuffix)),
+					resource.TestCheckResourceAttrSet("data.google_compute_service_attachments.all", "service_attachments.0.self_link"),
+					resource.TestCheckResourceAttrSet("data.google_compute_service_attachments.all", "service_attachments.0.connection_preference"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleComputeServiceAttachments_basic(project, region, randomSuffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "sa_network" {
+  name                    = "tf-test-sa-net-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "sa_subnetwork" {
+  name          = "tf-test-sa-subnet-%s"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "%s"
+  network       = google_compute_network.sa_network.id
+}
+
+resource "google_compute_subnetwork" "psc_subnetwork" {
+  name          = "tf-test-psc-subnet-%s"
+  ip_cidr_range = "10.1.0.0/16"
+  region        = "%s"
+  network       = google_compute_network.sa_network.id
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+}
+
+resource "google_compute_health_check" "sa_health_check" {
+  name = "tf-test-sa-hc-%s"
+
+  tcp_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_backend_service" "sa_backend" {
+  name          = "tf-test-sa-backend-%s"
+  region        = "%s"
+  health_checks = [google_compute_health_check.sa_health_check.id]
+}
+
+resource "google_compute_forwarding_rule" "sa_forwarding_rule" {
+  name                  = "tf-test-sa-fr-%s"
+  region                = "%s"
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.sa_backend.id
+  all_ports             = true
+  network               = google_compute_network.sa_network.id
+  subnetwork            = google_compute_subnetwork.sa_subnetwork.id
+}
+
+resource "google_compute_service_attachment" "sa" {
+  name                  = "tf-test-sa-%s"
+  region                = "%s"
+  description           = "A service attachment for testing"
+  enable_proxy_protocol = false
+  connection_preference = "ACCEPT_AUTOMATIC"
+  nat_subnets           = [google_compute_subnetwork.psc_subnetwork.id]
+  target_service        = google_compute_forwarding_rule.sa_forwarding_rule.id
+}
+
+data "google_compute_service_attachments" "all" {
+  project = "%s"
+  region  = "%s"
+  filter  = "name = tf-test-sa-%s"
+
+  depends_on = [google_compute_service_attachment.sa]
+}
+`, randomSuffix, randomSuffix, region, randomSuffix, region, randomSuffix, randomSuffix, region, randomSuffix, region, randomSuffix, region, project, region, randomSuffix)
+}

--- a/mmv1/third_party/terraform/website/docs/d/compute_service_attachments.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_service_attachments.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "Compute Engine"
+description: |-
+  List all service attachments in a given project and region.
+---
+
+# google_compute_service_attachments
+
+List all service attachments in a given project and region. For more information see
+[the official documentation](https://cloud.google.com/vpc/docs/about-service-attachments)
+and
+[API reference](https://cloud.google.com/compute/docs/reference/rest/v1/serviceAttachments/list).
+
+## Example Usage
+
+```hcl
+data "google_compute_service_attachments" "all" {
+  project = "my-project"
+  region  = "us-central1"
+}
+```
+
+### With Filter
+
+```hcl
+data "google_compute_service_attachments" "filtered" {
+  project = "my-project"
+  region  = "us-central1"
+  filter  = "name = my-service-attachment"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Optional) The project in which the resource belongs.
+  If it is not provided, the provider project is used.
+
+* `region` - (Optional) The region in which the resource belongs.
+  If it is not provided, the provider region is used.
+
+* `filter` - (Optional) A filter expression that filters service attachments listed in the
+  response. See the
+  [API `filter` parameter documentation](https://cloud.google.com/compute/docs/reference/rest/v1/serviceAttachments/list#query-parameters)
+  for details.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `service_attachments` - A list of service attachments matching the provided filter. Each
+  element contains:
+
+  * `name` - The name of the service attachment.
+
+  * `description` - An optional description of the service attachment.
+
+  * `self_link` - The URI of the service attachment.
+
+  * `target_service` - The URL of the forwarding rule that represents the service identified
+    by this service attachment.
+
+  * `connection_preference` - The connection preference of the service attachment.
+    Possible values are `ACCEPT_AUTOMATIC` and `ACCEPT_MANUAL`.
+
+  * `nat_subnets` - A list of URLs of subnetworks used for NAT in this service attachment.
+
+  * `enable_proxy_protocol` - Whether the proxy protocol is enabled on the service attachment.
+
+  * `domain_names` - A list of domain names for the service attachment.
+
+  * `fingerprint` - The fingerprint of the service attachment.
+
+  * `region` - The region of the service attachment.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/23397

Adds a new plural data source `google_compute_service_attachments` that lists all service attachments in a given project and region, enabling discovery without hardcoding names or self_links.

### Details

* Calls the `serviceAttachments.list` compute API with pagination support
* Accepts optional `project`, `region`, and `filter` arguments
* Returns a `service_attachments` list with key attributes: `name`, `self_link`, `target_service`, `connection_preference`, `nat_subnets`, `enable_proxy_protocol`, `domain_names`, `fingerprint`, `region`
* Adds acceptance test `TestAccDataSourceGoogleComputeServiceAttachments_basic`
* Adds documentation

### Tests

TestAccDataSourceGoogleComputeServiceAttachments_basic

### Release Note Template for Downstream PRs (will be copied)

```release-note:new-datasource
`google_compute_service_attachments`
```