### PR TITLE
Add Terraform support for Cloud Run v2 scaling controls

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -58,6 +58,28 @@ samples:
           cloud_run_service_name: 'cloudrun-service'
         ignore_read_extra:
           - 'deletion_protection'
+  - name: 'cloudrunv2_service_scaling_controls'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    steps:
+      - name: 'cloudrunv2_service_scaling_controls'
+        min_version: 'beta'
+        resource_id_vars:
+          cloud_run_service_name: 'cloudrun-service'
+        vars:
+          cpu_util: '0.75'
+          concurrency_util: '0.5'
+        ignore_read_extra:
+          - 'deletion_protection'
+      - name: 'cloudrunv2_service_scaling_controls'
+        min_version: 'beta'
+        resource_id_vars:
+          cloud_run_service_name: 'cloudrun-service'
+        vars:
+          cpu_util: '0.6'
+          concurrency_util: '0.8'
+        ignore_read_extra:
+          - 'deletion_protection'
   - name: 'cloudrunv2_service_limits'
     primary_resource_id: 'default'
     steps:
@@ -456,6 +478,16 @@ properties:
             description: |-
               Maximum number of serving instances that this resource should have. Must not be less than minimum instance count. If absent, Cloud Run will calculate
               a default value based on the project's available container instances quota in the region and specified instance size.
+          - name: 'cpuUtilization'
+            type: Double
+            min_version: 'beta'
+            description: |-
+              Determines a threshold for CPU utilization before scaling begins. Accepted values are between 0.1 and 0.95 (inclusive) or 0.0 to disable CPU utilization as threshold for scaling. CPU and concurrency scaling cannot both be disabled.
+          - name: 'concurrencyUtilization'
+            type: Double
+            min_version: 'beta'
+            description: |-
+              Determines a threshold for concurrency utilization before scaling begins. Accepted values are between 0.1 and 0.95 (inclusive) or 0.0 to disable concurrency utilization as threshold for scaling. CPU and concurrency scaling cannot both be disabled.
       - name: 'vpcAccess'
         type: NestedObject
         description: |-

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_scaling_controls.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_scaling_controls.tf.tmpl
@@ -1,0 +1,20 @@
+resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  name     = "{{index $.ResourceIdVars "cloud_run_service_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+  ingress = "INGRESS_TRAFFIC_ALL"
+  launch_stage = "BETA"
+
+  template {
+    scaling {
+      min_instance_count      = 1
+      max_instance_count      = 5
+      cpu_utilization         = {{index $.Vars "cpu_util"}}
+      concurrency_utilization = {{index $.Vars "concurrency_util"}}
+    }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+}


### PR DESCRIPTION
Expose CPU and Concurrency utilization scaling thresholds under the scaling block. Fixes b/448515376

```release-note:enhancement
cloudrunv2: added `cpu_utilization` and `concurrency_utilization` fields to `google_cloud_run_v2_service` revision scaling configuration (beta)
```
