### PR TITLE
agents: fix release-notes link and streamline instructions in create-pr skill

### DIFF
--- a/.agents/skills/operations/create-pr/SKILL.md
+++ b/.agents/skills/operations/create-pr/SKILL.md
@@ -79,7 +79,7 @@ git push -u "$FORK_REMOTE" "$BRANCH"
 Every PR must contain at least one release note block in the PR body.
 
 Refer to the official guide for detailed release note rules, categories, and examples:
-* [docs/content/code-review/release-notes.md](../../../docs/content/code-review/release-notes.md)
+* [docs/content/code-review/release-notes.md](../../../../docs/content/code-review/release-notes.md)
 
 #### Release Note Block Format
 ```markdown
@@ -88,7 +88,11 @@ CONTENT
 ```
 ```
 
-Common types include `new-resource`, `new-datasource`, `new-list-resource`, `enhancement`, `bug`, `deprecation`, `breaking-change`, `note`, and `none`.
+Common types and formatting rules are defined in the official release notes guide:
+* [docs/content/code-review/release-notes.md](../../../../docs/content/code-review/release-notes.md)
+
+> [!IMPORTANT]
+> Always read [docs/content/code-review/release-notes.md](../../../../docs/content/code-review/release-notes.md) to select the correct release note type (e.g., `enhancement`, `bug`, `none`, `new-resource`, `deprecation`, etc.) and follow the end-user impact guidelines.
 
 #### Sample PR Body Content
 ```markdown

--- a/.agents/skills/operations/create-pr/SKILL.md
+++ b/.agents/skills/operations/create-pr/SKILL.md
@@ -81,18 +81,15 @@ Every PR must contain at least one release note block in the PR body.
 Refer to the official guide for detailed release note rules, categories, and examples:
 * [docs/content/code-review/release-notes.md](../../../../docs/content/code-review/release-notes.md)
 
+> [!IMPORTANT]
+> **Note to AI Agents:** View `docs/content/code-review/release-notes.md` from the repository root to determine the correct release note type (e.g., `enhancement`, `bug`, `none`, `new-resource`, `deprecation`, etc.) and follow the end-user impact guidelines.
+
 #### Release Note Block Format
 ```markdown
 ```release-note:TYPE
 CONTENT
 ```
 ```
-
-Common types and formatting rules are defined in the official release notes guide:
-* [docs/content/code-review/release-notes.md](../../../../docs/content/code-review/release-notes.md)
-
-> [!IMPORTANT]
-> Always read [docs/content/code-review/release-notes.md](../../../../docs/content/code-review/release-notes.md) to select the correct release note type (e.g., `enhancement`, `bug`, `none`, `new-resource`, `deprecation`, etc.) and follow the end-user impact guidelines.
 
 #### Sample PR Body Content
 ```markdown


### PR DESCRIPTION
Fixes relative link path to `docs/content/code-review/release-notes.md` (4 directory levels deep) and streamlines release note instructions in `.agents/skills/operations/create-pr/SKILL.md`.

```release-note:none
```
