### PR TITLE
accesscontextmanager: clarify access policy import ID

### DIFF
--- a/mmv1/products/accesscontextmanager/AccessPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/AccessPolicy.yaml
@@ -30,6 +30,9 @@ docs:
     in the provider configuration. Otherwise the ACM API will return a 403 error.
     Your account must have the `serviceusage.services.use` permission on the
     `billing_project` you defined.
+  note: |
+    When importing this resource by ID, use only the numeric access policy ID
+    (for example, `123456789`) and omit the `accessPolicies/` prefix.
 base_url: accessPolicies
 self_link: accessPolicies/{{name}}
 update_mask: true


### PR DESCRIPTION
Clarifies the `google_access_context_manager_access_policy` documentation so
ID-based imports use only the numeric policy ID and omit the
`accessPolicies/` prefix shown in Google Cloud.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27632

```release-note:none

```
