### PR TITLE
container: suppress permadiff on private endpoint fields when IP endpoints are disabled

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2377,9 +2377,10 @@ func ResourceContainerCluster() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
-										Type:        schema.TypeBool,
-										Required:    true,
-										Description: `Whether the cluster master is accessible globally or not.`,
+										Type:             schema.TypeBool,
+										Required:         true,
+										DiffSuppressFunc: containerClusterPrivateClusterConfigSuppress,
+										Description:      `Whether the cluster master is accessible globally or not.`,
 									},
 								},
 							},
@@ -9110,8 +9111,32 @@ func containerClusterAddedScopesSuppress(k, old, new string, d *schema.ResourceD
 	return true
 }
 
+// privateClusterConfigDiffSuppressData is the subset of *schema.ResourceData read by
+// containerClusterPrivateClusterConfigSuppressLogic. Accepting an interface lets the
+// logic be unit tested with tpgresource.ResourceDiffMock.
+type privateClusterConfigDiffSuppressData interface {
+	GetChange(string) (interface{}, interface{})
+	GetOk(string) (interface{}, bool)
+}
+
 // We want to suppress diffs for empty/disabled private cluster config.
 func containerClusterPrivateClusterConfigSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return containerClusterPrivateClusterConfigSuppressLogic(k, old, new, d)
+}
+
+func containerClusterPrivateClusterConfigSuppressLogic(k, old, new string, d privateClusterConfigDiffSuppressData) bool {
+	// When control plane IP endpoints are disabled (DNS-only access), the GKE API
+	// dictates enable_private_endpoint and master_global_access_config.enabled and
+	// ignores writes to them: expandControlPlaneEndpointsConfig returns early without
+	// sending either field. flattenPrivateClusterConfig still reads them back
+	// unconditionally, so any user-configured value permanently diffs against the
+	// fixed value the API returns.
+	if containerClusterIpEndpointsDisabled(d) &&
+		(k == "private_cluster_config.0.enable_private_endpoint" ||
+			k == "private_cluster_config.0.master_global_access_config.0.enabled") {
+		return true
+	}
+
 	o, n := d.GetChange("private_cluster_config.0.enable_private_endpoint")
 	suppressEndpoint := !o.(bool) && !n.(bool)
 
@@ -9137,9 +9162,22 @@ func containerClusterPrivateClusterConfigSuppress(k, old, new string, d *schema.
 		//   && private_endpoint_subnetwork is unset in terraform (new value == "")
 		//   && private_endpoint_subnetwork is returned from resource (old value != "")
 		_, hasMasterCidr := d.GetOk("private_cluster_config.0.master_ipv4_cidr_block")
-		return (hasMasterCidr && new == "" && old != "") || tpgresource.CompareSelfLinkOrResourceName(k, old, new, d)
+		// CompareSelfLinkOrResourceName ignores its ResourceData argument.
+		return (hasMasterCidr && new == "" && old != "") || tpgresource.CompareSelfLinkOrResourceName(k, old, new, nil)
 	}
 	return false
+}
+
+// containerClusterIpEndpointsDisabled reports whether control_plane_endpoints_config
+// turns off IP access (ip_endpoints_config.enabled = false). IP endpoints are enabled by
+// default, so this is only true when the block is present and explicitly disabled.
+func containerClusterIpEndpointsDisabled(d privateClusterConfigDiffSuppressData) bool {
+	if v, ok := d.GetOk("control_plane_endpoints_config.0.ip_endpoints_config.#"); !ok || v.(int) == 0 {
+		return false
+	}
+	_, n := d.GetChange("control_plane_endpoints_config.0.ip_endpoints_config.0.enabled")
+	enabled, ok := n.(bool)
+	return ok && !enabled
 }
 
 // Autopilot clusters have preconfigured defaults: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison.

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -9112,8 +9112,8 @@ func containerClusterAddedScopesSuppress(k, old, new string, d *schema.ResourceD
 }
 
 // privateClusterConfigDiffSuppressData is the subset of *schema.ResourceData read by
