### PR TITLE
Add support for scheduleCustomizations in the rule deployment resource.

### DIFF
--- a/mmv1/products/chronicle/RuleDeployment.yaml
+++ b/mmv1/products/chronicle/RuleDeployment.yaml
@@ -150,7 +150,10 @@ properties:
       LIVE_CUSTOMIZABLE
       HOURLY_CUSTOMIZABLE
 
-      Note: For multi-event rules, you must use LIVE_CUSTOMIZABLE or HOURLY_CUSTOMIZABLE for rules with match windows <=2d or DAILY for rules with match windows >2d. If you use LIVE or HOURLY, unexpected behavior may occur, such as terraform plan ignoring changes.
+      Note: Certain legacy run frequencies are deprecated. For multi-event rules, use LIVE_CUSTOMIZABLE or HOURLY_CUSTOMIZABLE (for match windows <=2d), or DAILY (for match windows >2d).
+      Legacy values LIVE and HOURLY are mapped to their customizable counterparts on the backend. DAILY for <=2d match window multi-event rules will be happed to HOURLY_CUSTOMIZABLE.
+      For single-event rules, HOURLY and DAILY are deprecated and mapped to LIVE. If you continue to use deprecated values in your Terraform configuration, Terraform will silently
+      suppress the diff and ignore the changes to prevent infinite update loops.
   - name: scheduleCustomizations
     type: NestedObject
     custom_flatten: 'templates/terraform/custom_flatten/chronicle_rule_deployment_schedule_customizations.go.tmpl'
@@ -163,7 +166,7 @@ properties:
         send_empty_value: true
         description: |-
           Indicates whether to add additional delays and runs to rules to ensure
-          enrichment completeness, with the trade-off of more late-arrving detections.
+          enrichment completeness, with the trade-off of more late-arriving detections.
       - name: lateArrivingDataAdjustment
         type: String
         description: |-

--- a/mmv1/products/chronicle/RuleDeployment.yaml
+++ b/mmv1/products/chronicle/RuleDeployment.yaml
@@ -52,6 +52,40 @@ samples:
       - name: 'chronicle_ruledeployment_run_frequency_missing'
         test_env_vars:
           chronicle_id: 'CHRONICLE_ID'
+  - name: 'chronicle_ruledeployment_schedule_customizations'
+    primary_resource_id: 'example'
+    exclude_basic_doc: true
+    steps:
+      - name: 'chronicle_ruledeployment_schedule_customizations'
+        test_env_vars:
+          chronicle_id: 'CHRONICLE_ID'
+      - name: 'chronicle_ruledeployment_schedule_customizations_update_customizations'
+        test_env_vars:
+          chronicle_id: 'CHRONICLE_ID'
+        ignore_read_extra:
+          - 'schedule_customizations'
+      - name: 'chronicle_ruledeployment_schedule_customizations_update_run_frequency'
+        test_env_vars:
+          chronicle_id: 'CHRONICLE_ID'
+        ignore_read_extra:
+          - 'schedule_customizations'
+      - name: 'chronicle_ruledeployment_schedule_customizations_update_both'
+        test_env_vars:
+          chronicle_id: 'CHRONICLE_ID'
+  - name: 'chronicle_ruledeployment_legacy_run_frequency_diff_suppressed'
+    primary_resource_id: 'example'
+    exclude_basic_doc: true
+    steps:
+      - name: 'chronicle_ruledeployment_legacy_run_frequency_diff_suppressed'
+        test_env_vars:
+          chronicle_id: 'CHRONICLE_ID'
+  - name: 'chronicle_ruledeployment_single_event_diff_suppressed'
+    primary_resource_id: 'example'
+    exclude_basic_doc: true
+    steps:
+      - name: 'chronicle_ruledeployment_single_event_diff_suppressed'
+        test_env_vars:
+          chronicle_id: 'CHRONICLE_ID'
 parameters:
   - name: location
     type: String
@@ -113,6 +147,27 @@ properties:
       LIVE
       HOURLY
       DAILY
