### PR TITLE
Fix hash function for security policy

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -1,11 +1,12 @@
 package compute
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -755,19 +756,79 @@ func resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams
 	}
 }
 
-// resourceComputeSecurityPolicyRuleHash hashes security policy rules by priority and action.
-// Using only priority causes hash collisions when two rules share the same priority (which
-// the API rejects, but which users may write transiently), causing schema.Set to silently
-// drop one rule and bypass the duplicate-priority validation in rulesCustomizeDiff.
-// Including action ensures distinct rules always produce distinct hashes while still
-// excluding volatile optional fields (description, preview, match sub-fields) that the
-// API may return as empty strings instead of nil, preventing unnecessary rule recreation.
+// resourceComputeSecurityPolicyRuleHash computes a deterministic hash of all configured rule attributes.
+// It normalizes empty/default values and sorts string collections to prevent permadiffs and unnecessary
+// rule recreation from API return defaults while ensuring any configuration change produces a distinct hash.
 func resourceComputeSecurityPolicyRuleHash(v interface{}) int {
-	raw := v.(map[string]interface{})
-	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("%d-", raw["priority"].(int)))
-	buf.WriteString(fmt.Sprintf("%s-", raw["action"].(string)))
-	return tpgresource.Hashcode(buf.String())
+	norm := normalizeRuleForHash(v)
+	b, err := json.Marshal(norm)
+	if err != nil {
+		return 0
+	}
+	return tpgresource.Hashcode(string(b))
+}
+
+func normalizeRuleForHash(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case *schema.Set:
+		return normalizeRuleForHash(val.List())
+	case []interface{}:
+		var list []interface{}
+		for _, item := range val {
+			norm := normalizeRuleForHash(item)
+			if norm != nil {
+				list = append(list, norm)
+			}
+		}
+		if len(list) == 0 {
+			return nil
+		}
+		if isStringSlice(list) {
+			strs := make([]string, len(list))
+			for i, s := range list {
+				strs[i] = s.(string)
+			}
+			sort.Strings(strs)
+			return strs
+		}
+		return list
+	case map[string]interface{}:
+		m := make(map[string]interface{})
+		for k, item := range val {
+			norm := normalizeRuleForHash(item)
+			if norm != nil {
+				m[k] = norm
+			}
+		}
+		if len(m) == 0 {
+			return nil
+		}
+		return m
+	case string:
+		if val == "" {
+			return nil
+		}
+		return val
+	case bool:
+		if !val {
+			return nil
+		}
+		return val
+	default:
+		return val
+	}
+}
+
+func isStringSlice(list []interface{}) bool {
+	for _, item := range list {
+		if _, ok := item.(string); !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func rulesCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -2470,9 +2470,10 @@ func TestAccComputeSecurityPolicy_inlineRuleUpdate(t *testing.T) {
 				Config: testAccComputeSecurityPolicy_inlineRuleUpdate_step1(spName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckTypeSetElemNestedAttrs("google_compute_security_policy.policy", "rule.*", map[string]string{
-						"priority":    "1000",
-						"action":      "allow",
-						"description": "initial description",
+						"priority":                 "1000",
+						"action":                   "allow",
+						"description":              "initial description",
+						"match.0.config.0.src_ip_ranges.#": "1",
 					}),
 				),
 			},
@@ -2490,9 +2491,10 @@ func TestAccComputeSecurityPolicy_inlineRuleUpdate(t *testing.T) {
 				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckTypeSetElemNestedAttrs("google_compute_security_policy.policy", "rule.*", map[string]string{
-						"priority":    "1000",
-						"action":      "allow",
-						"description": "updated description",
+						"priority":                 "1000",
+						"action":                   "allow",
+						"description":              "updated description",
+						"match.0.config.0.src_ip_ranges.#": "2",
 					}),
 				),
 			},
@@ -2558,7 +2560,7 @@ resource "google_compute_security_policy" "policy" {
     match {
       versioned_expr = "SRC_IPS_V1"
       config {
-        src_ip_ranges = ["9.9.9.0/24"]
+        src_ip_ranges = ["9.9.9.0/24", "10.0.0.0/8"]
       }
     }
   }
@@ -2570,21 +2572,165 @@ func TestComputeSecurityPolicyRuleHash_inlineRuleModification(t *testing.T) {
 	ruleSchema := tpgcompute.ResourceComputeSecurityPolicy().Schema["rule"]
 	ruleSetFunc := ruleSchema.Set
 
-	rule1 := map[string]interface{}{
+	baseRule := map[string]interface{}{
 		"priority":    1000,
 		"action":      "allow",
 		"description": "initial description",
+		"preview":     false,
+		"match": []interface{}{
+			map[string]interface{}{
+				"versioned_expr": "SRC_IPS_V1",
+				"config": []interface{}{
+					map[string]interface{}{
+						"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+					},
+				},
+			},
+		},
 	}
-	rule2 := map[string]interface{}{
-		"priority":    1000,
-		"action":      "allow",
-		"description": "updated description",
+	baseHash := ruleSetFunc(baseRule)
+
+	testCases := map[string]struct {
+		modifiedRule map[string]interface{}
+		expectEqual  bool
+	}{
+		"description modification": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "updated description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"preview boolean toggle": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     true,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"number of src_ip_ranges increased": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24", "10.0.0.0/8"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"src_ip_range value changed": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"192.168.1.0/24"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"src_ip_ranges order difference should produce identical hash": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: true,
+		},
 	}
 
-	hash1 := ruleSetFunc(rule1)
-	hash2 := ruleSetFunc(rule2)
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			modHash := ruleSetFunc(tc.modifiedRule)
+			if tc.expectEqual && modHash != baseHash {
+				t.Fatalf("expected equal hash %d, got %d for case %q", baseHash, modHash, name)
+			}
+			if !tc.expectEqual && modHash == baseHash {
+				t.Fatalf("expected different hashes when %s, but both produced %d", name, baseHash)
+			}
+		})
+	}
 
-	if hash1 == hash2 {
-		t.Fatalf("expected different set hashes when modifying rule description, but both produced hash %d (reproduces hashicorp/terraform-provider-google#28390)", hash1)
+	// Specifically test that order of elements in a multi-element src_ip_ranges does not change hash
+	multiRange1 := map[string]interface{}{
+		"priority": 1000,
+		"action":   "allow",
+		"match": []interface{}{
+			map[string]interface{}{
+				"config": []interface{}{
+					map[string]interface{}{
+						"src_ip_ranges": []interface{}{"9.9.9.0/24", "10.0.0.0/8"},
+					},
+				},
+			},
+		},
+	}
+	multiRange2 := map[string]interface{}{
+		"priority": 1000,
+		"action":   "allow",
+		"match": []interface{}{
+			map[string]interface{}{
+				"config": []interface{}{
+					map[string]interface{}{
+						"src_ip_ranges": []interface{}{"10.0.0.0/8", "9.9.9.0/24"},
+					},
+				},
+			},
+		},
+	}
+	if h1, h2 := ruleSetFunc(multiRange1), ruleSetFunc(multiRange2); h1 != h2 {
+		t.Fatalf("expected identical hash for reordered IP ranges, got %d and %d", h1, h2)
 	}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -2507,6 +2507,18 @@ resource "google_compute_security_policy" "policy" {
   description = "test policy"
 
   rule {
+    action   = "allow"
+    priority = "2147483647"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "default rule"
+  }
+
+  rule {
     action      = "allow"
     priority    = "1000"
     description = "initial description"
@@ -2526,6 +2538,18 @@ func testAccComputeSecurityPolicy_inlineRuleUpdate_step2(spName string) string {
 resource "google_compute_security_policy" "policy" {
   name        = "%s"
   description = "test policy"
+
+  rule {
+    action   = "allow"
+    priority = "2147483647"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "default rule"
+  }
 
   rule {
     action      = "allow"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -2973,25 +2973,6 @@ func TestComputeSecurityPolicyRuleHash_inlineRuleModification(t *testing.T) {
 			},
 			expectEqual: false,
 		},
-		"src_ip_ranges order difference should produce identical hash": {
-			modifiedRule: map[string]interface{}{
-				"priority":    1000,
-				"action":      "allow",
-				"description": "initial description",
-				"preview":     false,
-				"match": []interface{}{
-					map[string]interface{}{
-						"versioned_expr": "SRC_IPS_V1",
-						"config": []interface{}{
-							map[string]interface{}{
-								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
-							},
-						},
-					},
-				},
-			},
-			expectEqual: true,
-		},
 		"src_ip_ranges with empty string filtered out should produce identical hash": {
 			modifiedRule: map[string]interface{}{
 				"priority":    1000,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -9,9 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/compute"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/recaptchaenterprise"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/recaptchaenterprise"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -189,7 +189,7 @@ func TestAccComputeSecurityPolicy_update(t *testing.T) {
 			},
 
 			{
-				Config: testAccComputeSecurityPolicy_updateSamePriority(spName),
+				Config:      testAccComputeSecurityPolicy_updateSamePriority(spName),
 				ExpectError: regexp.MustCompile("Two rules have the same priority, please update one of the priorities to be different."),
 			},
 
@@ -315,7 +315,6 @@ func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-
 		},
 	})
 }
@@ -441,6 +440,7 @@ func TestAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig(t *test
 		},
 	})
 }
