### PR TITLE
Removed note about ignore_read not working on nested fields

### DIFF
--- a/docs/content/develop/diffs.md
+++ b/docs/content/develop/diffs.md
@@ -181,26 +181,10 @@ In the flattener for the field, return the value of the field in the user's conf
 
 {{% tabs "ignore_read" %}}
 {{< tab "MMv1" >}}
-On top-level fields, this can be done with:
+Set:
 
 ```yaml
 ignore_read: true
-```
-
-For nested fields, `ignore_read` is [not currently supported](https://github.com/hashicorp/terraform-provider-google/issues/12410), so this must be implemented with a [custom flattener]({{< ref "/develop/custom-code#custom_flatten" >}}). You will also need to add the field to `ignore_read_extra` on any examples that are used to generate tests; this will cause tests to ignore the field when checking that the values in the API match the user's configuration.
-
-```go
-func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-    // We want to ignore read on this field, but cannot because it is nested
-    return d.Get("path.0.to.0.nested.0.field")
-}
-```
-
-```yaml
-examples:
-   # example configuration
-   ignore_read_extra:
-     - "path.0.to.0.nested.0.field"
 ```
 {{< /tab >}}
 {{< tab "Handwritten" >}}


### PR DESCRIPTION
This behavior was fixed over two years ago in https://github.com/GoogleCloudPlatform/magic-modules/pull/10639

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
