### PR TITLE
cloudsecuritycompliance: update built-in cloud control in framework test and samples [default]

### DIFF
--- a/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_deployment_org_project_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_deployment_org_project_basic.tf.tmpl
@@ -9,7 +9,7 @@ resource "google_cloud_security_compliance_framework" "{{$.PrimaryResourceId}}" 
   description  = "A Terraform description for the framework"
   
   cloud_control_details {
-    name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-require-cmek-on-bigquery-datasets"
+    name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown"
     major_revision_id = "2"
     
     parameters {
@@ -41,7 +41,7 @@ resource "google_cloud_security_compliance_framework_deployment" "{{$.PrimaryRes
     enforcement_mode = "DETECTIVE"
     
     cloud_control_details {
-      name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-require-cmek-on-bigquery-datasets"
+      name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown"
       major_revision_id = "2"
       
       parameters {

--- a/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_deployment_project_application_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_deployment_project_application_basic.tf.tmpl
@@ -18,7 +18,7 @@ resource "google_cloud_security_compliance_framework" "{{$.PrimaryResourceId}}" 
   description  = "A Terraform description for the framework"
   
   cloud_control_details {
-    name              = "projects/${data.google_project.project.number}/locations/global/cloudControls/builtin-require-cmek-on-bigquery-datasets"
+    name              = "projects/${data.google_project.project.number}/locations/global/cloudControls/builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown"
     major_revision_id = "2"
     
     parameters {
@@ -51,7 +51,7 @@ resource "google_cloud_security_compliance_framework_deployment" "{{$.PrimaryRes
     enforcement_mode = "DETECTIVE"
     
     cloud_control_details {
-      name              = "projects/${data.google_project.project.number}/locations/global/cloudControls/builtin-require-cmek-on-bigquery-datasets"
+      name              = "projects/${data.google_project.project.number}/locations/global/cloudControls/builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown"
       major_revision_id = "2"
       
       parameters {

--- a/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_org_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_org_basic.tf.tmpl
@@ -7,8 +7,8 @@ resource "google_cloud_security_compliance_framework" "{{$.PrimaryResourceId}}" 
   description  = "An Terraform description for the framework"
   
   cloud_control_details {
-		name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-assess-resource-availability"
-		major_revision_id = "2"
+    name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown"
+    major_revision_id = "2"
     
     parameters {
       name = "location"
@@ -16,45 +16,51 @@ resource "google_cloud_security_compliance_framework" "{{$.PrimaryResourceId}}" 
         string_value = "us-central1"
       }
     }
-  }
-
-    cloud_control_details {
-		name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-cmek-key-in-use-for-bigquery-table"
-		major_revision_id = "1"
-    
     parameters {
-      name = "location"
+      name = "oneof-parameter"
       parameter_value {
-        string_list_value {
-          values = ["us-central1", "us-west1"]
+        oneof_value {
+          name = "test-oneof"
+          parameter_value {
+            string_value = "test-value"
+          }
+        }
+      }
+    }
+    parameters {
+      name = "bool-parameter"
+      parameter_value {
+        oneof_value {
+          name = "bool-oneof"
+          parameter_value {
+            bool_value = true
+          }
+        }
+      }
+    }
+    parameters {
+      name = "number-parameter"
+      parameter_value {
+        oneof_value {
+          name = "number-oneof"
+          parameter_value {
+            number_value = 123.45
+          }
+        }
+      }
+    }
+    parameters {
+      name = "string-list-parameter"
+      parameter_value {
+        oneof_value {
+          name = "string-list-oneof"
+          parameter_value {
+            string_list_value {
+              values = ["value1", "value2"]
+            }
+          }
         }
       }
     }
   }
-
-  cloud_control_details {
-		name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-enable-automatic-backups-cloud-sql"
-		major_revision_id = "3"
-    
-    parameters {
-      name = "location"
-      parameter_value {
-        bool_value = true
-      }
-    }
-  }
-
-  cloud_control_details {
-		name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-require-cmek-on-bigquery-datasets"
-		major_revision_id = "2"
-    
-    parameters {
-      name = "location"
-      parameter_value {
-        number_value = 1
-      }
-    }
-  }
-
-  
 }

--- a/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_org_basic_backward.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_org_basic_backward.tf.tmpl
@@ -7,8 +7,8 @@ resource "google_cloud_security_compliance_framework" "{{$.PrimaryResourceId}}" 
   description  = "An Terraform description for the framework"
   
   cloud_control_details {
-		name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-assess-resource-availability"
-		major_revision_id = "2"
+    name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown"
+    major_revision_id = "2"
     
     parameters {
       name = "location"
@@ -16,45 +16,51 @@ resource "google_cloud_security_compliance_framework" "{{$.PrimaryResourceId}}" 
         string_value = "us-central1"
       }
     }
-  }
-
-    cloud_control_details {
-		name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-cmek-key-in-use-for-bigquery-table"
-		major_revision_id = "1"
-    
     parameters {
-      name = "location"
+      name = "oneof-parameter"
       parameter_value {
-        string_list_value {
-          values = ["us-central1", "us-west1"]
+        oneof_value {
+          name = "test-oneof"
+          parameter_value {
+            string_value = "test-value"
+          }
+        }
+      }
+    }
+    parameters {
+      name = "bool-parameter"
+      parameter_value {
+        oneof_value {
+          name = "bool-oneof"
+          parameter_value {
+            bool_value = true
+          }
+        }
+      }
+    }
+    parameters {
+      name = "number-parameter"
+      parameter_value {
+        oneof_value {
+          name = "number-oneof"
+          parameter_value {
+            number_value = 123.45
+          }
+        }
+      }
+    }
+    parameters {
+      name = "string-list-parameter"
+      parameter_value {
+        oneof_value {
+          name = "string-list-oneof"
+          parameter_value {
+            string_list_value {
+              values = ["value1", "value2"]
+            }
+          }
         }
       }
     }
   }
-
-  cloud_control_details {
-		name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-enable-automatic-backups-cloud-sql"
-		major_revision_id = "3"
-    
-    parameters {
-      name = "location"
-      parameter_value {
-        bool_value = true
-      }
-    }
-  }
-
-  cloud_control_details {
-		name              = "organizations/{{index $.TestEnvVars "org_id"}}/locations/global/cloudControls/builtin-require-cmek-on-bigquery-datasets"
-		major_revision_id = "2"
-    
-    parameters {
-      name = "location"
-      parameter_value {
-        number_value = 1
-      }
-    }
-  }
-
-  
 }

--- a/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_project_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_project_basic.tf.tmpl
@@ -8,8 +8,8 @@ resource "google_cloud_security_compliance_framework" "{{$.PrimaryResourceId}}" 
   description  = "An Terraform description for the framework"
   
   cloud_control_details {
-		name              = "projects/${data.google_project.project.number}/locations/global/cloudControls/builtin-assess-resource-availability"
-		major_revision_id = "2"
+    name              = "projects/${data.google_project.project.number}/locations/global/cloudControls/builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown"
+    major_revision_id = "2"
     
     parameters {
       name = "location"
@@ -17,45 +17,51 @@ resource "google_cloud_security_compliance_framework" "{{$.PrimaryResourceId}}" 
         string_value = "us-central1"
       }
     }
-  }
-
-    cloud_control_details {
-		name              = "projects/${data.google_project.project.number}/locations/global/cloudControls/builtin-cmek-key-in-use-for-bigquery-table"
-		major_revision_id = "1"
-    
     parameters {
-      name = "location"
+      name = "oneof-parameter"
       parameter_value {
-        string_list_value {
-          values = ["us-central1", "us-west1"]
+        oneof_value {
+          name = "test-oneof"
+          parameter_value {
+            string_value = "test-value"
+          }
+        }
+      }
+    }
+    parameters {
+      name = "bool-parameter"
+      parameter_value {
+        oneof_value {
+          name = "bool-oneof"
+          parameter_value {
+            bool_value = true
+          }
+        }
+      }
+    }
+    parameters {
+      name = "number-parameter"
+      parameter_value {
+        oneof_value {
+          name = "number-oneof"
+          parameter_value {
+            number_value = 123.45
+          }
+        }
+      }
+    }
+    parameters {
+      name = "string-list-parameter"
+      parameter_value {
+        oneof_value {
+          name = "string-list-oneof"
+          parameter_value {
+            string_list_value {
+              values = ["value1", "value2"]
+            }
+          }
         }
       }
     }
   }
-
-  cloud_control_details {
-		name              = "projects/${data.google_project.project.number}/locations/global/cloudControls/builtin-enable-automatic-backups-cloud-sql"
-		major_revision_id = "3"
-    
-    parameters {
-      name = "location"
-      parameter_value {
-        bool_value = true
-      }
-    }
-  }
-
-  cloud_control_details {
-		name              = "projects/${data.google_project.project.number}/locations/global/cloudControls/builtin-require-cmek-on-bigquery-datasets"
-		major_revision_id = "2"
-    
-    parameters {
-      name = "location"
-      parameter_value {
-        number_value = 1
-      }
-    }
-  }
-
-  
 }

--- a/mmv1/third_party/terraform/services/cloudsecuritycompliance/resource_cloud_security_compliance_framework_test.go
+++ b/mmv1/third_party/terraform/services/cloudsecuritycompliance/resource_cloud_security_compliance_framework_test.go
@@ -22,7 +22,7 @@ resource "google_cloud_security_compliance_framework" "example" {
   description  = "An Terraform description for the framework"
   
   cloud_control_details {
-		name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-assess-resource-availability"
+		name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown"
 		major_revision_id = "2"
     
     parameters {
@@ -132,8 +132,8 @@ resource "google_cloud_security_compliance_framework" "example" {
   description  = "An updated description for the framework with additional details"
   
   cloud_control_details {
-    name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-data-access-governance"
-    major_revision_id = "1"
+    name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown"
+    major_revision_id = "2"
     
     parameters {
       name = "region"
@@ -228,7 +228,7 @@ resource "google_cloud_security_compliance_framework" "example" {
   description  = "A Terraform description for the framework using organization for backward compatibility"
   
   cloud_control_details {
-		name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-assess-resource-availability"
+		name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown"
 		major_revision_id = "2"
     
     parameters {


### PR DESCRIPTION
Update built-in cloud control name to a valid control (`builtin-detective-policy-for-vertex-ai-runtime-template-idle-shutdown`) in `google_cloud_security_compliance_framework` sample templates and handwritten tests to fix nightly test failures.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28394

```release-note:none
```
