### PR TITLE
Add suspend/resume support for Cloud Workstations

### DIFF
--- a/mmv1/products/workstations/Workstation.yaml
+++ b/mmv1/products/workstations/Workstation.yaml
@@ -134,6 +134,8 @@ properties:
       - STATE_RUNNING
       - STATE_STOPPING
       - STATE_STOPPED
+      - STATE_SUSPENDING
+      - STATE_SUSPENDED
   - name: sourceWorkstation
     type: String
     description: |

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -142,6 +142,14 @@ samples:
         resource_id_vars:
           workstation_cluster_name: workstation-cluster
           workstation_config_name: workstation-config
+  - name: workstation_config_idle_action
+    primary_resource_id: default
+    min_version: beta
+    steps:
+      - name: workstation_config_idle_action
+        resource_id_vars:
+          workstation_cluster_name: workstation-cluster
+          workstation_config_name: workstation-config
 parameters:
   - name: workstationConfigId
     type: String
@@ -202,6 +210,15 @@ properties:
       How long to wait before automatically stopping an instance that hasn't recently received any user traffic. A value of 0 indicates that this instance should never time out from idleness. Defaults to 20 minutes.
       A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
     default_value: 1200s
+  - name: idleAction
+    type: Enum
+    description: |
+      The action to take when the workstation has been idle for the duration specified in idle_timeout.
+      Defaults to STOP.
+    enum_values:
+      - STOP
+      - SUSPEND
+    min_version: beta
   - name: runningTimeout
     type: String
     description: |

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -211,6 +211,7 @@ properties:
       A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
     default_value: 1200s
   - name: idleAction
+    default_value: STOP
     type: Enum
     description: |
       The action to take when the workstation has been idle for the duration specified in idle_timeout.

--- a/mmv1/templates/terraform/samples/services/workstations/workstation_config_idle_action.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/workstations/workstation_config_idle_action.tf.tmpl
@@ -1,0 +1,39 @@
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "{{index $.ResourceIdVars "workstation_cluster_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "{{index $.ResourceIdVars "workstation_cluster_name"}}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "{{$.PrimaryResourceId}}" {
+  provider               = google-beta
+  workstation_cluster_id = "{{index $.ResourceIdVars "workstation_cluster_name"}}"
+  network                = google_compute_network.default.id
+  subnetwork             = google_compute_subnetwork.default.id
+  location               = "us-central1"
+}
+
+resource "google_workstations_workstation_config" "{{$.PrimaryResourceId}}" {
+  provider               = google-beta
+  workstation_config_id  = "{{index $.ResourceIdVars "workstation_config_name"}}"
+  workstation_cluster_id = google_workstations_workstation_cluster.{{$.PrimaryResourceId}}.workstation_cluster_id
+  location               = "us-central1"
+
+  idle_timeout = "600s"
+  idle_action  = "SUSPEND"
+
+  host {
+    gce_instance {
+      machine_type                 = "e2-standard-4"
+      boot_disk_size_gb            = 35
+      disable_public_ip_addresses  = true
+    }
+  }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Add new states for cloud workstations
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
workstations: added `idle_action` field to `google_workstations_workstation_config` (beta)
```
