### PR TITLE
Add data_governance_tags_info to google_bigquery_table schema

### DIFF
--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -277,6 +277,19 @@ properties:
                 Definition of the foreign data type.
                 Only valid for top-level schema fields (not nested fields).
                 If the type is FOREIGN, this field is required.
+            - name: 'dataGovernanceTagsInfo'
+              type: NestedObject
+              description: |
+                Specifies the data governance tags on this field.
+              properties:
+                - name: 'dataGovernanceTags'
+                  type: KeyValuePairs
+                  description: |
+                    The tags attached to this field. Tag keys are globally unique.
+                    Tag key is expected to be in the namespaced format, for example
+                    "123456789012/environment" where 123456789012 is the ID of the
+                    parent organization or project resource for this tag key.
+                    Tag value is expected to be the short name, for example "Production".
   - name: 'schemaForeignTypeInfo'
     type: NestedObject
     description: |

--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -287,9 +287,9 @@ properties:
                   description: |
                     The tags attached to this field. Tag keys are globally unique.
                     Tag key is expected to be in the namespaced format, for example
-                    "123456789012/environment" where 123456789012 is the ID of the
-                    parent organization or project resource for this tag key.
-                    Tag value is expected to be the short name, for example "Production".
+                    "parent-id/pii" where "parent-id" is the ID of the parent
+                    organization or project resource for this tag key.
+                    Tag value is expected to be the short name, for example "sensitive"..
   - name: 'schemaForeignTypeInfo'
     type: NestedObject
     description: |

--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -289,7 +289,7 @@ properties:
                     Tag key is expected to be in the namespaced format, for example
                     "parent-id/pii" where "parent-id" is the ID of the parent
                     organization or project resource for this tag key.