+      LIVE_CUSTOMIZABLE
+      HOURLY_CUSTOMIZABLE
+
+      Note: For multi-event rules, you must use LIVE_CUSTOMIZABLE or HOURLY_CUSTOMIZABLE for rules with match windows <=2d or DAILY for rules with match windows >2d. If you use LIVE or HOURLY, unexpected behavior may occur, such as terraform plan ignoring changes.
+  - name: scheduleCustomizations
+    type: NestedObject
+    custom_flatten: 'templates/terraform/custom_flatten/chronicle_rule_deployment_schedule_customizations.go.tmpl'
+    description: |-
+      The schedule customizations of the rule deployment. Only valid for
+      customizable run frequencies.
+    properties:
+      - name: ensureEnrichmentCompleteness
+        type: Boolean
+        send_empty_value: true
+        description: |-
+          Indicates whether to add additional delays and runs to rules to ensure
+          enrichment completeness, with the trade-off of more late-arrving detections.
+      - name: lateArrivingDataAdjustment
+        type: String
+        description: |-
+          Delay the first rule execution run to account for late-arriving data.
   - name: executionState
     type: String
     description: |-

--- a/mmv1/templates/terraform/constants/chronicle_rule_deployment.go.tmpl
+++ b/mmv1/templates/terraform/constants/chronicle_rule_deployment.go.tmpl
@@ -1,5 +1,23 @@
 func chronicleRuleDeploymentNilRunFrequencyDiffSuppressFunc(_, old, new string, _ *schema.ResourceData) bool {
-    if new == "" {
+    // Ignore run frequency when it is not specified. This is a fix for
+	// https://github.com/hashicorp/terraform-provider-google/issues/21347.
+	if new == "" {
+		return true
+	}
+	// Suppress diffs for coerced run frequencies. With the release of customizable
+	// schedules, setting a multi-event rule to LIVE or HOURLY will set the backend
+	// state to LIVE_CUSTOMIZABLE or HOURLY_CUSTOMIZABLE, respectively. So by
+	// suppressing this diff we avoid a permadiff.
+	if (old == "LIVE_CUSTOMIZABLE" && new == "LIVE") || (old == "HOURLY_CUSTOMIZABLE" && new == "HOURLY") {
+		return true
+	}
+	// For single-event rules, we coerce HOURLY and DAILY to LIVE. Note that this
+	// creates an edge case when a legacy multi-event rule is set to LIVE and the
+	// new requested state is HOURLY - in this case, nothing will happen. There is
+	// no good way to differentiate this, so the only solution is for the user to
+	// update their terraform config to begin using the new CUSTOMIZABLE run
+	// frequencies.
+	if old == "LIVE" && (new == "HOURLY" || new == "DAILY") {
 		return true
 	}
 	return false

--- a/mmv1/templates/terraform/constants/chronicle_rule_deployment.go.tmpl
+++ b/mmv1/templates/terraform/constants/chronicle_rule_deployment.go.tmpl
@@ -6,9 +6,10 @@ func chronicleRuleDeploymentNilRunFrequencyDiffSuppressFunc(_, old, new string, 
 	}
 	// Suppress diffs for coerced run frequencies. With the release of customizable
 	// schedules, setting a multi-event rule to LIVE or HOURLY will set the backend
-	// state to LIVE_CUSTOMIZABLE or HOURLY_CUSTOMIZABLE, respectively. So by
+	// state to LIVE_CUSTOMIZABLE or HOURLY_CUSTOMIZABLE, respectively. Non-large match
+	// window rules requesting DAILY are also coerced to HOURLY_CUSTOMIZABLE. So by
 	// suppressing this diff we avoid a permadiff.
-	if (old == "LIVE_CUSTOMIZABLE" && new == "LIVE") || (old == "HOURLY_CUSTOMIZABLE" && new == "HOURLY") {
+	if (old == "LIVE_CUSTOMIZABLE" && new == "LIVE") || (old == "HOURLY_CUSTOMIZABLE" && (new == "HOURLY" || new == "DAILY")) {
 		return true
 	}
 	// For single-event rules, we coerce HOURLY and DAILY to LIVE. Note that this

--- a/mmv1/templates/terraform/custom_create/chronicle_rule_deployment.go.tmpl
+++ b/mmv1/templates/terraform/custom_create/chronicle_rule_deployment.go.tmpl
@@ -1,3 +1,8 @@
+// Custom create logic for Chronicle RuleDeployment.
+//
+// RuleDeployment instances are auto-created when a Rule is created. Therefore, creation in Terraform
+// performs a GET to retrieve the existing deployment, expands the desired deployment configuration
+// (enabled, alerting, archived, runFrequency, scheduleCustomizations), and sends a PATCH request to initialize settings.
 userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 if err != nil {
     return err
@@ -50,6 +55,10 @@ if err != nil {
     return err
 }
 runFrequencyProp, err := expandChronicleRuleDeploymentRunFrequency(d.Get("run_frequency"), d, config)
+if err != nil {
+    return err
+}
+scheduleCustomizationsProp, err := expandChronicleRuleDeploymentScheduleCustomizations(d.Get("schedule_customizations"), d, config)
 if err != nil {
     return err
 }
@@ -115,6 +124,21 @@ if res != nil {
             updateMask = append(updateMask, "runFrequency")
         }
     }
+
+    scheduleCustomizationsValue, scheduleCustomizationsExists := res["scheduleCustomizations"]
+    if scheduleCustomizationsExists {
+        // Flatten existing scheduleCustomizations from GET response to compare against expanded config
+        scheduleCustomizations := flattenChronicleRuleDeploymentScheduleCustomizations(scheduleCustomizationsValue, d, config)
+        _, ok := d.GetOkExists("schedule_customizations")
+        if !reflect.DeepEqual(scheduleCustomizationsProp, scheduleCustomizations) && ok {
+            obj["scheduleCustomizations"] = scheduleCustomizationsProp
+        }
+    } else {
+        // Handle the case where "schedule_customizations" is missing from the API response
+        if v, ok := d.GetOkExists("schedule_customizations"); ok && !tpgresource.IsEmptyValue(reflect.ValueOf(v)) {
+            obj["scheduleCustomizations"] = scheduleCustomizationsProp
+        }
+    }
 } else {
     if v, ok:= d.GetOkExists("enabled"); ok && !tpgresource.IsEmptyValue(reflect.ValueOf(v)) {
         obj["enabled"] = enabledProp
@@ -130,6 +154,41 @@ if res != nil {
     }
     if v, ok:= d.GetOkExists("run_frequency"); ok && !tpgresource.IsEmptyValue(reflect.ValueOf(v)) {
         obj["runFrequency"] = runFrequencyProp
+        updateMask = append(updateMask, "runFrequency")
+    }
+    if v, ok:= d.GetOkExists("schedule_customizations"); ok && !tpgresource.IsEmptyValue(reflect.ValueOf(v)) {
+        obj["scheduleCustomizations"] = scheduleCustomizationsProp
+    }
+}
+
+// We solve two problems here:
+//  1. The scheduleCustomizations field does not have its own update mask field. Instead, it uses
+//     the runFrequency update mask field. So, if we want to update scheduleCustomizations, we
+//     have to add the runFrequency update mask if it's not already there.
+//  2. Because scheduleCustomizations and runFrequency share the same update mask field, they are
+//     always updated together. By default terraform won't add runFrequency or scheduleCustomizations
+//     if either did not change. But because they will be updated together, we still need to include
+//     the field that did not change into the request, or it will revert back to the default,
+//     unspecified value.
+hasScheduleCustomizationsUpdate := obj["scheduleCustomizations"] != nil
+hasRunFrequencyUpdate := obj["runFrequency"] != nil
+if hasScheduleCustomizationsUpdate || hasRunFrequencyUpdate {
+    if hasScheduleCustomizationsUpdate && !hasRunFrequencyUpdate {
+        obj["runFrequency"] = runFrequencyProp
+    }
+    if hasRunFrequencyUpdate && !hasScheduleCustomizationsUpdate {
+        if scheduleCustomizationsProp != nil {
+            obj["scheduleCustomizations"] = scheduleCustomizationsProp
+        }
+    }
+    hasRunFreqMask := false
+    for _, m := range updateMask {
+        if m == "runFrequency" {
+            hasRunFreqMask = true
+            break
+        }
+    }
+    if !hasRunFreqMask {
         updateMask = append(updateMask, "runFrequency")
     }
 }

--- a/mmv1/templates/terraform/custom_flatten/chronicle_rule_deployment_schedule_customizations.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/chronicle_rule_deployment_schedule_customizations.go.tmpl
@@ -1,0 +1,41 @@
+// Custom flattener for scheduleCustomizations.
+//
+// In Proto3 / Google API JSON responses, boolean fields with value `false` (such as ensureEnrichmentCompleteness)
+// are omitted from the JSON response body (or returned as an empty map `{}`).
+//
+// If the default flattener receives a nil/empty map, it passes nil to Terraform state. When HCL specifies
+// ensure_enrichment_completeness = false, comparing state (nil) against HCL (false) produces false plan diffs
+// ("+ ensure_enrichment_completeness = false") and causes import verification failures.
+//
+// This flattener checks if schedule_customizations is active in Terraform configuration (d.GetOk).
+// If active and ensureEnrichmentCompleteness is omitted by the API, it explicitly sets ensure_enrichment_completeness = false
+// in Terraform state to preserve state parity with HCL.
+func flattenChronicleRuleDeploymentScheduleCustomizations(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		if _, ok := d.GetOk("schedule_customizations"); ok {
+			transformed := make(map[string]interface{})
+			transformed["ensure_enrichment_completeness"] = false
+			return []interface{}{transformed}
+		}
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		if _, ok := d.GetOk("schedule_customizations"); ok {
+			transformed := make(map[string]interface{})
+			transformed["ensure_enrichment_completeness"] = false
+			return []interface{}{transformed}
+		}
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	if val, ok := original["ensureEnrichmentCompleteness"]; ok && val != nil {
+		transformed["ensure_enrichment_completeness"] = val
+	} else if _, ok := d.GetOk("schedule_customizations"); ok {
+		transformed["ensure_enrichment_completeness"] = false
+	}
+	if val, ok := original["lateArrivingDataAdjustment"]; ok && val != nil {
+		transformed["late_arriving_data_adjustment"] = val
+	}
+	return []interface{}{transformed}
+}

--- a/mmv1/templates/terraform/pre_update/chronicle_rule_deployment.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/chronicle_rule_deployment.go.tmpl
@@ -1,20 +1,33 @@
-// removeRunFrequencyFromUpdateMask removes 'runFrequency' from the updateMask in a URL.
-removeRunFrequencyFromUpdateMask := func(url string) (string) {
-    // Remove "runFrequency" and handle commas.
-    url = strings.ReplaceAll(url, "%2CrunFrequency", "")
-    url = strings.ReplaceAll(url, "runFrequency%2C", "")
-    url = strings.ReplaceAll(url, "runFrequency", "")
-
-    // Remove extra commas.
-    url = strings.ReplaceAll(url, "%2C%2C", "%2C")
-
-    //Remove trailing commas.
-    url = strings.TrimSuffix(url, "%2C")
-
-    return url
+// scheduleCustomizations uses the "runFrequency" field mask path for updates,
+// rather than "scheduleCustomizations". So if there's an update, remove the
+// "scheduleCustomizations" field mask path and add "runFrequency".
+hasScheduleCustomizationsUpdate := obj["scheduleCustomizations"] != nil
+if hasScheduleCustomizationsUpdate {
+    updateMask = slices.DeleteFunc(updateMask, func(s string) bool {
+        return s == "scheduleCustomizations"
+    })
+    if !slices.Contains(updateMask, "runFrequency") {
+        updateMask = append(updateMask, "runFrequency")
+    }
 }
 
-// Remove "runFrequency" and handle commas if run_frequency not configured by user
-if _, ok := d.GetOk("run_frequency"); !ok {
-    url = removeRunFrequencyFromUpdateMask(url)
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+    return err
+}
+
+// Because runFrequency and scheduleCustomizations share an update mask, they
+// are always updated together. That means if only one is being updated, we
+// must pass in the existing value for the other field to ensure it does not
+// revert back to the default value.
+hasRunFrequencyUpdate := obj["runFrequency"] != nil
+if hasScheduleCustomizationsUpdate && !hasRunFrequencyUpdate {
+    if rfProp, err := expandChronicleRuleDeploymentRunFrequency(d.Get("run_frequency"), d, config); err == nil && rfProp != nil {
+        obj["runFrequency"] = rfProp
+    }
+}
+if hasRunFrequencyUpdate && !hasScheduleCustomizationsUpdate {
+    if scProp, err := expandChronicleRuleDeploymentScheduleCustomizations(d.Get("schedule_customizations"), d, config); err == nil && scProp != nil {
+        obj["scheduleCustomizations"] = scProp
+    }
 }

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_legacy_run_frequency_diff_suppressed.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_legacy_run_frequency_diff_suppressed.tf.tmpl
@@ -2,7 +2,19 @@ resource "google_chronicle_rule" "my-rule" {
  location = "us"
  instance = "{{index $.TestEnvVars "chronicle_id"}}"
  text = <<-EOT
-             rule test_rule { meta: events:  $userid = $e.principal.user.userid  match: $userid over 10m condition: $e }
+             rule test_rule {
+               meta:
+                 description = "test multi-event rule for diff suppression"
+               events:
+                 $e1.metadata.event_type = "USER_LOGIN"
+                 $e1.principal.user.userid = $user
+                 $e2.metadata.event_type = "USER_LOGOUT"
+                 $e2.principal.user.userid = $user
+               match:
+                 $user over 10m
+               condition:
+                 $e1 and $e2
+             }
          EOT
 }
 

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_schedule_customizations.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_schedule_customizations.tf.tmpl
@@ -1,0 +1,37 @@
+resource "google_chronicle_rule" "my-rule" {
+ location = "us"
+ instance = "{{index $.TestEnvVars "chronicle_id"}}"
+ text = <<-EOT
+             rule test_rule {
+               meta:
+                 description = "test multi-event rule"
+               events:
+                 $e1.metadata.event_type = "USER_LOGIN"
+                 $e1.principal.user.userid = $user
+                 $e2.metadata.event_type = "USER_LOGOUT"
+                 $e2.principal.user.userid = $user
+               match:
+                 $user over 10m
+               condition:
+                 $e1 and $e2
+             }
+         EOT
+}
+
+resource "google_chronicle_rule_deployment" "{{$.PrimaryResourceId}}" {
+ location = "us"
+ instance = "{{index $.TestEnvVars "chronicle_id"}}"
+ rule = element(split("/", resource.google_chronicle_rule.my-rule.name), length(split("/", resource.google_chronicle_rule.my-rule.name)) - 1)
+ enabled = true
+ alerting = true
+ archived = false
+ # Make sure to use the default run_frequency for the configured rule along with
+ # a non-default schedule_customizations. This ensures we test the fallback logic
+ # to always populate run_frequency alongside schedule_customizations in the
+ # custom_create PATCH step even when the run_frequency value does not change.
+ run_frequency = "LIVE_CUSTOMIZABLE"
+ schedule_customizations {
+   ensure_enrichment_completeness = true
+   late_arriving_data_adjustment  = "60s"
+ }
+}

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_schedule_customizations_update_both.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_schedule_customizations_update_both.tf.tmpl
@@ -1,0 +1,33 @@
+resource "google_chronicle_rule" "my-rule" {
+ location = "us"
+ instance = "{{index $.TestEnvVars "chronicle_id"}}"
+ text = <<-EOT
+             rule test_rule {
+               meta:
+                 description = "test multi-event rule"
+               events:
+                 $e1.metadata.event_type = "USER_LOGIN"
+                 $e1.principal.user.userid = $user
+                 $e2.metadata.event_type = "USER_LOGOUT"
+                 $e2.principal.user.userid = $user
+               match:
+                 $user over 10m
+               condition:
+                 $e1 and $e2
+             }
+         EOT
+}
+
+resource "google_chronicle_rule_deployment" "{{$.PrimaryResourceId}}" {
+ location = "us"
+ instance = "{{index $.TestEnvVars "chronicle_id"}}"
+ rule = element(split("/", resource.google_chronicle_rule.my-rule.name), length(split("/", resource.google_chronicle_rule.my-rule.name)) - 1)
+ enabled = true
+ alerting = true
+ archived = false
+ run_frequency = "LIVE_CUSTOMIZABLE"
+ schedule_customizations {
+   ensure_enrichment_completeness = true
+   late_arriving_data_adjustment  = "120s"
+ }
+}

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_schedule_customizations_update_customizations.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_schedule_customizations_update_customizations.tf.tmpl
@@ -1,0 +1,33 @@
+resource "google_chronicle_rule" "my-rule" {
+ location = "us"
+ instance = "{{index $.TestEnvVars "chronicle_id"}}"
+ text = <<-EOT
+             rule test_rule {
+               meta:
+                 description = "test multi-event rule"
+               events:
+                 $e1.metadata.event_type = "USER_LOGIN"
+                 $e1.principal.user.userid = $user
+                 $e2.metadata.event_type = "USER_LOGOUT"
+                 $e2.principal.user.userid = $user
+               match:
+                 $user over 10m
+               condition:
+                 $e1 and $e2
+             }
+         EOT
+}
+
+resource "google_chronicle_rule_deployment" "{{$.PrimaryResourceId}}" {
+ location = "us"
+ instance = "{{index $.TestEnvVars "chronicle_id"}}"
+ rule = element(split("/", resource.google_chronicle_rule.my-rule.name), length(split("/", resource.google_chronicle_rule.my-rule.name)) - 1)
+ enabled = true
+ alerting = true
+ archived = false
+ run_frequency = "LIVE_CUSTOMIZABLE"
+ schedule_customizations {
+   ensure_enrichment_completeness = false
+   late_arriving_data_adjustment  = "300s"
+ }
+}

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_schedule_customizations_update_run_frequency.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_schedule_customizations_update_run_frequency.tf.tmpl
@@ -1,0 +1,33 @@
+resource "google_chronicle_rule" "my-rule" {
+ location = "us"
+ instance = "{{index $.TestEnvVars "chronicle_id"}}"
+ text = <<-EOT
+             rule test_rule {
+               meta:
+                 description = "test multi-event rule"
+               events:
+                 $e1.metadata.event_type = "USER_LOGIN"
+                 $e1.principal.user.userid = $user
+                 $e2.metadata.event_type = "USER_LOGOUT"
+                 $e2.principal.user.userid = $user
+               match:
+                 $user over 10m
+               condition:
+                 $e1 and $e2
+             }
+         EOT
+}
+
+resource "google_chronicle_rule_deployment" "{{$.PrimaryResourceId}}" {
+ location = "us"
+ instance = "{{index $.TestEnvVars "chronicle_id"}}"
+ rule = element(split("/", resource.google_chronicle_rule.my-rule.name), length(split("/", resource.google_chronicle_rule.my-rule.name)) - 1)
+ enabled = true
+ alerting = true
+ archived = false
+ run_frequency = "HOURLY_CUSTOMIZABLE"
+ schedule_customizations {
+   ensure_enrichment_completeness = false
+   late_arriving_data_adjustment  = "300s"
+ }
+}

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_single_event_diff_suppressed.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_ruledeployment_single_event_diff_suppressed.tf.tmpl
@@ -1,0 +1,24 @@
+resource "google_chronicle_rule" "my-single-event-rule" {
+ location = "us"
+ instance = "{{index $.TestEnvVars "chronicle_id"}}"
+ text = <<-EOT
+             rule test_single_event_rule {
+               meta:
+                 description = "test single event rule for diff suppression"
+               events:
+                 $e.metadata.event_type = "USER_LOGIN"
+               condition:
+                 $e
+             }
+         EOT
+}
+
+resource "google_chronicle_rule_deployment" "{{$.PrimaryResourceId}}" {
+ location = "us"
+ instance = "{{index $.TestEnvVars "chronicle_id"}}"
+ rule = element(split("/", resource.google_chronicle_rule.my-single-event-rule.name), length(split("/", resource.google_chronicle_rule.my-single-event-rule.name)) - 1)
+ enabled = true
+ alerting = true
+ archived = false
+ run_frequency = "HOURLY"
+}

--- a/mmv1/third_party/terraform/services/chronicle/resource_chronicle_rule_deployment_test.go
+++ b/mmv1/third_party/terraform/services/chronicle/resource_chronicle_rule_deployment_test.go
@@ -61,7 +61,7 @@ resource "google_chronicle_rule_deployment" "example" {
  enabled = true
  alerting = true
  archived = false
- run_frequency = "DAILY"
+ run_frequency = "LIVE"
 }
 `, context)
 }
@@ -83,7 +83,7 @@ resource "google_chronicle_rule_deployment" "example" {
  enabled = false
  alerting = false
  archived = false
- run_frequency = "HOURLY"
+ run_frequency = "LIVE"
 }
 `, context)
 }


### PR DESCRIPTION
Add `schedule_customizations` field to `RuleDeployment` resource.

This is for the customizable schedules feature, which is launching to GA soon.

There were two difficulties in updating the RuleDeployment resource.

### Problem 1: Bad terraform interaction with backwards compatibility behaviors

With the release of customizable schedules we've added additional restrictions on which run frequencies are allowed for which rules. However, because of this, we run into a "permadiff" problem: 

* Multi-event rule is currently HOURLY and the user updates their HCL for that rule to LIVE.
* Terraform sees a diff between current state (HOURLY) and requested state (LIVE).
* Terraform sends an UpdateRuleDeployment request with run_frequency=LIVE.
* Backend updates saved run frequency to LIVE_CUSTOMIZABLE.
* Now on the second terraform run, terraform again sees a diff between current state (LIVE_CUSTOMIZABLE) and requested state (LIVE). So it again sends a request. Terraform calls this a permadiff.
* Terraform will keep sending needless requests and eat through API quotas.

A similar problem happens with single-event rules.

We can *mostly* solve the problem using the diff suppression function. However, we have one edge case where the user has a LIVE (legacy run frequency) multi-event rule, and tries to update to HOURLY or DAILY. In that case, we will silently suppress the diff because of the single-event permadiff logic. There does not seem to be a good way around this because we can't figure out the parent rule resource rule_type corresponding to the rule deployment.

Added tests for this. I also tested manually since some of the logic depends on feature flags being flipped which we can't replicate in the basic terraform unit tests.

So to help with this, we noted a warning in the terraform docs to suggest people to start using the new customizable run frequencies. We will also add warnings to our normal API docs.

### Problem 2: The run_frequency and schedule_customizations fields share a field mask

This is for the customizable schedules feature, which is launching to GA soon. In addition to the typical boilerplate of adding a new field, we had to add special logic to the custom_create and pre_update handlers to address two problems:

This causes two related issues:

1. The scheduleCustomizations field does not have its own update mask field. Instead, it uses the runFrequency update mask field. So, if we want to update scheduleCustomizations, we have to add the runFrequency update mask if it's not already there.
2. Because scheduleCustomizations and runFrequency share the same update mask field, they are always updated together. By default terraform won't add runFrequency or scheduleCustomizations if either did not change. But because they will be updated together, we still need to include the field that did not change into the request, or it will revert back to the default, unspecified value.

We added special logic to the custom_create and pre_update handlers to handle this. Added test cases to catch these edge cases. There is no user-facing impact of this change, unlike for problem 1.

I also removed the logic that removes runFrequency from the updateMask. This is no longer needed because we made run frequency updates idempotent in Feb 2026.

### Other changes

* Removed the logic that removes runFrequency from the updateMask. This is not needed because run_frequency updates are now idempotent, which fixes the issue with https://github.com/hashicorp/terraform-provider-google/issues/21347.
* I turned on the feature flag for the customizable schedules feature in all 3 CI secops tenants, which is needed for the VCR tests to record and pass correctly.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
chronicle: Added `schedule_customizations` field to `RuleDeployment` resource.
```