### PR TITLE
Adding TelemetryPolicy

### DIFF
--- a/mmv1/products/networkservices/TelemetryPolicy.yaml
+++ b/mmv1/products/networkservices/TelemetryPolicy.yaml
@@ -1,0 +1,164 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'TelemetryPolicy'
+min_version: nightly
+description: |
+  Provides a configuration for telemetry.
+references:
+  guides:
+  api: https://cloud.google.com/traffic-director/docs/reference/network-services/rest/v1beta1/projects.locations.telemetryPolicies
+docs:
+base_url: 'projects/{{project}}/locations/{{location}}/telemetryPolicies'
+self_link: 'projects/{{project}}/locations/{{location}}/telemetryPolicies/{{name}}'
+create_url: 'projects/{{project}}/locations/{{location}}/telemetryPolicies?telemetryPolicyId={{name}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - projects/{{project}}/locations/{{location}}/telemetryPolicies/{{name}}
+timeouts:
+  insert_minutes: 30
+  update_minutes: 30
+  delete_minutes: 30
+async:
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 30
+      update_minutes: 30
+      delete_minutes: 30
+    base_url: '{{op_id}}'
+  actions: [create, delete, update]
+  result:
+    resource_inside_response: false
+autogen_async: true
+custom_code:
+parameters:
+  - name: name
+    type: String
+    description: |
+      Short name of the TelemetryPolicy resource to be created.
+    required: true
+    immutable: true
+    url_param_only: true
+  - name: location
+    type: String
+    default_value: 'global'
+    description: |
+      Location (region) of the TelemetryPolicy resource to be created.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: selfLink
+    type: String
+    description: |
+      Server-defined URL of this resource.
+    output: true
+  - name: createTime
+    type: Time
+    description: |
+      Time the TelemetryPolicy was created in UTC.
+    output: true
+  - name: updateTime
+    type: Time
+    description: |
+      Time the TelemetryPolicy was updated in UTC.
+    output: true
+  - name: uid
+    type: String
+    description: |
+      Specifies the server-assigned unique identifier for the policy.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: |
+      Set of label tags associated with the TelemetryPolicy resource.
+  - name: displayName
+    type: String
+    description: |
+      Provides a human-readable name for the policy.
+  - name: telemetryTarget
+    type: NestedObject
+    required: true
+    description: |
+      Specifies the set of targets to which this telemetry policy applies.
+    properties:
+      - name: resources
+        type: Array
+        required: true
+        description: |
+          Lists references to the resources that are targeted by the policy.
+        item_type:
+          type: String
+  - name: tracingConfiguration
+    type: NestedObject
+    description: |
+      Specifies the top-level configuration block within the telemetry policy that contains all the settings for how tracing will be applied to the target resources.
+    properties:
+      - name: samplingRate
+        type: Double
+        description: |
+          Specifies the tracing sampling rate.
+      - name: customSpanAttributes
+        type: Array
+        description: |
+          Provides key-value pairs for adding context to spans.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: attributeName
+              type: String
+              required: true
+              description: |
+                Defines the key for a custom attribute.
+            - name: literalValue
+              type: String
+              description: |
+                Assigns a static, constant value to the custom trace span attribute.
+              exactly_one_of:
+                - literalValue
+                - fromHeaderValue
+            - name: fromHeaderValue
+              type: String
+              description: |
+                Specifies an incoming request header name from which the value for the custom span attribute should be dynamically extracted.
+              exactly_one_of:
+                - literalValue
+                - fromHeaderValue
+      - name: parentBasedSampling
+        type: NestedObject
+        description: |
+          Configures honoring a sampled bit in downstream traceparentID headers.
+        properties:
+          - name: enabled
+            type: Boolean
+            description: |
+              Provides a master switch to respect a sampled bit in incoming traceparentID headers.
+          - name: samplingRate
+            type: Double
+            description: |
+              Specifies the sampling rate to use when the sampled bit is set in the incoming traceparentID header.
+  - name: metricsConfiguration
+    type: NestedObject
+    description: |
+      Specifies the top-level configuration block within the telemetry policy that contains all the settings for how metrics will be applied to the target resources.
+    properties:
+      - name: enabled
+        type: Boolean
+        description: |
+          Indicates whether metrics are enabled or disabled.
+      - name: metadata
+        type: KeyValuePairs
+        description: |
+          Can be used by an internal caller to propagate metadata.

--- a/mmv1/products/networkservices/product.yaml
+++ b/mmv1/products/networkservices/product.yaml
@@ -21,3 +21,7 @@ versions:
     base_url: https://networkservices.googleapis.com/v1/
   - name: ga
     base_url: https://networkservices.googleapis.com/v1/
+  - name: nightly
+    base_url: https://networkservices.googleapis.com/v1alpha1/
+  - name: private
+    base_url: https://networkservices.googleapis.com/v1alpha1/

--- a/tools/issue-labeler/labeler/enrolled_teams.yml
+++ b/tools/issue-labeler/labeler/enrolled_teams.yml
@@ -658,6 +658,7 @@ service/networkservices-traffic-director:
   - google_network_services_service_binding
   - google_network_services_tcp_route
   - google_network_services_tls_route
+  - google_network_services_telemetry_policy
 service/notebooks:
   resources:
   - google_notebooks_.*


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds early support for TelemetryPolicy resources to NetworkServices API in google-nightly. 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_network_services_telemetry_policy`
```







Test added in https://github.com/GoogleCloudPlatform/magic-modules/compare/main...pawelJas:magic-modules:network_services_telemetry_policy_no_tests?expand=1
<img width="1564" height="524" alt="image" src="https://github.com/user-attachments/assets/b8c9f09d-d61a-4ea4-98dc-7f60b786bf24" />