-                    Tag value is expected to be the short name, for example "sensitive"..
+                    Tag value is expected to be the short name, for example "sensitive".
   - name: 'schemaForeignTypeInfo'
     type: NestedObject
     description: |

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -288,6 +288,9 @@ func bigQueryTableMapKeyOverride(key string, objectA, objectB map[string]interfa
 	case "policyTags":
 		eq := bigQueryTableNormalizePolicyTags(valA) == nil && bigQueryTableNormalizePolicyTags(valB) == nil
 		return eq
+	case "dataGovernanceTagsInfo":
+		eq := bigQueryTableNormalizeDataGovernanceTagsInfo(valA) == nil && bigQueryTableNormalizeDataGovernanceTagsInfo(valB) == nil
+		return eq
 	case "dataPolicies":
 		if d == nil {
 			return false
@@ -412,6 +415,23 @@ func bigQueryTableNormalizePolicyTags(val interface{}) interface{} {
 		}
 		// policyTags = {names = []} is same as nil.
 		if names, ok := policyTags["names"].([]interface{}); ok && len(names) == 0 {
+			return nil
+		}
+	}
+	return val
+}
+
+func bigQueryTableNormalizeDataGovernanceTagsInfo(val interface{}) interface{} {
+	if val == nil {
+		return nil
+	}
+	if dgTagsInfo, ok := val.(map[string]interface{}); ok {
+		// dgTagsInfo = {} is same as nil.
+		if len(dgTagsInfo) == 0 {
+			return nil
+		}
+		// dgTagsInfo = {dataGovernanceTags = {}} is same as nil.
+		if dgTags, ok := dgTagsInfo["dataGovernanceTags"].(map[string]interface{}); ok && len(dgTags) == 0 {
 			return nil
 		}
 	}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_internal_test.go.tmpl
@@ -369,6 +369,111 @@ func TestBigQueryTableSchemaDiffSuppress(t *testing.T) {
 			]`,
 			ExpectDiffSuppress: true,
 		},
+		"dataGovernanceTagsInfo: nil vs empty map": {
+			Old: `[
+				{
+					"name": "col",
+					"type": "STRING"
+				}
+			]`,
+			New: `[
+				{
+					"name": "col",
+					"type": "STRING",
+					"dataGovernanceTagsInfo": {}
+				}
+			]`,
+			ExpectDiffSuppress: true,
+		},
+		"dataGovernanceTagsInfo: nil vs empty tags": {
+			Old: `[
+				{
+					"name": "col",
+					"type": "STRING"
+				}
+			]`,
+			New: `[
+				{
+					"name": "col",
+					"type": "STRING",
+					"dataGovernanceTagsInfo": {
+						"dataGovernanceTags": {}
+					}
+				}
+			]`,
+			ExpectDiffSuppress: true,
+		},
+		"dataGovernanceTagsInfo: same tags": {
+			Old: `[
+				{
+					"name": "col",
+					"type": "STRING",
+					"dataGovernanceTagsInfo": {
+						"dataGovernanceTags": {
+							"projects/my-project/locations/us/taxonomies/123/policyTags/456": "sensitive"
+						}
+					}
+				}
+			]`,
+			New: `[
+				{
+					"name": "col",
+					"type": "STRING",
+					"dataGovernanceTagsInfo": {
+						"dataGovernanceTags": {
+							"projects/my-project/locations/us/taxonomies/123/policyTags/456": "sensitive"
+						}
+					}
+				}
+			]`,
+			ExpectDiffSuppress: true,
+		},
+		"dataGovernanceTagsInfo: different tag value": {
+			Old: `[
+				{
+					"name": "col",
+					"type": "STRING",
+					"dataGovernanceTagsInfo": {
+						"dataGovernanceTags": {
+							"projects/my-project/locations/us/taxonomies/123/policyTags/456": "sensitive"
+						}
+					}
+				}
+			]`,
+			New: `[
+				{
+					"name": "col",
+					"type": "STRING",
+					"dataGovernanceTagsInfo": {
+						"dataGovernanceTags": {
+							"projects/my-project/locations/us/taxonomies/123/policyTags/456": "public"
+						}
+					}
+				}
+			]`,
+			ExpectDiffSuppress: false,
+		},
+		"dataGovernanceTagsInfo: tags removed": {
+			Old: `[
+				{
+					"name": "col",
+					"type": "STRING",
+					"dataGovernanceTagsInfo": {
+						"dataGovernanceTags": {
+							"projects/my-project/locations/us/taxonomies/123/policyTags/456": "sensitive"
+						}
+					}
+				}
+			]`,
+			New: `[
+				{
+					"name": "col",
+					"type": "STRING",
+					"dataGovernanceTagsInfo": {}
+				}
+			]`,
+			ExpectDiffSuppress: false,
+		},
 		{{- if ne $.TargetVersionName "ga" }}
 		"foreignTypeDefinition from generated schema -> original schema": {
 			Old:                "[{\"name\": \"someValue\", \"type\": \"RECORD\", \"foreignTypeDefinition\" : \"STRUCT<id:STRING, name:STRING>\", \"fields\": [{\"name\": \"id\", \"type\": \"STRING\"}, {\"name\": \"name\", \"type\": \"STRING\"}]}]",
@@ -675,6 +780,24 @@ var testUnitBigQueryDataTableIsChangeableTestCases = []testUnitBigQueryDataTable
 		jsonNew:             "[{\"name\": \"col1\", \"type\" : \"STRING\"}]",
 		ignoreSchemaChanges: []interface{}{"dataPolicies"},
 		changeable:          true, // Should not trigger ForceNew
+	},
+	{
+		name:       "dataGovernanceTagsInfoAdded",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\"}]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"dataGovernanceTagsInfo\": {\"dataGovernanceTags\": {\"123/env\": \"prod\"}}}]",
+		changeable: true,
+	},
+	{
+		name:       "dataGovernanceTagsInfoChanged",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"dataGovernanceTagsInfo\": {\"dataGovernanceTags\": {\"123/env\": \"prod\"}}}]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"dataGovernanceTagsInfo\": {\"dataGovernanceTags\": {\"123/env\": \"dev\"}}}]",
+		changeable: true,
+	},
+	{
+		name:       "dataGovernanceTagsInfoCleared",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"dataGovernanceTagsInfo\": {\"dataGovernanceTags\": {\"123/env\": \"prod\"}}}]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"dataGovernanceTagsInfo\": {}}]",
+		changeable: true,
 	},
 	{{- if ne $.TargetVersionName "ga" }}
 	{

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -5930,6 +5930,123 @@ resource "google_bigquery_table" "test" {
 `, datasetID, bucketName, tableID)
 }
 