-// containerClusterPrivateClusterConfigSuppressLogic. Accepting an interface lets the
-// logic be unit tested with tpgresource.ResourceDiffMock.
+// containerClusterApiDictatedPrivateEndpointField. Accepting an interface lets the logic
+// be unit tested with tpgresource.ResourceDiffMock.
 type privateClusterConfigDiffSuppressData interface {
 	GetChange(string) (interface{}, interface{})
 	GetOk(string) (interface{}, bool)
@@ -9121,19 +9121,7 @@ type privateClusterConfigDiffSuppressData interface {
 
 // We want to suppress diffs for empty/disabled private cluster config.
 func containerClusterPrivateClusterConfigSuppress(k, old, new string, d *schema.ResourceData) bool {
-	return containerClusterPrivateClusterConfigSuppressLogic(k, old, new, d)
-}
-
-func containerClusterPrivateClusterConfigSuppressLogic(k, old, new string, d privateClusterConfigDiffSuppressData) bool {
-	// When control plane IP endpoints are disabled (DNS-only access), the GKE API
-	// dictates enable_private_endpoint and master_global_access_config.enabled and
-	// ignores writes to them: expandControlPlaneEndpointsConfig returns early without
-	// sending either field. flattenPrivateClusterConfig still reads them back
-	// unconditionally, so any user-configured value permanently diffs against the
-	// fixed value the API returns.
-	if containerClusterIpEndpointsDisabled(d) &&
-		(k == "private_cluster_config.0.enable_private_endpoint" ||
-			k == "private_cluster_config.0.master_global_access_config.0.enabled") {
+	if containerClusterApiDictatedPrivateEndpointField(k, d) {
 		return true
 	}
 
@@ -9162,10 +9150,24 @@ func containerClusterPrivateClusterConfigSuppressLogic(k, old, new string, d pri
 		//   && private_endpoint_subnetwork is unset in terraform (new value == "")
 		//   && private_endpoint_subnetwork is returned from resource (old value != "")
 		_, hasMasterCidr := d.GetOk("private_cluster_config.0.master_ipv4_cidr_block")
-		// CompareSelfLinkOrResourceName ignores its ResourceData argument.
-		return (hasMasterCidr && new == "" && old != "") || tpgresource.CompareSelfLinkOrResourceName(k, old, new, nil)
+		return (hasMasterCidr && new == "" && old != "") || tpgresource.CompareSelfLinkOrResourceName(k, old, new, d)
 	}
 	return false
+}
+
+// containerClusterApiDictatedPrivateEndpointField reports whether k is a
+// private_cluster_config field whose value the GKE API dictates rather than accepting from
+// the user. With control plane IP endpoints disabled (DNS-only access),
+// expandControlPlaneEndpointsConfig returns early without sending
+// enable_private_endpoint or master_global_access_config.enabled, while
+// flattenPrivateClusterConfig still reads both back unconditionally, so any configured
+// value permanently diffs against the fixed value the API returns.
+func containerClusterApiDictatedPrivateEndpointField(k string, d privateClusterConfigDiffSuppressData) bool {
+	if k != "private_cluster_config.0.enable_private_endpoint" &&
+		k != "private_cluster_config.0.master_global_access_config.0.enabled" {
+		return false
+	}
+	return containerClusterIpEndpointsDisabled(d)
 }
 
 // containerClusterIpEndpointsDisabled reports whether control_plane_endpoints_config

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -773,3 +773,122 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 		})
 	}
 }
