### PR TITLE
compute: promote mirror_percent in url map request_mirror_policy to GA

### DIFF
--- a/mmv1/products/compute/RegionUrlMap.yaml
+++ b/mmv1/products/compute/RegionUrlMap.yaml
@@ -208,10 +208,8 @@ samples:
           home_region_backend_service_name: '"home" + randomSuffix'
   - name: 'region_url_map_default_mirror_percent'
     primary_resource_id: 'regionurlmap'
-    min_version: 'beta'
     steps:
       - name: 'region_url_map_default_mirror_percent'
-        min_version: 'beta'
         resource_id_vars:
           region_url_map_name: 'regionurlmap'
           home_backend_service_name: 'home'
@@ -226,10 +224,8 @@ samples:
           mirror_backend_service_name: '"mirror" + randomSuffix'
   - name: 'region_url_map_path_matcher_default_mirror_percent'
     primary_resource_id: 'regionurlmap'
-    min_version: 'beta'
     steps:
       - name: 'region_url_map_path_matcher_default_mirror_percent'
-        min_version: 'beta'
         resource_id_vars:
           region_url_map_name: 'regionurlmap'
           home_backend_service_name: 'home'
@@ -244,10 +240,8 @@ samples:
           mirror_backend_service_name: '"mirror" + randomSuffix'
   - name: 'region_url_map_path_rule_mirror_percent'
     primary_resource_id: 'regionurlmap'
-    min_version: 'beta'
     steps:
       - name: 'region_url_map_path_rule_mirror_percent'
-        min_version: 'beta'
         resource_id_vars:
           region_url_map_name: 'regionurlmap'
           home_backend_service_name: 'home'
@@ -262,10 +256,8 @@ samples:
           mirror_backend_service_name: '"mirror" + randomSuffix'
   - name: 'region_url_map_route_rule_mirror_percent'
     primary_resource_id: 'regionurlmap'
-    min_version: 'beta'
     steps:
       - name: 'region_url_map_route_rule_mirror_percent'
-        min_version: 'beta'
         resource_id_vars:
           region_url_map_name: 'regionurlmap'
           home_backend_service_name: 'home'
@@ -932,7 +924,6 @@ properties:
                         resource: 'RegionBackendService'
                         imports: 'selfLink'
                       - name: 'mirrorPercent'
-                        min_version: beta
                         type: Double
                         description: |
                           The percentage of requests to be mirrored to backendService.
@@ -1402,7 +1393,6 @@ properties:
                         resource: 'RegionBackendService'
                         imports: 'selfLink'
                       - name: 'mirrorPercent'
-                        min_version: beta
                         type: Double
                         description: |
                           The percentage of requests to be mirrored to backendService.
@@ -2017,7 +2007,6 @@ properties:
                   resource: 'BackendService'
                   imports: 'selfLink'
                 - name: 'mirrorPercent'
-                  min_version: beta
                   type: Double
                   description: |
                     The percentage of requests to be mirrored to backendService.
@@ -2504,7 +2493,6 @@ properties:
             resource: 'RegionBackendService'
             imports: 'selfLink'
           - name: 'mirrorPercent'
-            min_version: beta
             type: Double
             description: |
               The percentage of requests to be mirrored to backendService.

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -142,10 +142,8 @@ samples:
           default_backend_service_name: '"default" + randomSuffix'
   - name: 'url_map_default_mirror_percent'
     primary_resource_id: 'urlmap'
-    min_version: 'beta'
     steps:
       - name: 'url_map_default_mirror_percent'
-        min_version: 'beta'
         resource_id_vars:
           url_map_name: 'urlmap'
           home_backend_service_name: 'home'
@@ -160,10 +158,8 @@ samples:
           mirror_backend_service_name: '"mirror" + randomSuffix'
   - name: 'url_map_path_matcher_default_mirror_percent'
     primary_resource_id: 'urlmap'
-    min_version: 'beta'
     steps:
       - name: 'url_map_path_matcher_default_mirror_percent'
-        min_version: 'beta'
         resource_id_vars:
           url_map_name: 'urlmap'
           home_backend_service_name: 'home'
@@ -204,10 +200,8 @@ samples:
           backend_service_name: '"home" + randomSuffix'
   - name: 'url_map_path_rule_mirror_percent'
     primary_resource_id: 'urlmap'
-    min_version: 'beta'
     steps:
       - name: 'url_map_path_rule_mirror_percent'
-        min_version: 'beta'
         resource_id_vars:
           url_map_name: 'urlmap'
           home_backend_service_name: 'home'
@@ -222,10 +216,8 @@ samples:
           mirror_backend_service_name: '"mirror" + randomSuffix'
   - name: 'url_map_route_rule_mirror_percent'
     primary_resource_id: 'urlmap'
