### PR TITLE
Clarify single field index management in Firestore docs

### DIFF
--- a/mmv1/products/firestore/Field.yaml
+++ b/mmv1/products/firestore/Field.yaml
@@ -17,6 +17,8 @@ description: |
   Represents a single field in the database.
   Fields are grouped by their "Collection Group", which represent all collections
   in the database with the same id.
+
+  In Standard edition databases, single field indexes are managed using the `google_firestore_field` resource. In Enterprise edition databases, they are managed using the `google_firestore_index` resource.
 references:
   guides:
     Official Documentation: https://cloud.google.com/firestore/docs/query-data/indexing

--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -16,8 +16,8 @@ name: 'Index'
 description: |
   Cloud Firestore indexes enable simple and complex queries against documents in a database.
    Firestore Native, Firestore with MongoDB compatibility and Datastore Mode indexes are all supported.
-   This resource manages composite indexes and not single field indexes.
-   To manage single field indexes, use the `google_firestore_field` resource instead.
+   In Enterprise edition databases, this resource manages both single field and composite indexes.
+   In Standard edition databases, single field indexes are managed using the `google_firestore_field` resource instead.
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/firestore/docs/query-data/indexing'
@@ -228,12 +228,13 @@ properties:
   - name: 'fields'
     type: Array
     description: |
-      The fields supported by this index. The last non-stored field entry is
-      always for the field path `__name__`. If, on creation, `__name__` was not
-      specified as the last field, it will be added automatically with the same
-      direction as that of the last field defined. If the final field in a
-      composite index is not directional, the `__name__` will be ordered
-      `"ASCENDING"` (unless explicitly specified otherwise).
+      The field(s) supported by this index. Indexes with the `ANY_API` `api_scope` in Standard
+      edition databases have special behavior with respect to the `__name__` field. In these
+      indexes, the last non-stored field entry is always for the field path `__name__`. If, on
+      creation, `__name__` was not specified as the last field, it will be added automatically
+      with the same direction as that of the last field defined. If the final field in an
+      index is not directional, the `__name__` will be ordered `"ASCENDING"` (unless explicitly
+      specified otherwise).
     required: true
     diff_suppress_func: 'firestoreIFieldsDiffSuppress'
     item_type:


### PR DESCRIPTION
```release-note:note
firestore: clarified which resource to use for which kind of index in Standard and Enterprise editions
```
