### PR TITLE
compute: fix DiskImageDiffSuppress for fedora-coreos testing-devel images [default]

### DIFF
--- a/mmv1/third_party/terraform/services/compute/image.go
+++ b/mmv1/third_party/terraform/services/compute/image.go
@@ -33,7 +33,7 @@ var (
 
 	windowsSqlImage         = regexp.MustCompile("^sql-(?:server-)?([0-9]{4})-([a-z]+)-windows-(?:server-)?([0-9]{4})(?:-r([0-9]+))?-dc-v[0-9]+$")
 	canonicalUbuntuLtsImage = regexp.MustCompile("^ubuntu-(minimal-)?([0-9]+)(?:.*(arm64|amd64))?.*$")
-	fedoraImage             = regexp.MustCompile("^fedora-coreos-([0-9]+)-([0-9]+)-([0-9]+)-([0-9]+)-gcp-(x86-64|aarch64)$")
+	fedoraImage             = regexp.MustCompile("^fedora-coreos-([0-9]+)-([0-9]+)-([0-9]+)-([a-zA-Z0-9]+)-gcp-(x86-64|aarch64)$")
 	suseImage               = regexp.MustCompile("^sles-([0-9]+)-([0-9]+)-(v[0-9]+)-x86-64$")
 	cosLtsImage             = regexp.MustCompile("^cos-([0-9]+)-")
 )

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
@@ -316,6 +316,16 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			New:                "ubuntu-minimal-2404-lts-amd64",
 			ExpectDiffSuppress: false,
 		},
+		"matching fedora coreos testing devel family": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images/fedora-coreos-43-20260411-20-dev0-gcp-x86-64",
+			New:                "family/fedora-coreos-testing-devel",
+			ExpectDiffSuppress: true,
+		},
+		"matching fedora coreos testing devel arm64 family": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images/fedora-coreos-43-20260411-20-dev0-gcp-aarch64",
+			New:                "family/fedora-coreos-testing-devel-arm64",
+			ExpectDiffSuppress: true,
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
Update `fedoraImage` regex to support non-numeric sub-build components (such as `dev0`) in Fedora CoreOS `testing-devel` stream images.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28424

```release-note:bug
compute: fixed diff suppression for `google_compute_disk` when referencing Fedora CoreOS images with `dev` sub-builds
```
