### PR TITLE
Add static_ip_scan field to google_security_scanner_scan_config

### DIFF
--- a/mmv1/products/securityscanner/ScanConfig.yaml
+++ b/mmv1/products/securityscanner/ScanConfig.yaml
@@ -49,6 +49,15 @@ samples:
         resource_id_vars:
           address_name: scan-ignore-http-ip
           scan_config_name: terraform-scan-config
+  - name: scan_config_static_ip
+    primary_resource_id: scan-config
+    min_version: beta
+    steps:
+      - name: scan_config_static_ip
+        min_version: beta
+        resource_id_vars:
+          address_name: scan-static-ip
+          scan_config_name: terraform-scan-config
 properties:
   - name: name
     type: String
@@ -205,3 +214,9 @@ properties:
   - name: ignoreHttpStatusErrors
     type: Boolean
     description: Whether to keep scanning even if most requests return HTTP error codes.
+  - name: staticIpScan
+    type: Boolean
+    description: |
+      Whether the scan configuration has enabled static IP address scan feature.
+      If enabled, the scanner will access applications from static IP addresses.
+    min_version: beta

--- a/mmv1/templates/terraform/samples/services/securityscanner/scan_config_static_ip.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/securityscanner/scan_config_static_ip.tf.tmpl
@@ -1,0 +1,12 @@
+resource "google_compute_address" "scanner_static_ip" {
+  provider = google-beta
+  name     = "{{index $.ResourceIdVars "address_name"}}"
+}
+
+resource "google_security_scanner_scan_config" "{{$.PrimaryResourceId}}" {
+  provider         = google-beta
+  display_name     = "{{index $.ResourceIdVars "scan_config_name"}}"
+  starting_urls    = ["http://${google_compute_address.scanner_static_ip.address}"]
+  target_platforms = ["COMPUTE"]
+  static_ip_scan   = true
+}


### PR DESCRIPTION
Adds the beta-only `staticIpScan` boolean field to the ScanConfig resource so scans can run from static source IP addresses (exposes the Web Security Scanner v1beta `staticIpScan` API field). 
Included a dedicated `scan_config_static_ip` example as well.

Fixes hashicorp/terraform-provider-google#6461

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
securityscanner: added `static_ip_scan` field to `google_security_scanner_scan_config`
```