+
 {{- end }}
 
 func TestAccComputeSecurityPolicy_withRateLimitOptions(t *testing.T) {
@@ -546,7 +546,6 @@ func TestAccComputeSecurityPolicy_withRateLimitOption_withMultipleEnforceOnKeyCo
 		},
 	})
 }
-
 
 func TestAccComputeSecurityPolicy_EnforceOnKeyUpdates(t *testing.T) {
 	t.Parallel()
@@ -687,7 +686,6 @@ func TestAccComputeSecurityPolicy_ruleActionUpdate(t *testing.T) {
 	})
 }
 
-
 func TestAccComputeSecurityPolicy_withHeadAction(t *testing.T) {
 	t.Parallel()
 
@@ -771,7 +769,7 @@ func TestAccComputeSecurityPolicy_withExprOptions(t *testing.T) {
 func TestAccComputeSecurityPolicy_modifyExprOptions(t *testing.T) {
 	t.Parallel()
 
-  spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1780,6 +1778,7 @@ resource "google_compute_security_policy" "policy" {
 }
 `, spName)
 }
+
 {{- end }}
 
 func testAccComputeSecurityPolicy_withRateLimitOptions(spName string) string {
@@ -2455,4 +2454,113 @@ resource "google_compute_security_policy" "policy" {
   }
 }
 `, spName)
+}
+
+func TestAccComputeSecurityPolicy_inlineRuleUpdate(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicy_inlineRuleUpdate_step1(spName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs("google_compute_security_policy.policy", "rule.*", map[string]string{
+						"priority":    "1000",
+						"action":      "allow",
+						"description": "initial description",
+					}),
+				),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicy_inlineRuleUpdate_step2(spName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_security_policy.policy", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs("google_compute_security_policy.policy", "rule.*", map[string]string{
+						"priority":    "1000",
+						"action":      "allow",
+						"description": "updated description",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccComputeSecurityPolicy_inlineRuleUpdate_step1(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "test policy"
+
+  rule {
+    action      = "allow"
+    priority    = "1000"
+    description = "initial description"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["9.9.9.0/24"]
+      }
+    }
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_inlineRuleUpdate_step2(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "test policy"
+
+  rule {
+    action      = "allow"
+    priority    = "1000"
+    description = "updated description"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["9.9.9.0/24"]
+      }
+    }
+  }
+}
+`, spName)
+}
+
+func TestComputeSecurityPolicyRuleHash_inlineRuleModification(t *testing.T) {
+	ruleSchema := tpgcompute.ResourceComputeSecurityPolicy().Schema["rule"]
+	ruleSetFunc := ruleSchema.Set
+
+	rule1 := map[string]interface{}{
+		"priority":    1000,
+		"action":      "allow",
+		"description": "initial description",
+	}
+	rule2 := map[string]interface{}{
+		"priority":    1000,
+		"action":      "allow",
+		"description": "updated description",
+	}
+
+	hash1 := ruleSetFunc(rule1)
+	hash2 := ruleSetFunc(rule2)
+
+	if hash1 == hash2 {
+		t.Fatalf("expected different set hashes when modifying rule description, but both produced hash %d (reproduces hashicorp/terraform-provider-google#28390)", hash1)
+	}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -2568,6 +2569,101 @@ resource "google_compute_security_policy" "policy" {
 `, spName)
 }
 
