### PR TITLE
secretmanager: fixed secret_data/secret_data_wo constraint allowing neither to be set

### DIFF
--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -202,8 +202,9 @@ properties:
         type: String
         description: The secret data. Must be no larger than 64KiB.
         api_name: data
-        conflicts:
-          - 'secretDataWo'
+        exactly_one_of:
+          - 'payload.0.secretData'
+          - 'payload.0.secretDataWo'
         immutable: true
         sensitive: true
         is_missing_in_cai: true
@@ -213,8 +214,9 @@ properties:
         api_name: data
         required_with:
           - 'SecretDataWoVersion'
-        conflicts:
+        exactly_one_of:
           - 'payload.0.secretData'
+          - 'payload.0.secretDataWo'
         write_only_legacy: true
       - name: 'SecretDataWoVersion'
         type: Integer

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -212,8 +212,6 @@ properties:
         type: String
         description: The secret data. Must be no larger than 64KiB. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)
         api_name: data
-        required_with:
-          - 'SecretDataWoVersion'
         exactly_one_of:
           - 'payload.0.secretData'
           - 'payload.0.secretDataWo'

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_version_test.go
@@ -80,6 +80,7 @@ func TestAccSecretManagerSecretVersion_byName(t *testing.T) {
 }
 
 func TestAccSecretManagerSecretVersion_neitherSecretDataSet(t *testing.T) {
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_version_test.go
@@ -1,6 +1,7 @@
 package secretmanager_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -76,6 +77,42 @@ func TestAccSecretManagerSecretVersion_byName(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccSecretManagerSecretVersion_neitherSecretDataSet(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSecretManagerSecretVersion_noSecretData(context),
+				ExpectError: regexp.MustCompile(`Invalid combination of arguments`),
+			},
+		},
+	})
+}
+
+func testAccSecretManagerSecretVersion_noSecretData(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-version-%{random_suffix}"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_secret.secret-basic.name
+  secret_data_wo_version = 3
+}
+`, context)
 }
 
 func testAccSecretManagerSecretVersion_basic(context map[string]interface{}) string {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

`google_secret_manager_secret_version` accepted a config with neither `secret_data` nor `secret_data_wo` set. terraform planned it  successfully, created the parent secret , then failed at apply with an API error naming a field that doesn't exist in the provider:
`Error: Error creating SecretVersion: googleapi: Error 400: Field [payload] is required.`

Fixes https://github.com/hashicorp/terraform-provider-google/issues/24269
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
secretmanager: fixed an issue where `google_secret_manager_secret_version` would fail at apply time with `Field [payload]` is required if neither `secret_data` or `secret_data_wo` was set. The provider  now returns a validation error at plan time.
```
