### PR TITLE
memorystore: document TOKEN_AUTH as a google-beta-only authorization_mode value

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -282,6 +282,8 @@ properties:
       Optional. Immutable. Authorization mode of the instance. Possible values:
        AUTH_DISABLED
       IAM_AUTH
+
+      TOKEN_AUTH is also supported, but only available in the google-beta provider.
     immutable: true
     default_from_api: true
   - name: transitEncryptionMode

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -281,7 +281,7 @@ properties:
     description: |-
       Optional. Immutable. Authorization mode of the instance. Possible values:
        AUTH_DISABLED
-      IAM_AUTH
+      IAM_AUTH.
 
       TOKEN_AUTH is also supported, but only available in the google-beta provider.
     immutable: true


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27309.

`authorization_mode` on `google_memorystore_instance` has no client-side enum validation, so this is a documentation-only change to the field's description.

I verified `TOKEN_AUTH` is currently only accepted by the beta (v1beta) API surface, not GA (v1):
- `gcloud memorystore instances create --authorization-mode=token-auth` (GA track) is rejected client-side: `Invalid choice: 'token-auth'. Valid choices are [auth-disabled, iam-auth].`
- `gcloud beta memorystore instances create --authorization-mode=token-auth` (beta track) passes both client-side and server-side validation — a real create request against a test project got all the way to a running operation and only failed on an unrelated (intentionally invalid) network field.

So the description now notes `TOKEN_AUTH` is only available via the `google-beta` provider, matching the existing convention for beta-only capabilities documented on otherwise-GA fields (e.g. `compute/BackendService.yaml`'s "Currently self-managed internal load balancing is only available in beta.").

```release-note:enhancement
memorystore: documented `TOKEN_AUTH` as a `google-beta`-only value for `authorization_mode` field on `google_memorystore_instance` resource
```