+
+func TestContainerClusterPrivateClusterConfigDiffSuppress(t *testing.T) {
+	t.Parallel()
+
+	const (
+		enablePrivateEndpointKey = "private_cluster_config.0.enable_private_endpoint"
+		enablePrivateNodesKey    = "private_cluster_config.0.enable_private_nodes"
+		masterGlobalAccessKey    = "private_cluster_config.0.master_global_access_config.0.enabled"
+		ipEndpointsCountKey      = "control_plane_endpoints_config.0.ip_endpoints_config.#"
+		ipEndpointsEnabledKey    = "control_plane_endpoints_config.0.ip_endpoints_config.0.enabled"
+	)
+
+	cases := map[string]struct {
+		key              string
+		old              string
+		new              string
+		before           map[string]interface{}
+		after            map[string]interface{}
+		expectedSuppress bool
+	}{
+		// Reproduces hashicorp/terraform-provider-google#27901: with IP endpoints
+		// disabled the API forces enable_private_endpoint to true, so a configured
+		// value of false would permanently diff. The diff must be suppressed.
+		"enable_private_endpoint permadiff with ip endpoints disabled - suppress": {
+			key: enablePrivateEndpointKey,
+			old: "true",
+			new: "false",
+			before: map[string]interface{}{
+				enablePrivateEndpointKey: true,
+				enablePrivateNodesKey:    true,
+			},
+			after: map[string]interface{}{
+				enablePrivateEndpointKey: false,
+				enablePrivateNodesKey:    true,
+				ipEndpointsCountKey:      1,
+				ipEndpointsEnabledKey:    false,
+			},
+			expectedSuppress: true,
+		},
+		// Reproduces the second permadiff from #27901: with IP endpoints disabled the
+		// API forces master_global_access_config.enabled to false.
+		"master_global_access_config permadiff with ip endpoints disabled - suppress": {
+			key: masterGlobalAccessKey,
+			old: "false",
+			new: "true",
+			before: map[string]interface{}{
+				enablePrivateEndpointKey: true,
+				enablePrivateNodesKey:    true,
+			},
+			after: map[string]interface{}{
+				enablePrivateEndpointKey: false,
+				enablePrivateNodesKey:    true,
+				ipEndpointsCountKey:      1,
+				ipEndpointsEnabledKey:    false,
+			},
+			expectedSuppress: true,
+		},
+		// With IP endpoints enabled, a real change to enable_private_endpoint must
+		// still surface as a diff.
+		"enable_private_endpoint change with ip endpoints enabled - do not suppress": {
+			key: enablePrivateEndpointKey,
+			old: "true",
+			new: "false",
+			before: map[string]interface{}{
+				enablePrivateEndpointKey: true,
+				enablePrivateNodesKey:    true,
+			},
+			after: map[string]interface{}{
+				enablePrivateEndpointKey: false,
+				enablePrivateNodesKey:    true,
+			},
+			expectedSuppress: false,
+		},
+		// With IP endpoints enabled, a real change to master_global_access_config must
+		// still surface as a diff.
+		"master_global_access_config change with ip endpoints enabled - do not suppress": {
+			key: masterGlobalAccessKey,
+			old: "false",
+			new: "true",
+			before: map[string]interface{}{
+				enablePrivateEndpointKey: false,
+				enablePrivateNodesKey:    false,
+			},
+			after: map[string]interface{}{
+				enablePrivateEndpointKey: false,
+				enablePrivateNodesKey:    false,
+			},
+			expectedSuppress: false,
+		},
+		// Pre-existing behavior: removing an all-disabled private_cluster_config block
+		// is suppressed.
+		"private_cluster_config block all disabled - suppress": {
+			key: "private_cluster_config.#",
+			old: "1",
+			new: "0",
+			before: map[string]interface{}{
+				enablePrivateEndpointKey: false,
+				enablePrivateNodesKey:    false,
+			},
+			after: map[string]interface{}{
+				enablePrivateEndpointKey: false,
+				enablePrivateNodesKey:    false,
+			},
+			expectedSuppress: true,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			d := &tpgresource.ResourceDiffMock{
+				Before: tc.before,
+				After:  tc.after,
+			}
+			if got := containerClusterPrivateClusterConfigSuppressLogic(tc.key, tc.old, tc.new, d); got != tc.expectedSuppress {
+				t.Errorf("%s: expected suppress to be %v, but was %v", tn, tc.expectedSuppress, got)
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -774,7 +774,7 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 	}
 }
 
-func TestContainerClusterPrivateClusterConfigDiffSuppress(t *testing.T) {
+func TestContainerClusterApiDictatedPrivateEndpointField(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -786,108 +786,71 @@ func TestContainerClusterPrivateClusterConfigDiffSuppress(t *testing.T) {
 	)
 
 	cases := map[string]struct {
-		key              string
-		old              string
-		new              string
-		before           map[string]interface{}
-		after            map[string]interface{}
-		expectedSuppress bool
+		key string
+		// planned holds the new side of the diff; only new values are read.
+		planned  map[string]interface{}
+		expected bool
 	}{
 		// Reproduces hashicorp/terraform-provider-google#27901: with IP endpoints
 		// disabled the API forces enable_private_endpoint to true, so a configured
-		// value of false would permanently diff. The diff must be suppressed.
-		"enable_private_endpoint permadiff with ip endpoints disabled - suppress": {
+		// value of false would permanently diff.
+		"enable_private_endpoint with ip endpoints disabled": {
 			key: enablePrivateEndpointKey,
-			old: "true",
-			new: "false",
-			before: map[string]interface{}{
-				enablePrivateEndpointKey: true,
-				enablePrivateNodesKey:    true,
-			},
-			after: map[string]interface{}{
+			planned: map[string]interface{}{
 				enablePrivateEndpointKey: false,
-				enablePrivateNodesKey:    true,
 				ipEndpointsCountKey:      1,
 				ipEndpointsEnabledKey:    false,
 			},
-			expectedSuppress: true,
+			expected: true,
 		},
-		// Reproduces the second permadiff from #27901: with IP endpoints disabled the
-		// API forces master_global_access_config.enabled to false.
-		"master_global_access_config permadiff with ip endpoints disabled - suppress": {
+		// The second permadiff from #27901: with IP endpoints disabled the API forces
+		// master_global_access_config.enabled to false.
+		"master_global_access_config with ip endpoints disabled": {
 			key: masterGlobalAccessKey,
-			old: "false",
-			new: "true",
-			before: map[string]interface{}{
-				enablePrivateEndpointKey: true,
-				enablePrivateNodesKey:    true,
+			planned: map[string]interface{}{
+				masterGlobalAccessKey: true,
+				ipEndpointsCountKey:   1,
+				ipEndpointsEnabledKey: false,
 			},
-			after: map[string]interface{}{
-				enablePrivateEndpointKey: false,
-				enablePrivateNodesKey:    true,
-				ipEndpointsCountKey:      1,
-				ipEndpointsEnabledKey:    false,
-			},
-			expectedSuppress: true,
+			expected: true,
 		},
-		// With IP endpoints enabled, a real change to enable_private_endpoint must
-		// still surface as a diff.
-		"enable_private_endpoint change with ip endpoints enabled - do not suppress": {
+		// With IP endpoints enabled the API honors both fields, so their diffs must
+		// reach the regular suppression logic.
+		"enable_private_endpoint with ip endpoints enabled": {
 			key: enablePrivateEndpointKey,
-			old: "true",
-			new: "false",
-			before: map[string]interface{}{
-				enablePrivateEndpointKey: true,
-				enablePrivateNodesKey:    true,
-			},
-			after: map[string]interface{}{
+			planned: map[string]interface{}{
 				enablePrivateEndpointKey: false,
-				enablePrivateNodesKey:    true,
+				ipEndpointsCountKey:      1,
+				ipEndpointsEnabledKey:    true,
 			},
-			expectedSuppress: false,
+			expected: false,
 		},
-		// With IP endpoints enabled, a real change to master_global_access_config must
-		// still surface as a diff.
-		"master_global_access_config change with ip endpoints enabled - do not suppress": {
+		// IP endpoints are enabled by default, so an absent block dictates nothing.
+		"master_global_access_config without control_plane_endpoints_config": {
 			key: masterGlobalAccessKey,
-			old: "false",
-			new: "true",
-			before: map[string]interface{}{
-				enablePrivateEndpointKey: false,
-				enablePrivateNodesKey:    false,
+			planned: map[string]interface{}{
+				masterGlobalAccessKey: true,
 			},
-			after: map[string]interface{}{
-				enablePrivateEndpointKey: false,
-				enablePrivateNodesKey:    false,
-			},
-			expectedSuppress: false,
+			expected: false,
 		},
-		// Pre-existing behavior: removing an all-disabled private_cluster_config block
-		// is suppressed.
-		"private_cluster_config block all disabled - suppress": {
-			key: "private_cluster_config.#",
-			old: "1",
-			new: "0",
-			before: map[string]interface{}{
-				enablePrivateEndpointKey: false,
-				enablePrivateNodesKey:    false,
+		// Only the two fields the API overrides are affected; the rest of
+		// private_cluster_config stays user-controlled.
+		"unaffected private_cluster_config field with ip endpoints disabled": {
+			key: enablePrivateNodesKey,
+			planned: map[string]interface{}{
+				enablePrivateNodesKey: false,
+				ipEndpointsCountKey:   1,
+				ipEndpointsEnabledKey: false,
 			},
-			after: map[string]interface{}{
-				enablePrivateEndpointKey: false,
-				enablePrivateNodesKey:    false,
-			},
-			expectedSuppress: true,
+			expected: false,
 		},
 	}
 
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			d := &tpgresource.ResourceDiffMock{
-				Before: tc.before,
-				After:  tc.after,
-			}
-			if got := containerClusterPrivateClusterConfigSuppressLogic(tc.key, tc.old, tc.new, d); got != tc.expectedSuppress {
-				t.Errorf("%s: expected suppress to be %v, but was %v", tn, tc.expectedSuppress, got)
+			d := &tpgresource.ResourceDiffMock{After: tc.planned}
+			if got := containerClusterApiDictatedPrivateEndpointField(tc.key, d); got != tc.expected {
+				t.Errorf("%s: expected %v, but was %v", tn, tc.expected, got)
 			}
 		})
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -16918,6 +16918,20 @@ func TestAccContainerCluster_disableControlPlaneIP(t *testing.T) {
         ImportStateVerify: true,
         ImportStateVerifyIgnore: []string{"deletion_protection"},
       },
+      {
+        // With IP endpoints disabled, the API dictates private_cluster_config:
+        // enable_private_endpoint is forced to true and master_global_access is
+        // forced to disabled. The config deliberately sets the opposite values,
+        // so this step fails with a non-empty plan unless diffs on those
+        // API-dictated fields are suppressed.
+        Config: testAccContainerCluster_ControlPlaneIPdisabledWithPrivateClusterConfig(clusterName, networkName, subnetworkName),
+      },
+      {
+        ResourceName:      "google_container_cluster.primary",
+        ImportState:       true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"deletion_protection"},
+      },
     },
   })
 }
@@ -16939,6 +16953,36 @@ resource "google_container_cluster" "primary" {
     }
     dns_endpoint_config {
       allow_external_traffic = true
+    }
+  }
+}
+`, clusterName, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_ControlPlaneIPdisabledWithPrivateClusterConfig(clusterName, networkName, subnetworkName string) string {
+        return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  network            = "%s"
+  subnetwork         = "%s"
+
+  deletion_protection = false
+
+  control_plane_endpoints_config {
+    ip_endpoints_config {
+      enabled = false
+    }
+    dns_endpoint_config {
+      allow_external_traffic = true
+    }
+  }
+
+  private_cluster_config {
+    enable_private_endpoint = false
+    master_global_access_config {
+      enabled = true
     }
   }
 }


### PR DESCRIPTION
When `control_plane_endpoints_config.ip_endpoints_config.enabled` is `false` (DNS-only access), the GKE API dictates `private_cluster_config.enable_private_endpoint` and `private_cluster_config.master_global_access_config.enabled` and ignores writes to them: the expander returns early without sending either field. The flattener still reads the API's fixed values back into state, so any configured value produced a permanent plan diff that never converged after apply.

This suppresses the diff on both fields when IP endpoints are disabled, and wires the existing private-cluster-config diff suppressor onto `master_global_access_config.enabled`. The suppression logic is extracted into a helper accepting an interface so it can be unit tested with `tpgresource.ResourceDiffMock`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27901.

```release-note:bug
container: fixed a permadiff on `enable_private_endpoint` and `master_global_access_config.enabled` in `google_container_cluster` when `control_plane_endpoints_config.ip_endpoints_config.enabled` is set to `false`
```
