### PR TITLE
fix: apigee_flowhook continue_on_error argument

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook.go
@@ -102,7 +102,8 @@ func resourceApigeeFlowhookCreate(d *schema.ResourceData, meta interface{}) erro
 	continue_on_errorProp, err := expandApigeeFlowhookContinueOnError(d.Get("continue_on_error"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOkExists("continue_on_error"); !tpgresource.IsEmptyValue(reflect.ValueOf(continue_on_errorProp)) && (ok || !reflect.DeepEqual(v, continue_on_errorProp)) {
+	} else if continueOnErrorRaw := d.GetRawConfig().GetAttr("continue_on_error"); !continueOnErrorRaw.IsNull() {
+		// If a configured `false` is preserved instead of being dropped by the IsEmptyValue() guard.
 		obj["continueOnError"] = continue_on_errorProp
 	}
 

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook.go
@@ -102,8 +102,8 @@ func resourceApigeeFlowhookCreate(d *schema.ResourceData, meta interface{}) erro
 	continue_on_errorProp, err := expandApigeeFlowhookContinueOnError(d.Get("continue_on_error"), d, config)
 	if err != nil {
 		return err
-	} else if continueOnErrorRaw := d.GetRawConfig().GetAttr("continue_on_error"); !continueOnErrorRaw.IsNull() {
-		// If a configured `false` is preserved instead of being dropped by the IsEmptyValue() guard.
+	} else if v, ok := d.GetOkExists("continue_on_error"); ok || !reflect.DeepEqual(v, continue_on_errorProp) {
+		// Preserve explicitly configured false values when send_empty_value behavior is desired.
 		obj["continueOnError"] = continue_on_errorProp
 	}
 

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook_meta.yaml
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook_meta.yaml
@@ -5,6 +5,7 @@ api_version: 'v1'
 api_resource_type_kind: 'FlowHook'
 fields:
   - api_field: 'continueOnError'
+    send_empty_value: true
   - api_field: 'description'
   - field: 'environment'
   - api_field: 'flowHookPoint'

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook_test.go
@@ -23,9 +23,10 @@ func TestAccApigeeFlowhook_apigeeFlowhookTestExample(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org_id":          envvar.GetTestOrgFromEnv(t),
-		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
-		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":            envvar.GetTestOrgFromEnv(t),
+		"billing_account":   envvar.GetTestBillingAccountFromEnv(t),
+		"random_suffix":     acctest.RandString(t, 10),
+		"continue_on_error": true,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -38,6 +39,42 @@ func TestAccApigeeFlowhook_apigeeFlowhookTestExample(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigeeFlowhook_apigeeFlowhookTestExample(context),
+			},
+			{
+				ResourceName:            "google_apigee_flowhook.flowhook_test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccApigeeFlowhook_continueOnErrorFalse(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":            envvar.GetTestOrgFromEnv(t),
+		"billing_account":   envvar.GetTestBillingAccountFromEnv(t),
+		"random_suffix":     acctest.RandString(t, 10),
+		"continue_on_error": false,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeFlowhookDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeFlowhook_apigeeFlowhookTestExample(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_apigee_flowhook.flowhook_test", "continue_on_error", "false"),
+					testAccCheckApigeeFlowhookContinueOnError(t, "google_apigee_flowhook.flowhook_test", false),
+				),
 			},
 			{
 				ResourceName:            "google_apigee_flowhook.flowhook_test",
@@ -140,9 +177,53 @@ resource "google_apigee_flowhook" "flowhook_test" {
 	flow_hook_point = "PreProxyFlowHook"
 	sharedflow = google_apigee_sharedflow.test_apigee_sharedflow.name
 	description = "test flowhook"
-	continue_on_error = true
+	continue_on_error = %{continue_on_error}
   }
 `, context)
+}
+
+// Verifies continue_on_error is correctly persisted when explicitly set.
+// Verify continueOnError is returned by the API with the expected value.
+func testAccCheckApigeeFlowhookContinueOnError(t *testing.T, resourceName string, expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		config := acctest.GoogleProviderConfig(t)
+
+		url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"organizations/{{org_id}}/environments/{{environment}}/flowhooks/{{flow_hook_point}}")
+		if err != nil {
+			return err
+		}
+
+		billingProject := ""
+		if config.BillingProject != "" {
+			billingProject = config.BillingProject
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   billingProject,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			return fmt.Errorf("error reading flowhook at %s: %s", url, err)
+		}
+
+		got, ok := res["continueOnError"].(bool)
+		if !ok {
+			return fmt.Errorf("continueOnError missing or not a bool in API response for %s", url)
+		}
+		if got != expected {
+			return fmt.Errorf("continueOnError = %t, want %t at %s", got, expected, url)
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckApigeeFlowhookDestroyProducer(t *testing.T) func(s *terraform.State) error {


### PR DESCRIPTION
## Description

The `continue_on_error` arguement is being dropped if it is set to `false` so there is no way to set the variable to `false`.

```release-note:bug
apigee: fixed `continue_on_error` arguement being dropped in `google_apigee_flowhook`, aligning provider behavior with the Apigee API
```

## Problem

 If you set `continue_on_error` arguement to `false` it will show up in the plan properly. You apply it will apply, it will say everything got applied but the change will not persist. Running the plan again will try to set it again. In GCP it never changes from true which is the default by which gets created with because `continue_on_error` is an optional flag which by default is true.

## Solution

This change fixes the handling of `continue_on_error` by using the field reference: [send_empty_value: true](https://googlecloudplatform.github.io/magic-modules/reference/field/#send_empty_value)

## Testing

- Added an acceptance test covering the `continue_on_error = false` case.
- Updated the existing acceptance test to parameterize `continue_on_error` so both `true` and `false` configurations can be exercised.
- Added an API verification helper (`testAccCheckApigeeFlowhookContinueOnError`) that performs a direct GET request against the Apigee API and asserts that the returned `continueOnError` value matches the expected boolean.
- Verified that both resource creation and import correctly preserve the configured value.