### PR TITLE
Fix GKE ignore_node_count_changes flag and stale IGM cache

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -664,6 +664,10 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 						Optional: true,
 						Elem:     &schema.Resource{Schema: map[string]*schema.Schema{"create_pod_range": {Type: schema.TypeBool}}},
 					},
+					"ignore_node_count_changes": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
 				},
 			},
 			Optional: true,
@@ -701,6 +705,7 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 					"managed_instance_group_urls": []string{},
 					"version":                     "",
 					"network_config":              []map[string]interface{}{},
+					"ignore_node_count_changes":   false,
 				},
 				{
 					"name":                        "pool-2",
@@ -713,6 +718,7 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 					"managed_instance_group_urls": []string{},
 					"version":                     "",
 					"network_config":              []map[string]interface{}{},
+					"ignore_node_count_changes":   false,
 				},
 			},
 			expectError: false,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1992,7 +1992,7 @@ func TestAccContainerCluster_regionalWithNodePool(t *testing.T) {
 				ResourceName:		 "google_container_cluster.regional",
 				ImportState:		 true,
 				ImportStateVerify:	 true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_node_count_changes", "node_pool.0.ignore_node_count_changes"},
+				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_node_count_changes", "node_pool.0.ignore_node_count_changes", "node_pool.0.managed_instance_group_urls"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -158,6 +158,17 @@ func (instanceGroupManagerCache *instanceGroupManagerCache) needsRefresh(fullyQu
 	return time.Since(igm.updateTime) > instanceGroupManagerCache.ttl
 }
 
+func (instanceGroupManagerCache *instanceGroupManagerCache) invalidate(igmUrl string) {
+	instanceGroupManagerCache.mutex.Lock()
+	defer instanceGroupManagerCache.mutex.Unlock()
+
+	matches := instanceGroupManagerURL.FindStringSubmatch(igmUrl)
+	if len(matches) >= 4 {
+		delete(instanceGroupManagerCache.instanceGroupManagers, matches[0])
+	}
+}
+
+
 // We need to set ttl to 0 to disable caching in VCR testing.
 // This ensure all NP/MIG LIST requests are made consistently,
 // preventing non-deterministic behavior that would break VCR.
@@ -1524,6 +1535,7 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 		// or leave them empty. Passing the API URLs to igmUrls at least populates them for basic usage.
 		for _, url := range np.InstanceGroupUrls {
 			igmUrls = append(igmUrls, url)
+			igmCache.invalidate(url)
 		}
 	} else {
 		for _, url := range np.InstanceGroupUrls {
@@ -1563,6 +1575,7 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 		"managed_instance_group_urls": managedIgmUrls,
 		"version":             np.Version,
 		"network_config":      flattenNodeNetworkConfig(np.NetworkConfig, d, prefix),
+		"ignore_node_count_changes": d.Get(prefix + "ignore_node_count_changes"),
 	}
 
 	if np.Autoscaling != nil {
@@ -1866,6 +1879,11 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 		}
 		if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
 				return err
+		}
+		if urls, ok := d.GetOk(prefix + "instance_group_urls"); ok {
+			for _, u := range urls.([]interface{}) {
+				igmCache.invalidate(u.(string))
+			}
 		}
 		log.Printf("[INFO] GKE node pool %s size has been updated to %d", name, newSize)
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27946
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27966

