### PR TITLE
fix(netapp): ignore read for hybrid_replication_parameters in google_netapp_volume

### DIFF
--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -555,6 +555,8 @@ properties:
       [Volume migration](https://docs.cloud.google.com/netapp/volumes/docs/migrate/ontap/overview) and
       [external replication](https://docs.cloud.google.com/netapp/volumes/docs/protect-data/replicate-ontap/overview)
       are two types of Hybrid Replication. This parameter block specifies the parameters for a hybrid replication.
+    # This parameter is only used at CREATE. READs will omit it.
+    ignore_read: true
     properties:
       - name: replication
         type: String

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -555,29 +555,39 @@ properties:
       [Volume migration](https://docs.cloud.google.com/netapp/volumes/docs/migrate/ontap/overview) and
       [external replication](https://docs.cloud.google.com/netapp/volumes/docs/protect-data/replicate-ontap/overview)
       are two types of Hybrid Replication. This parameter block specifies the parameters for a hybrid replication.
+      This field will suppress diffs that change the value from empty to non-empty. To force changing this field
+      from empty to non-empty, change another field at the same time.
     # This parameter is only used at CREATE. READs will omit it.
     ignore_read: true
+    immutable: true
+    # Diff suppress function prevents forced recreations for existing resources when upgrading from older provider versions
+    diff_suppress_func: 'netappVolumeHybridReplicationParametersDiffSuppress'
     properties:
       - name: replication
         type: String
         description: |
           Required. Desired name for the replication of this volume.
+        immutable: true
       - name: peerVolumeName
         type: String
         description: |
           Required. Name of the ONTAP source volume to be replicated to NetApp Volumes destination volume.
+        immutable: true
       - name: peerClusterName
         type: String
         description: |
           Required. Name of the ONTAP source cluster to be peered with NetApp Volumes.
+        immutable: true
       - name: peerSvmName
         type: String
         description: |
           Required. Name of the ONTAP source vserver SVM to be peered with NetApp Volumes.
+        immutable: true
       - name: peerIpAddresses
         type: Array
         description: |
           Required. List of all intercluster LIF IP addresses of the ONTAP source cluster.
+        immutable: true
         item_type:
           type: String
       - name: clusterLocation
@@ -585,19 +595,23 @@ properties:
         description: |
           Optional. Name of source cluster location associated with the replication. This is a free-form field
           for display purposes only.
+        immutable: true
       - name: description
         type: String
         description: |
           Optional. Description of the replication.
+        immutable: true
       - name: labels
         type: KeyValuePairs
         description: |
           Optional. Labels to be added to the replication as the key value pairs.
           An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+        immutable: true
       - name: replicationSchedule
         type: Enum
         description: |
           Optional. Replication Schedule for the replication created.
+        immutable: true
         enum_values:
           - EVERY_10_MINUTES
           - HOURLY
@@ -609,6 +623,7 @@ properties:
           and `ONPREM_REPLICATION` to create an external replication.
           Other values are read-only. `REVERSE_ONPREM_REPLICATION` is used to represent an external
           replication which got reversed. Default is `MIGRATION`.
+        immutable: true
         enum_values:
           - MIGRATION
           - CONTINUOUS_REPLICATION
@@ -618,6 +633,7 @@ properties:
         type: Integer
         description: |
           Optional. If the source is a FlexGroup volume, this field needs to match the number of constituents in the FlexGroup.
+        immutable: true
   - name: throughputMibps
     type: Double
     description: |

--- a/mmv1/templates/terraform/constants/netapp_volume.go.tmpl
+++ b/mmv1/templates/terraform/constants/netapp_volume.go.tmpl
@@ -40,3 +40,11 @@ func SuppressHasRootAccessDiff(k, old, new string, d *schema.ResourceData) bool 
     }
     return false
 }
+
+// netappVolumeHybridReplicationParametersDiffSuppress suppresses diffs for existing resources
+// when state (old) is empty. This prevents forced recreations when upgrading from provider versions
+// where hybrid_replication_parameters was omitted from state due to being CREATE-only.
+func netappVolumeHybridReplicationParametersDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return d.Id() != "" && (old == "" || old == "0")
+}
+

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_diff_suppress_test.go
@@ -1,0 +1,92 @@
+package netapp
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestNetappVolumeHybridReplicationParametersDiffSuppress(t *testing.T) {
+	dExisting := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"hybrid_replication_parameters": {
+			Type: schema.TypeList,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"peer_cluster_name": {
+						Type: schema.TypeString,
+					},
+				},
+			},
+		},
+	}, map[string]interface{}{})
+	dExisting.SetId("projects/my-project/locations/us-central1/volumes/my-volume")
+
+	dNew := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"hybrid_replication_parameters": {
+			Type: schema.TypeList,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"peer_cluster_name": {
+						Type: schema.TypeString,
+					},
+				},
+			},
+		},
+	}, map[string]interface{}{})
+
+	cases := map[string]struct {
+		Data               *schema.ResourceData
+		Key                string
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"existing resource with empty count and non-empty config (upgrade scenario)": {
+			Data:               dExisting,
+			Key:                "hybrid_replication_parameters.#",
+			Old:                "0",
+			New:                "1",
+			ExpectDiffSuppress: true,
+		},
+		"existing resource with empty string and non-empty config": {
+			Data:               dExisting,
+			Key:                "hybrid_replication_parameters.0.peer_cluster_name",
+			Old:                "",
+			New:                "cluster1",
+			ExpectDiffSuppress: true,
+		},
+		"existing resource with non-empty state and same config": {
+			Data:               dExisting,
+			Key:                "hybrid_replication_parameters.0.peer_cluster_name",
+			Old:                "cluster1",
+			New:                "cluster1",
+			ExpectDiffSuppress: false,
+		},
+		"existing resource with non-empty state and different config": {
+			Data:               dExisting,
+			Key:                "hybrid_replication_parameters.0.peer_cluster_name",
+			Old:                "cluster1",
+			New:                "cluster2",
+			ExpectDiffSuppress: false,
+		},
+		"new resource creation with non-empty config": {
+			Data:               dNew,
+			Key:                "hybrid_replication_parameters.#",
+			Old:                "0",
+			New:                "1",
+			ExpectDiffSuppress: false,
+		},
+		"new resource creation with empty config": {
+			Data:               dNew,
+			Key:                "hybrid_replication_parameters.#",
+			Old:                "0",
+			New:                "0",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if netappVolumeHybridReplicationParametersDiffSuppress(tc.Key, tc.Old, tc.New, tc.Data) != tc.ExpectDiffSuppress {
+			t.Errorf("failed case %s: Key='%s', Old='%s', New='%s', expected suppress=%t", tn, tc.Key, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}


### PR DESCRIPTION
Fixes b/485810341

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
netapp: fixed an issue in `google_netapp_volume` where `hybrid_replication_parameters` caused configuration drift and failed updates after volume creation
```

 ### Implementation Details:

 • Configuration Drift Fix: `hybrid_replication_parameters` are only accepted by the API during volume creation and are omitted from the response of subsequent GET requests. Because of this, Terraform detected a mismatch between the state file and the configuration, which failed during the update phase (`invalid update_mask path`). Adding the `ignore_read: true` property explicitly eliminates the drift. This strictly mirrors the established pattern used for the `restoreParameters` block on the same resource.
 • Verification: Generated the downstream google-beta provider and verified that `resource_netapp_volume.go` properly applies the `ignore_read` attribute. Compiled and vetted the generated provider code cleanly via make build and go vet in the downstream repository.