### PR TITLE
Mark WorkforcePoolProviderScimTenant ClaimMapping as required

### DIFF
--- a/mmv1/products/iamworkforcepool/WorkforcePoolProviderScimTenant.yaml
+++ b/mmv1/products/iamworkforcepool/WorkforcePoolProviderScimTenant.yaml
@@ -121,6 +121,7 @@ properties:
   - name: claimMapping
     type: KeyValuePairs
     description: Maps BYOID claims to SCIM claims. This is a required field for new SCIM Tenants being created.
+    required: true
   - name: purgeTime
     type: Time
     description: The timestamp that represents the time when the SCIM tenant is purged.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

https://github.com/hashicorp/terraform-provider-google/issues/25286

**Description**

Align the Terraform Provider Google schema for google_iam_workforce_pool_provider_scim_tenant with Cloud Identity (GCP) SCIM Create tenant validation by marking claimMapping required on create.

  * The `claim_mapping` field is now required when creating a SCIM tenant.
  * 
```release-note:breaking-change
iamworkforcepool: made the `claim_mapping` field in `google_iam_workforce_pool_provider_scim_tenant` required.
```