+func TestAccBigQueryTable_DataGovernanceTags(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	tagKeyShortName := fmt.Sprintf("tag_key_%s", acctest.RandString(t, 5))
+	tagValueShortName := fmt.Sprintf("tag_val_%s", acctest.RandString(t, 5))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTable_dataGovernanceTags(project, tagKeyShortName, tagValueShortName, datasetID, tableID),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccBigQueryTable_dataGovernanceTagsClear(project, tagKeyShortName, tagValueShortName, datasetID, tableID),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccBigQueryTable_dataGovernanceTags(project, tagKeyShortName, tagValueShortName, datasetID, tableID string) string {
+	return fmt.Sprintf(`
+resource "google_tags_tag_key" "key" {
+  parent     = "projects/%s"
+  short_name = "%s"
+  purpose    = "DATA_GOVERNANCE"
+}
+
+resource "google_tags_tag_value" "value" {
+  parent     = "tagKeys/${google_tags_tag_key.key.name}"
+  short_name = "%s"
+}
+
+resource "google_bigquery_dataset" "test" {
+  dataset_id                  = "%s"
+  location                    = "US"
+}
+
+resource "google_bigquery_table" "test" {
+  dataset_id = google_bigquery_dataset.test.dataset_id
+  table_id   = "%s"
+
+  schema = <<EOF
+[
+  {
+    "name": "state",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "dataGovernanceTagsInfo": {
+      "dataGovernanceTags": {
+        "${google_tags_tag_key.key.namespaced_name}": "${google_tags_tag_value.value.short_name}"
+      }
+    }
+  }
+]
+EOF
+
+  deletion_protection = false
+}
+`, project, tagKeyShortName, tagValueShortName, datasetID, tableID)
+}
+
+func testAccBigQueryTable_dataGovernanceTagsClear(project, tagKeyShortName, tagValueShortName, datasetID, tableID string) string {
+	return fmt.Sprintf(`
+resource "google_tags_tag_key" "key" {
+  parent     = "projects/%s"
+  short_name = "%s"
+  purpose    = "DATA_GOVERNANCE"
+}
+
+resource "google_tags_tag_value" "value" {
+  parent     = "tagKeys/${google_tags_tag_key.key.name}"
+  short_name = "%s"
+}
+
+resource "google_bigquery_dataset" "test" {
+  dataset_id                  = "%s"
+  location                    = "US"
+}
+
+resource "google_bigquery_table" "test" {
+  dataset_id = google_bigquery_dataset.test.dataset_id
+  table_id   = "%s"
+
+  schema = <<EOF
+[
+  {
+    "name": "state",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "dataGovernanceTagsInfo": {}
+  }
+]
+EOF
+
+  deletion_protection = false
+}
+`, project, tagKeyShortName, tagValueShortName, datasetID, tableID)
+}
+
+
 var TEST_CSV = `lifelock,LifeLock,,web,Tempe,AZ,1-May-07,6850000,USD,b
 lifelock,LifeLock,,web,Tempe,AZ,1-Oct-06,6000000,USD,a
 lifelock,LifeLock,,web,Tempe,AZ,1-Jan-08,25000000,USD,c

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -5951,7 +5951,7 @@ func TestAccBigQueryTable_DataGovernanceTags(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_auto_generated_schema", "generated_schema_columns"},
 			},
 			{
 				Config: testAccBigQueryTable_dataGovernanceTagsClear(project, tagKeyShortName, tagValueShortName, datasetID, tableID),
@@ -5960,7 +5960,7 @@ func TestAccBigQueryTable_DataGovernanceTags(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_auto_generated_schema", "generated_schema_columns"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -6046,7 +6046,6 @@ EOF
 `, project, tagKeyShortName, tagValueShortName, datasetID, tableID)
 }
 
-
 var TEST_CSV = `lifelock,LifeLock,,web,Tempe,AZ,1-May-07,6850000,USD,b
 lifelock,LifeLock,,web,Tempe,AZ,1-Oct-06,6000000,USD,a
 lifelock,LifeLock,,web,Tempe,AZ,1-Jan-08,25000000,USD,c


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement 
bigquery: added `data_governance_tags_info` field to `google_bigquery_table` resource
```