+func TestComputeSecurityPolicyRuleHash_nilAndEmptyCases(t *testing.T) {
+	ruleSchema := tpgcompute.ResourceComputeSecurityPolicy().Schema["rule"]
+	ruleSetFunc := ruleSchema.Set
+
+	nilHash := ruleSetFunc(nil)
+
+	emptyCases := map[string]interface{}{
+		"nil":                                 nil,
+		"typed nil map":                       (map[string]interface{})(nil),
+		"empty map":                           map[string]interface{}{},
+		"map with nil values":                 map[string]interface{}{"description": nil, "priority": nil, "match": nil},
+		"map with empty strings":              map[string]interface{}{"description": "", "action": ""},
+		"map with false bools":                map[string]interface{}{"preview": false},
+		"map with empty slice":                map[string]interface{}{"match": []interface{}{}},
+		"map with nested empty map in slice":  map[string]interface{}{"match": []interface{}{map[string]interface{}{}}},
+		"map with nested empty match configs": map[string]interface{}{"match": []interface{}{map[string]interface{}{"versioned_expr": "", "config": []interface{}{map[string]interface{}{"src_ip_ranges": []interface{}{}}}}}},
+		"map with empty string slice element": map[string]interface{}{"match": []interface{}{map[string]interface{}{"config": []interface{}{map[string]interface{}{"src_ip_ranges": []interface{}{""}}}}}},
+		"empty schema.Set":                    schema.NewSet(schema.HashResource(ruleSchema.Elem.(*schema.Resource)), []interface{}{}),
+		"schema.Set containing empty map":     schema.NewSet(schema.HashResource(ruleSchema.Elem.(*schema.Resource)), []interface{}{map[string]interface{}{}}),
+	}
+
+	for name, input := range emptyCases {
+		t.Run(name, func(t *testing.T) {
+			h := ruleSetFunc(input)
+			if h != nilHash {
+				t.Fatalf("expected hash for %s to equal nilHash %d, got %d", name, nilHash, h)
+			}
+		})
+	}
+}
+
+func TestComputeSecurityPolicyRuleHash_defaultAndZeroValueEquivalence(t *testing.T) {
+	ruleSchema := tpgcompute.ResourceComputeSecurityPolicy().Schema["rule"]
+	ruleSetFunc := ruleSchema.Set
+
+	baseRule := map[string]interface{}{
+		"priority": 1000,
+		"action":   "allow",
+	}
+	baseHash := ruleSetFunc(baseRule)
+
+	equivalentCases := map[string]map[string]interface{}{
+		"explicit empty description": {
+			"priority":    1000,
+			"action":      "allow",
+			"description": "",
+		},
+		"nil description": {
+			"priority":    1000,
+			"action":      "allow",
+			"description": nil,
+		},
+		"explicit preview false": {
+			"priority": 1000,
+			"action":   "allow",
+			"preview":  false,
+		},
+		"explicit empty match list": {
+			"priority": 1000,
+			"action":   "allow",
+			"match":    []interface{}{},
+		},
+		"nested empty match config": {
+			"priority": 1000,
+			"action":   "allow",
+			"match": []interface{}{
+				map[string]interface{}{
+					"versioned_expr": "",
+					"config":         []interface{}{},
+				},
+			},
+		},
+		"all zero/empty fields simultaneously present": {
+			"priority":                 1000,
+			"action":                   "allow",
+			"description":              "",
+			"preview":                  false,
+			"match":                    []interface{}{},
+			"rate_limit_options":       []interface{}{},
+			"redirect_options":         []interface{}{},
+			"header_action":            []interface{}{},
+			"preconfigured_waf_config": []interface{}{},
+		},
+	}
+
+	for name, rule := range equivalentCases {
+		t.Run(name, func(t *testing.T) {
+			h := ruleSetFunc(rule)
+			if h != baseHash {
+				t.Fatalf("expected hash for %s (%d) to match baseHash (%d)", name, h, baseHash)
+			}
+		})
+	}
+}
+
 func TestComputeSecurityPolicyRuleHash_inlineRuleModification(t *testing.T) {
 	ruleSchema := tpgcompute.ResourceComputeSecurityPolicy().Schema["rule"]
 	ruleSetFunc := ruleSchema.Set
@@ -2613,6 +2709,63 @@ func TestComputeSecurityPolicyRuleHash_inlineRuleModification(t *testing.T) {
 			},
 			expectEqual: false,
 		},
