### PR TITLE
Exclude .agents/ directory from provider cleanup

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -102,7 +102,7 @@ clean-provider: check_safe_build
 				echo "---> Downloading Go module dependencies... (Ensures tools like gofmt can find relevant code)" && \
 				go mod download && \
 				echo "---> Finding tracked files to remove..." && \
-				git ls-files | grep -v -E '(^\.git|^\.changelog|^\.travis\.yml$$|^\.golangci\.yml$$|^CHANGELOG\.md$$|^CHANGELOG_v.*\.md$$|^GNUmakefile$$|docscheck\.sh$$|^\.whitesource$$|^LICENSE$$|^CODEOWNERS$$|^README\.md$$|^\.go-version$$|^\.hashibot\.hcl$$|^go\.mod$$|^go\.sum$$|^examples|^scripts/)' | xargs -r git rm -f -q && \
+				git ls-files | grep -v -E '(^\.git|^\.changelog|^\.agents/|^\.travis\.yml$$|^\.golangci\.yml$$|^CHANGELOG\.md$$|^CHANGELOG_v.*\.md$$|^GNUmakefile$$|docscheck\.sh$$|^\.whitesource$$|^LICENSE$$|^CODEOWNERS$$|^README\.md$$|^\.go-version$$|^\.hashibot\.hcl$$|^go\.mod$$|^go\.sum$$|^examples|^scripts/)' | xargs -r git rm -f -q && \
 				echo "---> Unstaging changes with git reset..." && \
 				git reset -q && \
 				echo "---> clean-provider actions finished. Changes have been unstaged."; \


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR adds ^\.agents/ to the provider cleanup exclusion pattern in GNUmakefile so the downstream generator doesn't delete release workflows and scripts. 

Recently, @ScottSuarez 's original PRs introducing the prepare release skills (GA [#28443](https://github.com/hashicorp/terraform-provider-google/pull/28443) / Beta [#12758](https://github.com/hashicorp/terraform-provider-google-beta/pull/12758)) were immediately clobbered and deleted.

PRs to re-introduce the release skills:
https://github.com/hashicorp/terraform-provider-google/pull/28470
https://github.com/hashicorp/terraform-provider-google-beta/pull/12772


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
