### PR TITLE
compute: add update support to externalIpv6Prefix in Subnetwork

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -558,6 +558,12 @@ properties:
     type: String
     description: |
       The range of external IPv6 addresses that are owned by this subnetwork.
+    update_verb: PATCH
+    update_url: projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
+    fingerprint_name: fingerprint
+    diff_suppress_func: IpDiffSuppress
+    validation:
+      function: verify.ValidateIpCidrRange
     default_from_api: true
   - name: ipCollection
     type: String

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
@@ -3,6 +3,7 @@ package compute_test
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -773,6 +774,74 @@ func TestAccComputeSubnetwork_ipv6UpdateWithPdp(t *testing.T) {
 					resource.TestCheckResourceAttr(subnetResName, "stack_type", "IPV4_IPV6"),
 					resource.TestCheckResourceAttr(subnetResName, "ipv6_access_type", "INTERNAL"),
 					testAccCheckSubnetIpCollectionMatchesPdp(t, subnetResName, subPdpResName),
+				),
+			},
+			// Import Check
+			{
+				ResourceName:      subnetResName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeSubnetwork_ipv6UpdateWithExternalPdpAndVm(t *testing.T) {
+	t.Parallel()
+
+	randSuffix := acctest.RandString(t, 10)
+	networkName := fmt.Sprintf("tf-test-net-%s", randSuffix)
+	subnetName := fmt.Sprintf("tf-test-sub-%s", randSuffix)
+	vm1Name := fmt.Sprintf("tf-test-vm1-%s", randSuffix)
+	vm2Name := fmt.Sprintf("tf-test-vm2-%s", randSuffix)
+
+	subnetResName := "google_compute_subnetwork.test_subnet"
+	vm1ResName := "google_compute_instance.vm1"
+	vm2ResName := "google_compute_instance.vm2"
+
+	subPdpId := "projects/tf-static-byoip/regions/us-east1/publicDelegatedPrefixes/terraform-acceptance-test-sub-pdp"
+	pdpRange := fmt.Sprintf("2600:1901:4464:%x::/64", acctest.RandIntRange(t, 0, 255))
+
+	context := map[string]interface{}{
+		"network_name":         networkName,
+		"subnet_name":          subnetName,
+		"sub_pdp_id":           subPdpId,
+		"external_ipv6_prefix": pdpRange,
+		"vm1_name":             vm1Name,
+		"vm2_name":             vm2Name,
+		"region":               "us-east1",
+		"zone":                 "us-east1-b",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckComputeSubnetworkDestroyProducer(t),
+			testAccCheckComputeInstanceDestroyProducer(t),
+		),
+		Steps: []resource.TestStep{
+			// Step 1: Create IPv4 Network, Subnetwork and VM1
+			{
+				Config: testAccComputeSubnetwork_ipv6ExternalPdpSetup(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, subnetResName, new(map[string]interface{})),
+					resource.TestCheckResourceAttr(subnetResName, "name", subnetName),
+					resource.TestCheckResourceAttr(subnetResName, "stack_type", "IPV4_ONLY"),
+					testAccCheckComputeInstanceExists(t, vm1ResName, new(map[string]interface{})),
+				),
+			},
+			// Step 2: Update Subnetwork to Dual Stack with IP Collection and Add VM2 (dual-stack)
+			{
+				Config: testAccComputeSubnetwork_ipv6ExternalPdpUpdate(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, subnetResName, new(map[string]interface{})),
+					resource.TestCheckResourceAttr(subnetResName, "stack_type", "IPV4_IPV6"),
+					resource.TestCheckResourceAttr(subnetResName, "ipv6_access_type", "EXTERNAL"),
+					testAccCheckSubnetIpCollectionMatchesName(subnetResName, "terraform-acceptance-test-sub-pdp"),
+					testAccCheckSubnetExternalIpv6PrefixMatches(subnetResName, pdpRange),
+					testAccCheckComputeInstanceExists(t, vm1ResName, new(map[string]interface{})),
+					testAccCheckComputeInstanceExists(t, vm2ResName, new(map[string]interface{})),
 				),
 			},
 			// Import Check
@@ -1587,6 +1656,59 @@ func testAccCheckSubnetIpCollectionMatchesPdp(t *testing.T, subnetResourceName, 
 	}
 }
 
