### PR TITLE
mmv1: preserve property Required attribute in CustomIdentity

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -748,7 +748,12 @@ func (r Resource) IdentityProperties() []*Type {
 
 	if len(r.CustomCode.CustomIdentity) > 0 {
 		for _, fieldName := range r.CustomCode.CustomIdentity {
-			props = append(props, &Type{Name: google.Underscore(fieldName), Type: "string", Required: true})
+			underscored := google.Underscore(fieldName)
+			if idx := slices.IndexFunc(allProps, func(prop *Type) bool { return prop.Name == underscored }); idx != -1 {
+				props = append(props, allProps[idx])
+			} else {
+				props = append(props, &Type{Name: underscored, Type: "string", Required: true})
+			}
 		}
 	}
 

--- a/mmv1/api/resource_test.go
+++ b/mmv1/api/resource_test.go
@@ -991,6 +991,40 @@ func TestIdentityPropertiesFlattenObject(t *testing.T) {
 	}
 }
 
+func TestIdentityPropertiesCustomIdentityExistingProperty(t *testing.T) {
+	t.Parallel()
+
+	res := &api.Resource{
+		Name:            "Framework",
+		BaseUrl:         "{{parent}}/locations/{{location}}/frameworks",
+		ImportFormat:    []string{"organizations/{{%organization}}/locations/{{location}}/frameworks/{{framework_id}}"},
+		ProductMetadata: &api.Product{Name: "CloudSecurityCompliance"},
+		CustomCode: resource.CustomCode{
+			CustomIdentity: []string{"parent"},
+		},
+	}
+	res.Properties = []*api.Type{
+		{
+			Name:             "parent",
+			Type:             "String",
+			Required:         false,
+			ResourceMetadata: res,
+		},
+		{
+			Name:             "organization",
+			Type:             "String",
+			Required:         false,
+			ResourceMetadata: res,
+		},
+	}
+
+	for _, p := range res.IdentityProperties() {
+		if p.Name == "parent" && p.Required {
+			t.Errorf("expected CustomIdentity property \"parent\" to preserve Required=false, but got Required=true")
+		}
+	}
+}
+
 func TestSamplePrimaryResourceId(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Preserve property `Required` attribute when generating `IdentityProperties` from `CustomIdentity` if the property exists in `AllProperties()`.

Previously, `CustomIdentity` hardcoded `Required: true` for all fields, which marked optional fields (like `parent` when `organization` is an alternative) as `RequiredForImport: true`. This caused resource identity import tests to fail when using backward compatibility fields like `organization`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28396

```release-note:bug
cloudsecuritycompliance: fixed resource identity import validation when using backward-compatibility field `organization`
```