-    min_version: 'beta'
     steps:
       - name: 'url_map_route_rule_mirror_percent'
-        min_version: 'beta'
         resource_id_vars:
           url_map_name: 'urlmap'
           home_backend_service_name: 'home'
@@ -915,7 +907,6 @@ properties:
                         resource: 'BackendService'
                         imports: 'selfLink'
                       - name: 'mirrorPercent'
-                        min_version: beta
                         type: Double
                         description: |
                           The percentage of requests to be mirrored to backendService.
@@ -1976,7 +1967,6 @@ properties:
                         resource: 'BackendService'
                         imports: 'selfLink'
                       - name: 'mirrorPercent'
-                        min_version: beta
                         type: Double
                         description: |
                           The percentage of requests to be mirrored to backendService.
@@ -3006,7 +2996,6 @@ properties:
                   resource: 'BackendService'
                   imports: 'selfLink'
                 - name: 'mirrorPercent'
-                  min_version: beta
                   type: Double
                   is_missing_in_cai: true
                   description: |
@@ -3942,7 +3931,6 @@ properties:
             resource: 'BackendService'
             imports: 'selfLink'
           - name: 'mirrorPercent'
-            min_version: beta
             is_missing_in_cai: true
             type: Double
             description: |

--- a/mmv1/templates/terraform/samples/services/compute/region_url_map_default_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_url_map_default_mirror_percent.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_region_url_map" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "region_url_map_name"}}"
   description = "Test for default route action mirror percent"
@@ -25,7 +24,6 @@ resource "google_compute_region_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_region_backend_service" "home" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "home_backend_service_name"}}"
   port_name   = "http"
@@ -37,7 +35,6 @@ resource "google_compute_region_backend_service" "home" {
 }
 
 resource "google_compute_region_backend_service" "mirror" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "mirror_backend_service_name"}}"
   port_name   = "http"
@@ -49,7 +46,6 @@ resource "google_compute_region_backend_service" "mirror" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = google-beta
   region   = "us-central1"
   name     = "{{index $.ResourceIdVars "region_health_check_name"}}"
   http_health_check {

--- a/mmv1/templates/terraform/samples/services/compute/region_url_map_path_matcher_default_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_url_map_path_matcher_default_mirror_percent.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_region_url_map" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "region_url_map_name"}}"
   description = "Test for default route action mirror percent"
@@ -25,7 +24,6 @@ resource "google_compute_region_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_region_backend_service" "home" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "home_backend_service_name"}}"
   port_name   = "http"
@@ -37,7 +35,6 @@ resource "google_compute_region_backend_service" "home" {
 }
 
 resource "google_compute_region_backend_service" "mirror" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "mirror_backend_service_name"}}"
   port_name   = "http"
@@ -49,7 +46,6 @@ resource "google_compute_region_backend_service" "mirror" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = google-beta
   region   = "us-central1"
   name     = "{{index $.ResourceIdVars "region_health_check_name"}}"
   http_health_check {

--- a/mmv1/templates/terraform/samples/services/compute/region_url_map_path_rule_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_url_map_path_rule_mirror_percent.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_region_url_map" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "region_url_map_name"}}"
   description = "Test for path matcher default route action mirror percent"
@@ -25,7 +24,6 @@ resource "google_compute_region_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_region_backend_service" "home" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "home_backend_service_name"}}"
   port_name   = "http"
@@ -37,7 +35,6 @@ resource "google_compute_region_backend_service" "home" {
 }
 
 resource "google_compute_region_backend_service" "mirror" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "mirror_backend_service_name"}}"
   port_name   = "http"
@@ -49,7 +46,6 @@ resource "google_compute_region_backend_service" "mirror" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = google-beta 
   region   = "us-central1"
   name     = "{{index $.ResourceIdVars "region_health_check_name"}}"
   http_health_check {

--- a/mmv1/templates/terraform/samples/services/compute/region_url_map_route_rule_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_url_map_route_rule_mirror_percent.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_region_url_map" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "region_url_map_name"}}"
   description = "Test for path rule route action mirror percent"
@@ -29,7 +28,6 @@ resource "google_compute_region_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_region_backend_service" "home" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "home_backend_service_name"}}"
   port_name   = "http"
@@ -41,7 +39,6 @@ resource "google_compute_region_backend_service" "home" {
 }
 
 resource "google_compute_region_backend_service" "mirror" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "{{index $.ResourceIdVars "mirror_backend_service_name"}}"
   port_name   = "http"