This PR fixes 3 bugs or test failures introduced by [PR #17968](https://github.com/GoogleCloudPlatform/magic-modules/pull/17968) for the GKE `ignore_node_count_changes` flag. [PR #17968](https://github.com/GoogleCloudPlatform/magic-modules/pull/17968) successfully reduced reduced plan-time API calls by via the new flag, but was rushed as a high priority issue and missed a few things.

---

### 1: Flattener Bug
[PR #17968](https://github.com/GoogleCloudPlatform/magic-modules/pull/17968) failed to persist the flag's state in `google_container_cluster.node_pool.ignore_node_count_changes`  despite working correctly in `google_container_node_pool.ignore_node_count_changes`.

To address this, this PR adds the missing `ignore_node_count_changes` field mapping to `google_container_cluster`'s `flattenNodePool`.

---

### 2: Test Failure TestAccContainerCluster_regionalWithNodePool

[PR #17968](https://github.com/GoogleCloudPlatform/magic-modules/pull/17968) added the new flag to `TestAccContainerCluster_regionalWithNodePool`. The test was dismissed as flaky in VCR since it failed with
```
        Error: Error waiting for creating GKE cluster: Try a different location, or try again later: Google Compute Engine does not have enough resources available to fulfill request: us-central1.
```

However it actually failed in [non-VCR runs with](https://ff8811cb59430773d2236594d137c8662d8274e2feef6f406ef1dff-apidata.googleusercontent.com/download/storage/v1/b/nightly-test-data/o/test-errors%2Fbeta%2F2026-06-21%2FTestAccContainerCluster_regionalWithNodePool-beta-2026-06-21.txt?jk=AWuF6Pihn3kbJhj0FLmHfFcFSH5rUxJMNTG1Zj4fu7UmB3bxTW_nIr2RZSfU6WVsPgVFIo2SJZNQ_NiKghZE2ct8j5USh70TVsJivSfPWIYv15eupy3HCriO8Jc4w4V6QoL6NuVWZylpKFPDMpsA_saqh0q5UqFs6UGqQYlQvJ62RLUEsbaRFt5-t4Tvo6-ATeiio3gLb04aPB6Gi2IxNlYA3LC3OV0yAj5zob3r01rqGvCh3raVE1g8KRKHU0PkFwTCXrJym2kEIjcx_vLItLtMAn1DxRfCK_cdVbi1n2h_cs1ajgZfmF5BPfFnVKesWJmsPE8nnRnJGzqdsu1QJf97FKPADQd4VOaA6i79aso25dp302HKzqcB5YKcibi4Qvzx-JMyymqP6IFgOjMKLsxJNssx_IN7VmTDEZjwnvDQwjTlehUL--7q25ZbzkSbFmdREbNpiirhIXhFGh_16oEgeZFw3xb5RvPvzUi1O2kzUkaqow7auDACnzcT7ZUwhntUNcf69VghFkOLYYALOIs0GFj0MxXaBqNgEToI0JSwZYsWrZrnwml6S_sjYuS9gblKAiVAitIgss1l7xaUBPdd4A9DMlBMnVRsxqGOb_KuibTi9jQ-VF68yHtEvM80WhxWijSLAn6jXL6IR4Q33IVM2MJ157hImIwWtLo0uXTFNO-4P5DzPIkoOomKbyM8QnHFSj-HeLA-JaWhasYZNGkyLgE_0HiCwOTtBOk80hvNjnfik_vhMPf1ldS-520_FGHS3NtqZEbqLvYkaBKLL24po1vQ7UcSfu9Cp1T2B2yshqIx9gio6PNrG5zKf3wIuGf3-zy3BjWI6W5rm6CrLzLJ83yQ10BeS02rfXUdjLeT8aPsehikp0rJU7nzWasu0aDof2U9RbyPcXUtNNLY4-WxJJNbD2hHMxl9J7rzCKZGY7e-cdvJ-SDFu1ujdsHahjE24qaCoWvWuzxU8Rs3PVSI-d_xq_tu_1Z4-iZPLoxsxwP1LKaql9DUVziyGTokTiIpe7Caz5a7vy2Uky6Lx8BVxw5gyYfHQF2Iy4syRE1qVn-MjGT9mxG0-wAdNkzaE3KdxnzHVL6YljvgEb0wQ9gyujYrgu3FR9cN9GYPhvbX7v5LvPB5U0P0UukG8hoUuqRxaYKrrpCwGQAsHTIQXOjV0ESu3JVkB9UD6-_PwYAAgRJWIkdQimMYt1N3PqAk6XNNqL6M5mRWmXQinxXr9HILXR7ZpY8QhlFpU42C4RY9DPrNgFScBUbn_evX6IhBensaLTeOy6XA4suUOpnXaMkNJHVWnl9_W6AcmWabcMQFspleYgpNW_s&isca=1) 
```
              ~ node_pool {
                  ~ ignore_node_count_changes   = false -> true
```

The `flattenNodePool` fix from Bug #1 resolves this immediate diff, but exposes a new diff on the import step. Virtual fields are not loaded on import and are usually fixed by `ImportStateVerifyIgnore`. This doesn't work for `ignore_node_count_changes` because if the acceptance test config sets `ignore_node_count_changes` to true, but the import step sets it to the default `false`, the node counts are not ignored and `managed_instance_group_urls` is populated, resulting in a new import diff for `managed_instance_group_urls`.

This means for import steps where `ignore_node_count_changes` is true, both `ignore_node_count_changes` and `managed_instance_group_urls` should be ignored on the import step.

---

### 3: Test Failure TestAccContainerNodePool_ignoreNodeCountChanges

`TestAccContainerNodePool_ignoreNodeCountChanges` fails outside of VCR tests because of caching. Stale GCE instance group manager counts were served from the provider cache after config updates, causing 
```
    resource_container_node_pool_test.go:7010: Step 3/4 error: Check failed: Check 1/2 error: Check 1/1 error: google_container_node_pool.np: Attribute 'node_count' expected "3", got "2"
```

To fix this, this PR invalidates the IGM cache during count resizing or anytime `ignore_node_count_changes` is active, in order to make sure stale node counts do not persist after they are ignored by the flag. The cache is a provider-only client-side cache, and it makes sense to empty in these scenarios because once counts have been updated or ignored, the cached values are no longer guaranteed to reflect actual API values.

---

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
container: fixed a plan-time permadiff where `ignore_node_count_changes` was not persisted in the inline `node_pool` blocks of `google_container_cluster`
```
```release-note:bug
container: fixed a bug where `google_container_node_pool` and `google_container_cluster` failed to invalidate their Instance Group Manager cache when a resize occurred or when `ignore_node_count_changes` was active
```