### PR TITLE
compute: guard beta fields in FlattenSchedulingHTTP for GA builds [default]

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_http_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_http_helpers.go.tmpl
@@ -188,9 +188,9 @@ func FlattenSchedulingHTTP(resp map[string]interface{}) []map[string]interface{}
 	v_tt, _ := resp["terminationTime"].(string)
 	schedulingMap["termination_time"] = v_tt
 	if v, ok := resp["automaticRestart"]; ok { schedulingMap["automatic_restart"] = v }
+{{- if ne $.TargetVersionName "ga" }}
 	v_sgos, _ := resp["skipGuestOsShutdown"].(bool)
 	schedulingMap["skip_guest_os_shutdown"] = v_sgos
-{{- if ne $.TargetVersionName "ga" }}
 	if v, ok := resp["maintenanceInterval"]; ok { schedulingMap["maintenance_interval"] = v }
 	if v, ok := resp["hostErrorTimeoutSeconds"]; ok { schedulingMap["host_error_timeout_seconds"] = ParseIntHTTP(v) }
 {{- end }}
@@ -241,7 +241,6 @@ func FlattenSchedulingHTTP(resp map[string]interface{}) []map[string]interface{}
 		}
 		schedulingMap["graceful_shutdown"] = []map[string]interface{}{graceMap}
 	}
-{{- end }}
 
 	if pndRaw, ok := resp["preemptionNoticeDuration"]; ok && pndRaw != nil {
 		pnd := pndRaw.(map[string]interface{})
@@ -252,6 +251,7 @@ func FlattenSchedulingHTTP(resp map[string]interface{}) []map[string]interface{}
 			},
 		}
 	}
+{{- end }}
 
 	if naRaw, ok := resp["nodeAffinities"].([]interface{}); ok && naRaw != nil {
 		nodeAffinities := make([]map[string]interface{}, len(naRaw))


### PR DESCRIPTION
This is to fix an issue introduced by https://github.com/GoogleCloudPlatform/magic-modules/pull/18138

In GA builds (`TargetVersionName == "ga"`), beta-only scheduling fields such as `skip_guest_os_shutdown` and `preemption_notice_duration` are excluded from the resource schema.

`FlattenSchedulingHTTP` in `compute_instance_http_helpers.go.tmpl` was setting `skip_guest_os_shutdown` and `preemption_notice_duration` into `schedulingMap` without checking `TargetVersionName`. When `resourceComputeRegionInstanceTemplateRead` called `d.Set("scheduling", scheduling)`, this caused a schema mismatch panic because `scheduling.0.skip_guest_os_shutdown` was not present in the GA schema.

This fix wraps `skip_guest_os_shutdown` and `preemption_notice_duration` in `{{- if ne $.TargetVersionName "ga" }}` in `FlattenSchedulingHTTP`.

```release-note:bug
compute: fixed panic when setting scheduling attributes in `google_compute_region_instance_template` (ga)
```
