### PR TITLE
cloudsecuritycompliance: sort supported_enforcement_modes in Framework resource

### DIFF
--- a/mmv1/products/cloudsecuritycompliance/Framework.yaml
+++ b/mmv1/products/cloudsecuritycompliance/Framework.yaml
@@ -222,6 +222,7 @@ properties:
     type: Array
     description: The supported enforcement modes of the framework.
     output: true
+    custom_flatten: templates/terraform/custom_flatten/cloudsecuritycompliance_framework_supported_enforcement_modes.go.tmpl
     item_type:
       type: String
   - name: supportedTargetResourceTypes

--- a/mmv1/templates/terraform/custom_flatten/cloudsecuritycompliance_framework_supported_enforcement_modes.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/cloudsecuritycompliance_framework_supported_enforcement_modes.go.tmpl
@@ -1,0 +1,25 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	rawConfigValue := d.Get("supported_enforcement_modes")
+
+	// Convert config value to []string
+	configValue, err := tpgresource.InterfaceSliceToStringSlice(rawConfigValue)
+	if err != nil {
+		log.Printf("[ERROR] Failed to convert config value: %s", err)
+		return v
+	}
+
+	// Convert v to []string
+	apiStringValue, err := tpgresource.InterfaceSliceToStringSlice(v)
+	if err != nil {
+		log.Printf("[ERROR] Failed to convert API value: %s", err)
+		return v
+	}
+
+	sortedStrings, err := tpgresource.SortStringsByConfigOrder(configValue, apiStringValue)
+	if err != nil {
+		log.Printf("[ERROR] Could not sort API response value: %s", err)
+		return v
+	}
+
+	return sortedStrings
+}


### PR DESCRIPTION
Sort `supported_enforcement_modes` in `google_cloud_security_compliance_framework` flattener using `SortStringsByConfigOrder` to prevent index mismatch diffs during `ImportStateVerify`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28396

```release-note:bug
cloudsecuritycompliance: fixed state verification diffs for `supported_enforcement_modes` in `google_cloud_security_compliance_framework`
```