@@ -53,7 +50,6 @@ resource "google_compute_region_backend_service" "mirror" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = google-beta
   region   = "us-central1"
   name     = "{{index $.ResourceIdVars "region_health_check_name"}}"
   http_health_check {

--- a/mmv1/templates/terraform/samples/services/compute/url_map_default_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/url_map_default_mirror_percent.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "url_map_name"}}"
   description = "Test for default route action mirror percent"
   
@@ -24,7 +23,6 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "home" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "home_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -35,7 +33,6 @@ resource "google_compute_backend_service" "home" {
 }
 
 resource "google_compute_backend_service" "mirror" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "mirror_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -46,7 +43,6 @@ resource "google_compute_backend_service" "mirror" {
 }
 
 resource "google_compute_health_check" "default" {
-  provider    = google-beta
   name               = "{{index $.ResourceIdVars "health_check_name"}}"
   http_health_check {
     port = 80

--- a/mmv1/templates/terraform/samples/services/compute/url_map_path_matcher_default_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/url_map_path_matcher_default_mirror_percent.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "url_map_name"}}"
   description = "Test for default route action mirror percent"
   
@@ -24,7 +23,6 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "home" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "home_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -35,7 +33,6 @@ resource "google_compute_backend_service" "home" {
 }
 
 resource "google_compute_backend_service" "mirror" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "mirror_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -46,7 +43,6 @@ resource "google_compute_backend_service" "mirror" {
 }
 
 resource "google_compute_health_check" "default" {
-  provider = google-beta
   name               = "{{index $.ResourceIdVars "health_check_name"}}"
   http_health_check {
     port = 80

--- a/mmv1/templates/terraform/samples/services/compute/url_map_path_rule_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/url_map_path_rule_mirror_percent.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "url_map_name"}}"
   description = "Test for path matcher default route action mirror percent"
   
@@ -24,7 +23,6 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "home" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "home_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -35,7 +33,6 @@ resource "google_compute_backend_service" "home" {
 }
 
 resource "google_compute_backend_service" "mirror" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "mirror_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -46,7 +43,6 @@ resource "google_compute_backend_service" "mirror" {
 }
 
 resource "google_compute_health_check" "default" {
-  provider    = google-beta 
   name               = "{{index $.ResourceIdVars "health_check_name"}}"
   http_health_check {
     port = 80

--- a/mmv1/templates/terraform/samples/services/compute/url_map_route_rule_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/url_map_route_rule_mirror_percent.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "url_map_name"}}"
   description = "Test for path rule route action mirror percent"
 
@@ -28,7 +27,6 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "home" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "home_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -39,7 +37,6 @@ resource "google_compute_backend_service" "home" {
 }
 
 resource "google_compute_backend_service" "mirror" {
-  provider    = google-beta
   name        = "{{index $.ResourceIdVars "mirror_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -50,7 +47,6 @@ resource "google_compute_backend_service" "mirror" {
 }
 
 resource "google_compute_health_check" "default" {
-  provider = google-beta
   name               = "{{index $.ResourceIdVars "health_check_name"}}"
   http_health_check {
     port = 80


### PR DESCRIPTION
## Summary

`mirrorPercent` in `RequestMirrorPolicy` is available in the Compute **v1 (GA)** API, but the provider gates the corresponding `mirror_percent` field to `google-beta` only in both `google_compute_url_map` and `google_compute_region_url_map`.

Evidence it is GA — the v1 discovery document defines it directly on the shared `RequestMirrorPolicy` schema (referenced by `HttpRouteAction`, used by both global and regional URL maps):

```json
// https://www.googleapis.com/discovery/v1/apis/compute/v1/rest
"RequestMirrorPolicy": {
  "properties": {
    "mirrorPercent": { "type": "number", "format": "double", "description": "The percentage of requests to be mirrored to `backend_service`." },
    "backendService": { "type": "string" }
  }
}
```

REST reference: https://cloud.google.com/compute/docs/reference/rest/v1/urlMaps

The field was originally added as beta-only in #13974 (global) and #14493 (regional); this promotes it to GA.

## Changes

- Remove `min_version: beta` from all four `mirrorPercent` field definitions in each of `UrlMap.yaml` and `RegionUrlMap.yaml` (`default_route_action`, path-matcher `default_route_action`, path-rule `route_action`, route-rule `route_action`).
- Remove `min_version: 'beta'` from the corresponding `*_mirror_percent` examples.
- Drop the `google-beta` provider bindings from those example configs so they run against the GA provider. All resources used are GA.

Other unrelated beta gating in these files is left untouched.

## Release Note

```release-note:enhancement
compute: promoted `mirror_percent` in `request_mirror_policy` to GA for `google_compute_url_map` and `google_compute_region_url_map`
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)