### PR TITLE
networkservices: added allow_global_access to google_network_services_gateway

### DIFF
--- a/mmv1/products/networkservices/Gateway.yaml
+++ b/mmv1/products/networkservices/Gateway.yaml
@@ -253,3 +253,11 @@ properties:
     enum_values:
       - NEXT_HOP_ROUTING_MODE
       - EXPLICIT_ROUTING_MODE
+  - name: allowGlobalAccess
+    type: Boolean
+    description: |
+      Optional. If true, the gateway will allow traffic from clients outside
+      of the region where the gateway is located.
+      This field is configurable only for gateways of type SECURE_WEB_GATEWAY.
+    send_empty_value: true
+    immutable: true

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_gateway_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_gateway_test.go
@@ -2112,3 +2112,162 @@ resource "google_network_connectivity_policy_based_route" "default" {
 }
 `, context)
 }
+
+func TestAccNetworkServicesGateway_swpAllowGlobalAccess(t *testing.T) {
+	netName := fmt.Sprintf("tf-test-gateway-swp-net-%s", acctest.RandString(t, 10))
+	subnetName := fmt.Sprintf("tf-test-gateway-swp-subnet-%s", acctest.RandString(t, 10))
+	pSubnetName := fmt.Sprintf("tf-test-gateway-swp-proxyonly-%s", acctest.RandString(t, 10))
+	policyName := fmt.Sprintf("tf-test-gateway-swp-policy-%s", acctest.RandString(t, 10))
+	ruleName := fmt.Sprintf("tf-test-gateway-swp-rule-%s", acctest.RandString(t, 10))
+	gatewayName := fmt.Sprintf("tf-test-gateway-swp-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetworkServicesGatewayDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkServicesGateway_swpAllowGlobalAccessEnabled(netName, subnetName, pSubnetName, policyName, ruleName, gatewayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_network_services_gateway.foobar", "allow_global_access", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_network_services_gateway.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "delete_swg_autogen_router_on_destroy"},
+			},
+			{
+				Config: testAccNetworkServicesGateway_swpAllowGlobalAccessDisabled(netName, subnetName, pSubnetName, policyName, ruleName, gatewayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_network_services_gateway.foobar", "allow_global_access", "false"),
+				),
+			},
+			{
+				ResourceName:            "google_network_services_gateway.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "delete_swg_autogen_router_on_destroy"},
+			},
+		},
+	})
+}
+
+func testAccNetworkServicesGateway_swpAllowGlobalAccessEnabled(netName, subnetName, pSubnetName, policyName, ruleName, gatewayName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "default" {
+  name                    = "%s"
+  routing_mode            = "REGIONAL"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "proxyonlysubnet" {
+  name          = "%s"
+  purpose       = "REGIONAL_MANAGED_PROXY"
+  ip_cidr_range = "192.168.0.0/23"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+  role          = "ACTIVE"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "%s"
+  purpose       = "PRIVATE"
+  ip_cidr_range = "10.128.0.0/20"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+  role          = "ACTIVE"
+}
+
+resource "google_network_security_gateway_security_policy" "default" {
+  name     = "%s"
+  location = "us-central1"
+}
+
+resource "google_network_security_gateway_security_policy_rule" "default" {
+  name                    = "%s"
+  location                = "us-central1"
+  gateway_security_policy = google_network_security_gateway_security_policy.default.name
+  enabled                 = true
+  priority                = 1
+  session_matcher         = "host() == 'example.com'"
+  basic_profile           = "ALLOW"
+}
+
+resource "google_network_services_gateway" "foobar" {
+  name                                 = "%s"
+  location                             = "us-central1"
+  addresses                            = ["10.128.0.99"]
+  type                                 = "SECURE_WEB_GATEWAY"
+  routing_mode                         = "EXPLICIT_ROUTING_MODE"
+  ports                                = [443]
+  description                          = "my description"
+  gateway_security_policy              = google_network_security_gateway_security_policy.default.id
+  network                              = google_compute_network.default.id
+  subnetwork                           = google_compute_subnetwork.default.id
+  delete_swg_autogen_router_on_destroy = true
+  allow_global_access                  = true
+  depends_on                           = [google_compute_subnetwork.proxyonlysubnet]
+}
+`, netName, subnetName, pSubnetName, policyName, ruleName, gatewayName)
+}
+
+func testAccNetworkServicesGateway_swpAllowGlobalAccessDisabled(netName, subnetName, pSubnetName, policyName, ruleName, gatewayName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "default" {
+  name                    = "%s"
+  routing_mode            = "REGIONAL"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "proxyonlysubnet" {
+  name          = "%s"
+  purpose       = "REGIONAL_MANAGED_PROXY"
+  ip_cidr_range = "192.168.0.0/23"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+  role          = "ACTIVE"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "%s"
+  purpose       = "PRIVATE"
+  ip_cidr_range = "10.128.0.0/20"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+  role          = "ACTIVE"
+}
+
+resource "google_network_security_gateway_security_policy" "default" {
+  name     = "%s"
+  location = "us-central1"
+}
+
+resource "google_network_security_gateway_security_policy_rule" "default" {
+  name                    = "%s"
+  location                = "us-central1"
+  gateway_security_policy = google_network_security_gateway_security_policy.default.name
+  enabled                 = true
+  priority                = 1
+  session_matcher         = "host() == 'example.com'"
+  basic_profile           = "ALLOW"
+}
+
+resource "google_network_services_gateway" "foobar" {
+  name                                 = "%s"
+  location                             = "us-central1"
+  addresses                            = ["10.128.0.99"]
+  type                                 = "SECURE_WEB_GATEWAY"
+  routing_mode                         = "EXPLICIT_ROUTING_MODE"
+  ports                                = [443]
+  description                          = "my description"
+  gateway_security_policy              = google_network_security_gateway_security_policy.default.id
+  network                              = google_compute_network.default.id
+  subnetwork                           = google_compute_subnetwork.default.id
+  delete_swg_autogen_router_on_destroy = true
+  allow_global_access                  = false
+  depends_on                           = [google_compute_subnetwork.proxyonlysubnet]
+}
+`, netName, subnetName, pSubnetName, policyName, ruleName, gatewayName)
+}


### PR DESCRIPTION
Adds the `allow_global_access` field to the `google_network_services_gateway` resource.
As noted in GCP Console and observed via testing, this field cannot be updated in-place on the `SECURE_WEB_GATEWAY` proxy after creation. Thus, it is marked as immutable so Terraform can correctly handle updates by recreating the resource.

```release-note:enhancement
networkservices: added `allow_global_access` field to `google_network_services_gateway`
```
