### PR TITLE
compute: wrap beta-only scheduling fields in FlattenSchedulingHTTP [advanced]

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_http_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_http_helpers.go.tmpl
@@ -188,9 +188,9 @@ func FlattenSchedulingHTTP(resp map[string]interface{}) []map[string]interface{}
 	v_tt, _ := resp["terminationTime"].(string)
 	schedulingMap["termination_time"] = v_tt
 	if v, ok := resp["automaticRestart"]; ok { schedulingMap["automatic_restart"] = v }
+{{- if ne $.TargetVersionName "ga" }}
 	v_sgos, _ := resp["skipGuestOsShutdown"].(bool)
 	schedulingMap["skip_guest_os_shutdown"] = v_sgos
-{{- if ne $.TargetVersionName "ga" }}
 	if v, ok := resp["maintenanceInterval"]; ok { schedulingMap["maintenance_interval"] = v }
 	if v, ok := resp["hostErrorTimeoutSeconds"]; ok { schedulingMap["host_error_timeout_seconds"] = ParseIntHTTP(v) }
 {{- end }}
@@ -243,6 +243,7 @@ func FlattenSchedulingHTTP(resp map[string]interface{}) []map[string]interface{}
 	}
 {{- end }}
 
+{{- if ne $.TargetVersionName "ga" }}
 	if pndRaw, ok := resp["preemptionNoticeDuration"]; ok && pndRaw != nil {
 		pnd := pndRaw.(map[string]interface{})
 		schedulingMap["preemption_notice_duration"] = []map[string]interface{}{
@@ -252,6 +253,7 @@ func FlattenSchedulingHTTP(resp map[string]interface{}) []map[string]interface{}
 			},
 		}
 	}
+{{- end }}
 
 	if naRaw, ok := resp["nodeAffinities"].([]interface{}); ok && naRaw != nil {
 		nodeAffinities := make([]map[string]interface{}, len(naRaw))


### PR DESCRIPTION
Wrap beta-only scheduling fields (`skip_guest_os_shutdown` and `preemption_notice_duration`) within `{{- if ne $.TargetVersionName "ga" }}` guards in `FlattenSchedulingHTTP`.

Previously, `FlattenSchedulingHTTP` unconditionally set `skip_guest_os_shutdown` and `preemption_notice_duration` in `schedulingMap`, causing a panic in GA provider read/create functions because these fields do not exist in the GA schema.

```release-note:bug
compute: fixed panic when setting scheduling fields in `google_compute_region_instance_template` GA provider
```
