### PR TITLE
vertexai: fixed TestAccVertexAIReasoningEngine_apiParity ga failures

### DIFF
--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go
@@ -723,7 +723,7 @@ func TestAccVertexAIReasoningEngine_apiParity(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckVertexAIEndpointDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -735,9 +735,23 @@ func TestAccVertexAIReasoningEngine_apiParity(t *testing.T) {
 
 func testAccVertexAIReasoningEngine_apiParity(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_project" "project" {}
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_cloudbuild_worker_pool" "pool" {
+  provider = google-beta
+  name     = "pool-%{random_suffix}"
+  location = "us-central1"
+  worker_config {
+    disk_size_gb   = 100
+    machine_type   = "e2-standard-4"
+    no_external_ip = false
+  }
+}
 
 resource "google_vertex_ai_reasoning_engine" "primary" {
+  provider     = google-beta
   display_name = "tf-test-reasoning-engine-%{random_suffix}"
   description  = "Reasoning engine testing API parity fields"
   region       = "us-central1"
@@ -754,6 +768,9 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
       name        = "test-agent"
       description = "a test agent card"
     })
+    build_spec {
+      worker_pool = google_cloudbuild_worker_pool.pool.id
+    }
     deployment_spec {
       agent_server_mode                  = "EXPERIMENTAL"
       dedicated_ingress_endpoint_enabled = false
@@ -779,7 +796,7 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 }
 
 func TestAccVertexAIReasoningEngine_apiParityExternal(t *testing.T) {
-	t.Skip("Skipping worker_pool, agent_gateway and runtime_revision_name due to external infrastructure dependencies")
+	t.Skip("Skipping agent_gateway and runtime_revision_name due to external infrastructure dependencies")
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -802,16 +819,6 @@ func testAccVertexAIReasoningEngine_apiParityExternal(context map[string]interfa
 	return acctest.Nprintf(`
 data "google_project" "project" {}
 
-resource "google_cloudbuild_worker_pool" "pool" {
-  name     = "pool-%{random_suffix}"
-  location = "us-central1"
-  worker_config {
-    disk_size_gb   = 100
-    machine_type   = "e2-standard-4"
-    no_external_ip = false
-  }
-}
-
 resource "google_vertex_ai_reasoning_engine" "primary" {
   display_name = "tf-test-reasoning-engine-%{random_suffix}"
   description  = "Reasoning engine testing external API parity fields"
@@ -819,9 +826,6 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 
   spec {
     identity_type = "AGENT_IDENTITY"
-    build_spec {
-      worker_pool = google_cloudbuild_worker_pool.pool.id
-    }
     deployment_spec {
       agent_gateway_config {
         agent_to_anywhere_config {

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go
@@ -737,16 +737,6 @@ func testAccVertexAIReasoningEngine_apiParity(context map[string]interface{}) st
 	return acctest.Nprintf(`
 data "google_project" "project" {}
 
-resource "google_cloudbuild_worker_pool" "pool" {
-  name     = "pool-%{random_suffix}"
-  location = "us-central1"
-  worker_config {
-    disk_size_gb   = 100
-    machine_type   = "e2-standard-4"
-    no_external_ip = false
-  }
-}
-
 resource "google_vertex_ai_reasoning_engine" "primary" {
   display_name = "tf-test-reasoning-engine-%{random_suffix}"
   description  = "Reasoning engine testing API parity fields"
@@ -764,9 +754,6 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
       name        = "test-agent"
       description = "a test agent card"
     })
-    build_spec {
-      worker_pool = google_cloudbuild_worker_pool.pool.id
-    }
     deployment_spec {
       agent_server_mode                  = "EXPERIMENTAL"
       dedicated_ingress_endpoint_enabled = false
@@ -792,7 +779,7 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 }
 
 func TestAccVertexAIReasoningEngine_apiParityExternal(t *testing.T) {
-	t.Skip("Skipping agent_gateway and runtime_revision_name due to external infrastructure dependencies")
+	t.Skip("Skipping worker_pool, agent_gateway and runtime_revision_name due to external infrastructure dependencies")
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -815,6 +802,16 @@ func testAccVertexAIReasoningEngine_apiParityExternal(context map[string]interfa
 	return acctest.Nprintf(`
 data "google_project" "project" {}
 
+resource "google_cloudbuild_worker_pool" "pool" {
+  name     = "pool-%{random_suffix}"
+  location = "us-central1"
+  worker_config {
+    disk_size_gb   = 100
+    machine_type   = "e2-standard-4"
+    no_external_ip = false
+  }
+}
+
 resource "google_vertex_ai_reasoning_engine" "primary" {
   display_name = "tf-test-reasoning-engine-%{random_suffix}"
   description  = "Reasoning engine testing external API parity fields"
@@ -822,6 +819,9 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 
   spec {
     identity_type = "AGENT_IDENTITY"
+    build_spec {
+      worker_pool = google_cloudbuild_worker_pool.pool.id
+    }
     deployment_spec {
       agent_gateway_config {
         agent_to_anywhere_config {

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -714,6 +714,7 @@ resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
 `, context)
 }
 
+{{- if ne $.TargetVersionName "ga" }}
 func TestAccVertexAIReasoningEngine_apiParity(t *testing.T) {
 	t.Parallel()
 
@@ -794,6 +795,7 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 }
 `, context)
 }
+{{- end }}
 
 func TestAccVertexAIReasoningEngine_apiParityExternal(t *testing.T) {
 	t.Skip("Skipping agent_gateway and runtime_revision_name due to external infrastructure dependencies")


### PR DESCRIPTION
Made TestAccVertexAIReasoningEngine_apiParity beta-only because it tests beta fields.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28373

```release-note:none
```