### PR TITLE
compute: support alphanumeric build names in fedoraImage diff suppress regex [advanced]

### DIFF
--- a/mmv1/third_party/terraform/services/compute/image.go
+++ b/mmv1/third_party/terraform/services/compute/image.go
@@ -33,7 +33,7 @@ var (
 
 	windowsSqlImage         = regexp.MustCompile("^sql-(?:server-)?([0-9]{4})-([a-z]+)-windows-(?:server-)?([0-9]{4})(?:-r([0-9]+))?-dc-v[0-9]+$")
 	canonicalUbuntuLtsImage = regexp.MustCompile("^ubuntu-(minimal-)?([0-9]+)(?:.*(arm64|amd64))?.*$")
-	fedoraImage             = regexp.MustCompile("^fedora-coreos-([0-9]+)-([0-9]+)-([0-9]+)-([0-9]+)-gcp-(x86-64|aarch64)$")
+	fedoraImage             = regexp.MustCompile("^fedora-coreos-([0-9]+)-([0-9]+)-([0-9]+)-([a-zA-Z0-9]+)-gcp-(x86-64|aarch64)$")
 	suseImage               = regexp.MustCompile("^sles-([0-9]+)-([0-9]+)-(v[0-9]+)-x86-64$")
 	cosLtsImage             = regexp.MustCompile("^cos-([0-9]+)-")
 )

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
@@ -139,6 +139,11 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			New:                "cos-85-lts",
 			ExpectDiffSuppress: true,
 		},
+		"matching unconventional image family - fedora coreos dev": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/fedora-coreos-cloud/global/images/fedora-coreos-43-20260411-20-dev0-gcp-aarch64",
+			New:                "family/fedora-coreos-testing-devel-arm64",
+			ExpectDiffSuppress: true,
+		},
 		"different image family": {
 			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
 			New:                "family/debian-7",


### PR DESCRIPTION
Resolves acceptance test failure `TestAccComputeDisk_imageDiffSuppressPublicVendorsFamilyNames`.

The regular expression `fedoraImage` previously only matched numeric digits (`[0-9]+`) for the 4th version component of Fedora CoreOS image names. Newer Fedora CoreOS images (e.g. `fedora-coreos-43-20260411-20-dev0-gcp-aarch64`) include alphanumeric build tags (e.g. `dev0`). This update allows `fedoraImage` to match alphanumeric build tags.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28424

```release-note:bug
compute: fixed permadiffs for `google_compute_disk` onFedora CoreOS images
```