+func testAccCheckSubnetIpCollectionMatchesName(subnetResourceName, expectedPdpName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		subnetRes, ok := s.RootModule().Resources[subnetResourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", subnetResourceName)
+		}
+
+		ipCollection := subnetRes.Primary.Attributes["ip_collection"]
+		if ipCollection == "" {
+			return fmt.Errorf("ip_collection is empty, expected it to be set on %s", subnetResourceName)
+		}
+
+		normalizedIpCollection := tpgresource.GetResourceNameFromSelfLink(ipCollection)
+		if normalizedIpCollection != expectedPdpName {
+			return fmt.Errorf("mismatch: ip_collection (%s) normalized to (%s) does not match expected PDP name (%s)",
+				ipCollection, normalizedIpCollection, expectedPdpName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckSubnetExternalIpv6PrefixMatches(subnetResourceName, expectedPrefix string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		subnetRes, ok := s.RootModule().Resources[subnetResourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", subnetResourceName)
+		}
+
+		prefixAttr := subnetRes.Primary.Attributes["external_ipv6_prefix"]
+		if prefixAttr == "" {
+			return fmt.Errorf("external_ipv6_prefix is empty, expected it to be set on %s", subnetResourceName)
+		}
+
+		_, expectedNet, err := net.ParseCIDR(expectedPrefix)
+		if err != nil {
+			return fmt.Errorf("failed to parse expected prefix %q: %v", expectedPrefix, err)
+		}
+
+		_, gotNet, err := net.ParseCIDR(prefixAttr)
+		if err != nil {
+			return fmt.Errorf("failed to parse actual prefix %q from state: %v", prefixAttr, err)
+		}
+
+		if expectedNet.String() != gotNet.String() {
+			return fmt.Errorf("mismatch: external_ipv6_prefix expected %q, got %q (normalized: expected %s, got %s)",
+				expectedPrefix, prefixAttr, expectedNet, gotNet)
+		}
+
+		return nil
+	}
+}
+
 func testAccComputeSubnetwork_ipv6PdpSetup(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "test_network" {
@@ -1783,6 +1905,97 @@ resource "google_compute_subnetwork" "test_subnet" {
   stack_type       = "IPV4_IPV6"
   ipv6_access_type = "INTERNAL"
   ip_collection    = google_compute_public_delegated_prefix.test_sub_pdp.id
+}
+`, context)
+}
+
+func testAccComputeSubnetwork_ipv6ExternalPdpSetup(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "custom_test" {
+  name                    = "%{network_name}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test_subnet" {
+  name                     = "%{subnet_name}"
+  ip_cidr_range            = "10.5.4.0/24"
+  region                   = "%{region}"
+  network                  = google_compute_network.custom_test.id
+  private_ip_google_access = true
+  stack_type               = "IPV4_ONLY"
+}
+
+resource "google_compute_instance" "vm1" {
+  name         = "%{vm1_name}"
+  machine_type = "e2-medium"
+  zone         = "%{zone}"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.test_subnet.id
+  }
+}
+`, context)
+}
+
+func testAccComputeSubnetwork_ipv6ExternalPdpUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "custom_test" {
+  name                    = "%{network_name}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test_subnet" {
+  name                     = "%{subnet_name}"
+  ip_cidr_range            = "10.5.4.0/24"
+  region                   = "%{region}"
+  network                  = google_compute_network.custom_test.id
+  private_ip_google_access = true
+  stack_type               = "IPV4_IPV6"
+  ipv6_access_type         = "EXTERNAL"
+  ip_collection            = "%{sub_pdp_id}"
+  external_ipv6_prefix     = "%{external_ipv6_prefix}"
+}
+
+resource "google_compute_instance" "vm1" {
+  name         = "%{vm1_name}"
+  machine_type = "e2-medium"
+  zone         = "%{zone}"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.test_subnet.id
+  }
+}
+
+resource "google_compute_instance" "vm2" {
+  name         = "%{vm2_name}"
+  machine_type = "e2-medium"
+  zone         = "%{zone}"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.test_subnet.id
+    stack_type = "IPV4_IPV6"
+    ipv6_access_config {
+      network_tier = "PREMIUM"
+    }
+  }
 }
 `, context)
 }


### PR DESCRIPTION
This PR enables in-place updates for the `external_ipv6_prefix` field on `google_compute_subnetwork`. 
  
Previously, changing this field would have triggered resource recreation or was not supported via `PATCH`. This change adds the necessary `update_verb` configuration and `IpDiffSuppress` to handle logical IP equality correctly, ensuring standard formatting differences do not cause perpetual diffs. With this we ensure that the Terraform aligns with the in-place update of the external ipv6 prefix just like the current gcloud command allows us to.

An acceptance test `TestAccComputeSubnetwork_ipv6UpdateWithExternalPdpAndVm` has been added to verify that:
1. The subnetwork can be upgraded to dual-stack with an external IPv6 prefix in-place while virtual machines are attached.
2. The VM attachments remain uninterrupted.
  
Fixes b/528263965

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: `google_compute_subnetwork` now supports in-place updates for `external_ipv6_prefix`
```
