### PR TITLE
`cloudrunv2`: permadiff fix - set `template.scaling.maxInstanceCount` to `default_from_api: true`

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -453,6 +453,7 @@ properties:
               Minimum number of serving instances that this resource should have. Defaults to 0. Must not be greater than maximum instance count.
           - name: 'maxInstanceCount'
             type: Integer
+            default_from_api: true
             description: |-
               Maximum number of serving instances that this resource should have. Must not be less than minimum instance count. If absent, Cloud Run will calculate
               a default value based on the project's available container instances quota in the region and specified instance size.

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -2078,9 +2078,6 @@ resource "google_cloud_run_v2_service" "default" {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
-    scaling {
-      min_instance_count = 0
-    }
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -2033,3 +2033,57 @@ resource "google_cloud_run_v2_service" "default" {
 }
 `, context)
 }
+
+// TestAccCloudRunV2Service_cloudrunv2ServiceMaxInstanceCountNoPermadiff is a regression test for
+// https://github.com/GoogleCloudPlatform/magic-modules/pull/18394.
+// When template.scaling.max_instance_count is not set, the API returns a computed default value.
+// Prior to the fix, the provider read that value as 0 on the next plan, producing a perpetual diff.
+func TestAccCloudRunV2Service_cloudrunv2ServiceMaxInstanceCountNoPermadiff(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudRunV2ServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Create the service without an explicit max_instance_count so the API
+				// fills in its own default value.
+				Config: testAccCloudRunV2Service_cloudrunv2ServiceWithoutMaxInstanceCount(context),
+			},
+			{
+				// Re-apply the same config. Expect no changes (empty plan) to prove there
+				// is no permadiff caused by the API-populated max_instance_count default.
+				Config: testAccCloudRunV2Service_cloudrunv2ServiceWithoutMaxInstanceCount(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceWithoutMaxInstanceCount(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name                = "tf-test-cloudrun-service%{random_suffix}"
+  location            = "us-central1"
+  deletion_protection = false
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+    scaling {
+      min_instance_count = 0
+    }
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -2056,14 +2056,12 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceMaxInstanceCountNoPermadiff(t *te
 				Config: testAccCloudRunV2Service_cloudrunv2ServiceWithoutMaxInstanceCount(context),
 			},
 			{
-				// Re-apply the same config. Expect no changes (empty plan) to prove there
-				// is no permadiff caused by the API-populated max_instance_count default.
-				Config: testAccCloudRunV2Service_cloudrunv2ServiceWithoutMaxInstanceCount(context),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
+				// Plan-only step against the same config. After the first apply the API has
+				// populated max_instance_count with a computed default. Without
+				// default_from_api: true the provider would produce a diff (0 → <api-value>),
+				// causing this step to fail via ExpectNonEmptyPlan defaulting to false.
+				Config:   testAccCloudRunV2Service_cloudrunv2ServiceWithoutMaxInstanceCount(context),
+				PlanOnly: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Part of https://github.com/hashicorp/terraform-provider-google/issues/20399
reimplementing of https://github.com/GoogleCloudPlatform/magic-modules/pull/14971

Initially this wasn't merged due to some uncertainties surrounding the expected values that could be set by the API for `maxInstanceCount`. Though from looking through past PRs we get the following on how values are calculated for `maxinstanceCount`:

[PR](https://github.com/hashicorp/terraform-provider-google/issues/18969#issuecomment-2372221566) Comment:
> Cloud Run has a dynamic default max instances, based on the user's available quota in the region and specified instance size which makes doing accurate checks in the client rather difficult. Is there a downside to leaving this as it is and letting the server validate it?

Given that the docs contains the mention that if not set it will default to what the server determines is the appropriate value, this PR makes sense to include since the [current behavior does not match what the documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#max_instance_count-1) is stating:
> If absent, Cloud Run will calculate a default value based on the project's available container instances quota in the region and specified instance size.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
cloudrunv2: set `template.scaling.maxInstanceCount` to `Computed` in `google_cloud_run_v2_service` resource
```
