### PR TITLE
Extend timeout for Hypercompute Cluster creation

### DIFF
--- a/mmv1/products/hypercomputecluster/Cluster.yaml
+++ b/mmv1/products/hypercomputecluster/Cluster.yaml
@@ -22,15 +22,11 @@ update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}
 timeouts:
-  insert_minutes: 60
-  update_minutes: 60
-  delete_minutes: 60
+  insert_minutes: 120
+  update_minutes: 120
+  delete_minutes: 120
 async:
   operation:
-    timeouts:
-      insert_minutes: 60
-      update_minutes: 60
-      delete_minutes: 60
     base_url: '{{op_id}}'
   actions:
     - create


### PR DESCRIPTION
Increase Hypercompute Cluster timeout to 120 minutes

The underlying API configuration allows operations to take up to 2 hours.
This PR also cleans up the unused `async.operation.timeouts` block which is ignored by the mmv1 compiler, leaving the root-level `timeouts` block as the single source of truth. https://github.com/hashicorp/terraform-provider-google/issues/28175

Fixes b/528479176

```release-note:enhancement
hypercomputecluster: increased default timeouts for `google_hypercomputecluster_cluster` to 120 minutes
```
