### PR TITLE
Add new fields to Rule resource.

### DIFF
--- a/mmv1/products/chronicle/Rule.yaml
+++ b/mmv1/products/chronicle/Rule.yaml
@@ -279,3 +279,13 @@ properties:
     output: true
     item_type:
       type: String
+  - name: hasNonexistenceChecks
+    type: Boolean
+    description: |-
+      Output only. Indicates whether the rule has non-existence checks.
+    output: true
+  - name: timeWindowDuration
+    type: String
+    description: |-
+      Output only. The time window of the rule. For rules that do not specify a time window, this will be zero.
+    output: true


### PR DESCRIPTION
Add `hasNonexistenceChecks` and `timeWindowDuration` fields to `RuleDeployment` resource for chronicle.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement 
chronicle: Added `hasNonexistenceChecks` and `timeWindowDuration` fields to `RuleDeployment` resource.
```
