### PR TITLE
fix(vertexai): preserve GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY in state if explicitly configured for ReasoningEngine

### DIFF
--- a/mmv1/templates/terraform/custom_flatten/vertex_ai_reasoning_engine_env.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/vertex_ai_reasoning_engine_env.go.tmpl
@@ -13,6 +13,24 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 	if v == nil {
 		return nil
 	}
+	hasTelemetryConfig := false
+	if envRaw, ok := d.GetOk("spec.0.deployment_spec.0.env"); ok && envRaw != nil {
+		var envList []interface{}
+		if set, ok := envRaw.(*schema.Set); ok {
+			envList = set.List()
+		} else if list, ok := envRaw.([]interface{}); ok {
+			envList = list
+		}
+		for _, e := range envList {
+			if m, ok := e.(map[string]interface{}); ok {
+				if m["name"] == "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY" {
+					hasTelemetryConfig = true
+					break
+				}
+			}
+		}
+	}
+
 	l := v.([]interface{})
 	transformed := make([]interface{}, 0, len(l))
 	for _, raw := range l {
@@ -20,7 +38,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 			continue
 		}
 		original := raw.(map[string]interface{})
-		if original["name"] == "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY" {
+		if original["name"] == "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY" && !hasTelemetryConfig {
 			continue
 		}
 		transformed = append(transformed, map[string]interface{}{

--- a/mmv1/templates/terraform/custom_flatten/vertex_ai_reasoning_engine_env.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/vertex_ai_reasoning_engine_env.go.tmpl
@@ -13,6 +13,24 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 	if v == nil {
 		return nil
 	}
+	hasTelemetryConfig := false
+	if envRaw, ok := d.GetOk("spec.0.deployment_spec.0.env"); ok && envRaw != nil {
+		var envList []any
+		if set, ok := envRaw.(*schema.Set); ok {
+			envList = set.List()
+		} else if list, ok := envRaw.([]any); ok {
+			envList = list
+		}
+		for _, e := range envList {
+			if m, ok := e.(map[string]any); ok {
+				if m["name"] == "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY" {
+					hasTelemetryConfig = true
+					break
+				}
+			}
+		}
+	}
+
 	l := v.([]interface{})
 	transformed := make([]interface{}, 0, len(l))
 	for _, raw := range l {
@@ -20,7 +38,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 			continue
 		}
 		original := raw.(map[string]interface{})
-		if original["name"] == "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY" {
+		if original["name"] == "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY" && !hasTelemetryConfig {
 			continue
 		}
 		transformed = append(transformed, map[string]interface{}{

--- a/mmv1/third_party/terraform/services/vertexai/flatten_vertex_ai_reasoning_engine_env_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/flatten_vertex_ai_reasoning_engine_env_test.go
@@ -1,0 +1,138 @@
+package vertexai
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestFlattenVertexAIReasoningEngineSpecDeploymentSpecEnv(t *testing.T) {
+	resourceSchema := map[string]*schema.Schema{
+		"spec": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"deployment_spec": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"env": {
+									Type:     schema.TypeSet,
+									Optional: true,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"name": {
+												Type:     schema.TypeString,
+												Required: true,
+											},
+											"value": {
+												Type:     schema.TypeString,
+												Required: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	apiResponseEnv := []interface{}{
+		map[string]interface{}{
+			"name":  "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY",
+			"value": "true",
+		},
+		map[string]interface{}{
+			"name":  "CUSTOM_VAR",
+			"value": "custom_val",
+		},
+	}
+
+	// Case 1: Telemetry env var NOT configured in ResourceData
+	t.Run("Telemetry not in config - filtered out", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+			"spec": []interface{}{
+				map[string]interface{}{
+					"deployment_spec": []interface{}{
+						map[string]interface{}{
+							"env": []interface{}{
+								map[string]interface{}{
+									"name":  "CUSTOM_VAR",
+									"value": "custom_val",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		res := flattenVertexAIReasoningEngineSpecDeploymentSpecEnv(apiResponseEnv, d, nil)
+		resList, ok := res.([]interface{})
+		if !ok {
+			t.Fatalf("Expected []interface{}, got %T", res)
+		}
+
+		expected := []interface{}{
+			map[string]interface{}{
+				"name":  "CUSTOM_VAR",
+				"value": "custom_val",
+			},
+		}
+
+		if !reflect.DeepEqual(resList, expected) {
+			t.Errorf("Expected %v, got %v", expected, resList)
+		}
+	})
+
+	// Case 2: Telemetry env var IS configured in ResourceData
+	t.Run("Telemetry in config - preserved in state", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+			"spec": []interface{}{
+				map[string]interface{}{
+					"deployment_spec": []interface{}{
+						map[string]interface{}{
+							"env": []interface{}{
+								map[string]interface{}{
+									"name":  "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY",
+									"value": "true",
+								},
+								map[string]interface{}{
+									"name":  "CUSTOM_VAR",
+									"value": "custom_val",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		res := flattenVertexAIReasoningEngineSpecDeploymentSpecEnv(apiResponseEnv, d, nil)
+		resList, ok := res.([]interface{})
+		if !ok {
+			t.Fatalf("Expected []interface{}, got %T", res)
+		}
+
+		expected := []interface{}{
+			map[string]interface{}{
+				"name":  "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY",
+				"value": "true",
+			},
+			map[string]interface{}{
+				"name":  "CUSTOM_VAR",
+				"value": "custom_val",
+			},
+		}
+
+		if !reflect.DeepEqual(resList, expected) {
+			t.Errorf("Expected %v, got %v", expected, resList)
+		}
+	})
+}


### PR DESCRIPTION
fix(vertexai): preserve GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY in state if explicitly configured for ReasoningEngine

Update custom flattener for vertex_ai_reasoning_engine spec.deployment_spec.env to only filter out GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY if it was not explicitly defined in the Terraform configuration.

When configured in HCL, the environment variable is now correctly preserved in state, allowing telemetry settings to be managed via Terraform. Added unit test covering both scenarios.

Fixes hashicorp/terraform-provider-google#28409  
b/537345781

```release-note:bug
vertexai: fixed an issue where `GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY` environment variable in `google_vertex_ai_reasoning_engine` was ignored in state when explicitly configured
```