### PR TITLE
promoting to ga QT CRUD

### DIFF
--- a/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
+++ b/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
@@ -126,7 +126,7 @@ properties:
   - name: "proposer"
     type: String
     description: |
-      Email or URL of the primary point of contact of the QueryTemplate. 
+      Email or URL of the primary point of contact of the QueryTemplate.
       This field will be deprecated.
   - name: "primaryContact"
     type: String

--- a/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
+++ b/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
@@ -13,7 +13,6 @@
 
 ---
 name: "QueryTemplate"
-min_version: ga
 deletion_policy_default: "DELETE_IF_DRAFTED"
 deletion_policy_custom_docs: true
 description: |

--- a/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
+++ b/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
@@ -123,11 +123,6 @@ properties:
       Unicode non-characters and C0 and C1 control codes except tabs,
       new lines, carriage returns, and page breaks.
       Default value is an empty string. Max length: 2000 bytes.
-  - name: "proposer"
-    type: String
-    description: |
-      Email or URL of the primary point of contact of the QueryTemplate.
-      This field will be deprecated.
   - name: "primaryContact"
     type: String
     description: |

--- a/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
+++ b/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: "QueryTemplate"
-min_version: beta
+min_version: ga
 deletion_policy_default: "DELETE_IF_DRAFTED"
 deletion_policy_custom_docs: true
 description: |
@@ -123,6 +123,11 @@ properties:
       Unicode non-characters and C0 and C1 control codes except tabs,
       new lines, carriage returns, and page breaks.
       Default value is an empty string. Max length: 2000 bytes.
+  - name: "proposer"
+    type: String
+    description: |
+      Email or URL of the primary point of contact of the QueryTemplate. 
+      This field will be deprecated.
   - name: "primaryContact"
     type: String
     description: |

--- a/mmv1/templates/terraform/samples/services/bigqueryanalyticshub/bigquery_analyticshub_querytemplate_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/bigqueryanalyticshub/bigquery_analyticshub_querytemplate_basic.tf.tmpl
@@ -1,9 +1,7 @@
 data "google_client_openid_userinfo" "me" {
-  provider = google-beta
 }
 
 resource "google_bigquery_analytics_hub_data_exchange" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   display_name = "My Audience Data Exchange"
   data_exchange_id = "{{index $.ResourceIdVars "data_exchange_id"}}"
   description = "{{index $.Vars "desc"}}"
@@ -14,7 +12,6 @@ resource "google_bigquery_analytics_hub_data_exchange" "{{$.PrimaryResourceId}}"
 }
 
 resource "google_bigquery_analytics_hub_query_template" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   location = "us"
   data_exchange_id = google_bigquery_analytics_hub_data_exchange.{{$.PrimaryResourceId}}.data_exchange_id
   query_template_id = "{{index $.ResourceIdVars "query_template_id"}}"


### PR DESCRIPTION
This PR promotes the `google_bigquery_analytics_hub_query_template` resource to General Availability (GA) 

**Specific Changes:**
* Updated `min_version` from `beta` to `ga` in `QueryTemplate.yaml`.
* 
**Release Note Template for Downstream PRs (will be copied)**
See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigqueryanalyticshub: promoted `google_bigquery_analytics_hub_query_template` to GA
```

```release-note:enhancement
bigqueryanalyticshub: added `proposer` field to `google_bigquery_analytics_hub_query_template`
```
