### PR TITLE
cloudsecuritycompliance: set is_set: true on string array fields in Framework [advanced]

### DIFF
--- a/mmv1/products/cloudsecuritycompliance/Framework.yaml
+++ b/mmv1/products/cloudsecuritycompliance/Framework.yaml
@@ -224,6 +224,7 @@ properties:
     output: true
     item_type:
       type: String
+    is_set: true
   - name: supportedTargetResourceTypes
     type: Array
     description: target resource types supported by the Framework.


### PR DESCRIPTION
Fixes ImportStateVerify attribute mismatch on google_cloud_security_compliance_framework caused by unordered string list returned by the API for supportedEnforcementModes. Added is_set: true to supportedEnforcementModes.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28394

```release-note:bug
cloudsecuritycompliance: fixed state drift on `supported_enforcement_modes` in `google_cloud_security_compliance_framework` resource
```