+		"action modification": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "deny",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"priority modification": {
+			modifiedRule: map[string]interface{}{
+				"priority":    2000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"priority set to 0": {
+			modifiedRule: map[string]interface{}{
+				"priority":    0,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
 		"preview boolean toggle": {
 			modifiedRule: map[string]interface{}{
 				"priority":    1000,
@@ -2625,6 +2778,43 @@ func TestComputeSecurityPolicyRuleHash_inlineRuleModification(t *testing.T) {
 						"config": []interface{}{
 							map[string]interface{}{
 								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"versioned_expr modification": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "FIREWALL",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"match expr expression added": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"expr": []interface{}{
+							map[string]interface{}{
+								"expression": "request.headers['host'].contains('test')",
 							},
 						},
 					},
@@ -2670,6 +2860,119 @@ func TestComputeSecurityPolicyRuleHash_inlineRuleModification(t *testing.T) {
 			},
 			expectEqual: false,
 		},
+		"rate_limit_options added": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+				"rate_limit_options": []interface{}{
+					map[string]interface{}{
+						"conform_action": "allow",
+						"exceed_action":  "deny(502)",
+						"rate_limit_threshold": []interface{}{
+							map[string]interface{}{
+								"count":        10,
+								"interval_sec": 60,
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"redirect_options added": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+				"redirect_options": []interface{}{
+					map[string]interface{}{
+						"type":   "EXTERNAL_302",
+						"target": "https://example.com",
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"header_action added": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+				"header_action": []interface{}{
+					map[string]interface{}{
+						"request_headers_to_adds": []interface{}{
+							map[string]interface{}{
+								"header_name":  "X-Custom-Header",
+								"header_value": "value",
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
+		"preconfigured_waf_config added": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+				"preconfigured_waf_config": []interface{}{
+					map[string]interface{}{
+						"exclusions": []interface{}{
+							map[string]interface{}{
+								"target_rule_set": "sqli-v33-stable",
+							},
+						},
+					},
+				},
+			},
+			expectEqual: false,
+		},
 		"src_ip_ranges order difference should produce identical hash": {
 			modifiedRule: map[string]interface{}{
 				"priority":    1000,
@@ -2682,6 +2985,25 @@ func TestComputeSecurityPolicyRuleHash_inlineRuleModification(t *testing.T) {
 						"config": []interface{}{
 							map[string]interface{}{
 								"src_ip_ranges": []interface{}{"9.9.9.0/24"},
+							},
+						},
+					},
+				},
+			},
+			expectEqual: true,
+		},
+		"src_ip_ranges with empty string filtered out should produce identical hash": {
+			modifiedRule: map[string]interface{}{
+				"priority":    1000,
+				"action":      "allow",
+				"description": "initial description",
+				"preview":     false,
+				"match": []interface{}{
+					map[string]interface{}{
+						"versioned_expr": "SRC_IPS_V1",
+						"config": []interface{}{
+							map[string]interface{}{
+								"src_ip_ranges": []interface{}{"9.9.9.0/24", ""},
 							},
 						},
 					},

--- a/mmv1/third_party/tgc/tests/data/example_compute_security_policy.json
+++ b/mmv1/third_party/tgc/tests/data/example_compute_security_policy.json
@@ -12,19 +12,6 @@
         "name": "my-policy",
         "rule": [
           {
-            "action": "deny(403)",
-            "description": "Deny access to IPs in 9.9.9.0/24",
-            "match": {
-              "config": {
-                "srcIpRanges": [
-                  "9.9.9.0/24"
-                ]
-              },
-              "versionedExpr": "SRC_IPS_V1"
-            },
-            "priority": 1000
-          },
-          {
             "action": "allow",
             "description": "default rule",
             "match": {
@@ -36,6 +23,19 @@
               "versionedExpr": "SRC_IPS_V1"
             },
             "priority": 2147483647
+          },
+          {
+            "action": "deny(403)",
+            "description": "Deny access to IPs in 9.9.9.0/24",
+            "match": {
+              "config": {
+                "srcIpRanges": [
+                  "9.9.9.0/24"
+                ]
+              },
+              "versionedExpr": "SRC_IPS_V1"
+            },
+            "priority": 1000
           }
         ]
       }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/28390 (introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/17391)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed an issue where diffs in `google_compute_security_policy` were not detected
```
