### PR TITLE
dataform: promote google_dataform_repository to GA

### DIFF
--- a/mmv1/products/dataform/Repository.yaml
+++ b/mmv1/products/dataform/Repository.yaml
@@ -17,16 +17,14 @@ description: A resource represents a Dataform Git repository
 references:
   guides:
     Official Documentation: https://cloud.google.com/dataform/docs/
-  api: https://cloud.google.com/dataform/reference/rest/v1beta1/projects.locations.repositories
+  api: https://cloud.google.com/dataform/reference/rest/v1/projects.locations.repositories
 docs:
 base_url: projects/{{project}}/locations/{{region}}/repositories
-min_version: beta
 create_url: projects/{{project}}/locations/{{region}}/repositories?repositoryId={{name}}
 update_verb: PATCH
 iam_policy:
   method_name_separator: ':'
   parent_resource_attribute: repository
-  min_version: beta
 id_format: projects/{{project}}/locations/{{region}}/repositories/{{name}}
 import_format:
   - projects/{{project}}/locations/{{region}}/repositories/{{name}}
@@ -40,13 +38,11 @@ custom_code:
 samples:
   - name: dataform_repository
     primary_resource_id: dataform_repository
-    min_version: beta
     # This example is used in the docs to address this issue
     # See : https://github.com/hashicorp/terraform-provider-google/issues/17335
     exclude_test: true
     steps:
       - name: dataform_repository
-        min_version: beta
         resource_id_vars:
           dataform_repository_name: dataform_repository
           data: secret-data
@@ -58,11 +54,9 @@ samples:
         exclude_import_test: true
   - name: dataform_repository_with_cloudsource_repo
     primary_resource_id: dataform_repository
-    min_version: beta
     exclude_basic_doc: true
     steps:
       - name: dataform_repository_with_cloudsource_repo
-        min_version: beta
         resource_id_vars:
           git_repository_name: my/repository
           dataform_repository_name: dataform_repository
@@ -81,11 +75,9 @@ samples:
         exclude_import_test: true
   - name: dataform_repository_with_cloudsource_repo_and_ssh
     primary_resource_id: dataform_repository
-    min_version: beta
     exclude_basic_doc: true
     steps:
       - name: dataform_repository_with_cloudsource_repo_and_ssh
-        min_version: beta
         resource_id_vars:
           git_repository_name: my/repository
           dataform_repository_name: dataform_repository
@@ -99,12 +91,10 @@ samples:
           git_repository_name: '"my/repository" + randomSuffix'
   - name: dataform_repository_with_developer_connect
     primary_resource_id: dataform_repository
-    min_version: beta
     exclude_basic_doc: true
     exclude_test: true # Can't establish a Github connection in automated tests.
     steps:
       - name: dataform_repository_with_developer_connect
-        min_version: beta
         resource_id_vars:
           connection_name: my-connection
           repository_link_name: my-repository
@@ -130,36 +120,30 @@ parameters:
   - name: region
     type: String
     description: A reference to the region
-    min_version: beta
     url_param_only: true
     immutable: true
 properties:
   - name: name
     type: String
     description: The repository's name.
-    min_version: beta
     required: true
     immutable: true
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.tmpl
   - name: gitRemoteSettings
     type: NestedObject
     description: Optional. If set, configures this repository to be linked to a Git remote.
-    min_version: beta
     properties:
       - name: url
         type: String
         description: The Git remote's URL.
-        min_version: beta
         required: true
       - name: defaultBranch
         type: String
         description: The Git remote's default branch name.
-        min_version: beta
         required: true
       - name: authenticationTokenSecretVersion
         type: String
         description: The name of the Secret Manager secret version to use as an authentication token for Git operations. This secret is for assigning with HTTPS only(for SSH use `ssh_authentication_config`). Must be in the format projects/*/secrets/*/versions/*.
-        min_version: beta
         exactly_one_of:
           - gitRemoteSettings.0.authenticationTokenSecretVersion
           - gitRemoteSettings.0.sshAuthenticationConfig
@@ -167,7 +151,6 @@ properties:
       - name: sshAuthenticationConfig
         type: NestedObject
         description: Authentication fields for remote uris using SSH protocol.
-        min_version: beta
         exactly_one_of:
           - gitRemoteSettings.0.authenticationTokenSecretVersion
           - gitRemoteSettings.0.sshAuthenticationConfig
@@ -176,17 +159,14 @@ properties:
           - name: userPrivateKeySecretVersion
             type: String
             description: The name of the Secret Manager secret version to use as a ssh private key for Git operations. Must be in the format projects/*/secrets/*/versions/*.
-            min_version: beta
             required: true
           - name: hostPublicKey
             type: String
             description: Content of a public SSH key to verify an identity of a remote Git host.
-            min_version: beta
             required: true
       - name: gitRepositoryLink
         type: String
         description: The name of the Developer Connect GitRepositoryLink to use for machine credentials. Must be in the format projects/*/locations/*/connections/*/gitRepositoryLinks/*.
-        min_version: beta
         exactly_one_of:
           - gitRemoteSettings.0.authenticationTokenSecretVersion
           - gitRemoteSettings.0.sshAuthenticationConfig
@@ -194,47 +174,37 @@ properties:
       - name: tokenStatus
         type: String
         description: |
-          Indicates the status of the Git access token. https://cloud.google.com/dataform/reference/rest/v1beta1/projects.locations.repositories#TokenStatus
-        min_version: beta
+          Indicates the status of the Git access token. https://cloud.google.com/dataform/reference/rest/v1/projects.locations.repositories#TokenStatus
         output: true
   - name: workspaceCompilationOverrides
     type: NestedObject
     description: If set, fields of workspaceCompilationOverrides override the default compilation settings that are specified in dataform.json when creating workspace-scoped compilation results.
-    min_version: beta
     properties:
       - name: defaultDatabase
         type: String
         description: The default database (Google Cloud project ID).
-        min_version: beta
       - name: schemaSuffix
         type: String
         description: The suffix that should be appended to all schema (BigQuery dataset ID) names.
-        min_version: beta
       - name: tablePrefix
         type: String
         description: The prefix that should be prepended to all table names.
-        min_version: beta
   - name: serviceAccount
     type: String
     description: The service account to run workflow invocations under.
-    min_version: beta
   - name: npmrcEnvironmentVariablesSecretVersion
     type: String
     description: Optional. The name of the Secret Manager secret version to be used to interpolate variables into the .npmrc file for package installation operations. Must be in the format projects/*/secrets/*/versions/*. The file itself must be in a JSON format.
-    min_version: beta
   - name: displayName
     type: String
     description: Optional. The repository's user-friendly name.
-    min_version: beta
   - name: kmsKeyName
     type: String
     description: |
       Optional. The reference to a KMS encryption key. If provided, it will be used to encrypt user data in the repository and all child resources.
       It is not possible to add or update the encryption key after the repository is created. Example projects/[kms_project_id]/locations/[region]/keyRings/[key_region]/cryptoKeys/[key]
-    min_version: beta
   - name: labels
     type: KeyValueLabels
     description: |
       Optional. Repository user labels.
       An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
-    min_version: beta

--- a/mmv1/templates/terraform/samples/services/dataform/dataform_repository.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dataform/dataform_repository.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_secret_manager_secret" "secret" {
-  provider = google-beta
   secret_id = "{{index $.ResourceIdVars "secret_name"}}"
 
   replication {
@@ -8,28 +7,24 @@ resource "google_secret_manager_secret" "secret" {
 }
 
 resource "google_secret_manager_secret_version" "secret_version" {
-  provider = google-beta
   secret = google_secret_manager_secret.secret.id
 
   secret_data = "{{index $.ResourceIdVars "data"}}"
 }
 
 resource "google_kms_key_ring" "keyring" {
-  provider = google-beta
   
   name     = "{{index $.ResourceIdVars "key_ring_name"}}"
   location = "us-central1"
 }
 
 resource "google_kms_crypto_key" "example_key" {
-  provider = google-beta
   
   name            = "{{index $.ResourceIdVars "crypto_key_name"}}"
   key_ring        = google_kms_key_ring.keyring.id
 }
 
 resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
-  provider = google-beta
 
   crypto_key_id = google_kms_crypto_key.example_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
@@ -40,7 +35,6 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
 }
 
 resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name = "{{index $.ResourceIdVars "dataform_repository_name"}}"
   display_name = "{{index $.ResourceIdVars "dataform_repository_name"}}"
   npmrc_environment_variables_secret_version = google_secret_manager_secret_version.secret_version.id

--- a/mmv1/templates/terraform/samples/services/dataform/dataform_repository_with_cloudsource_repo.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dataform/dataform_repository_with_cloudsource_repo.tf.tmpl
@@ -1,14 +1,11 @@
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_sourcerepo_repository" "git_repository" {
-  provider = google-beta
   name = "{{index $.ResourceIdVars "git_repository_name"}}"
 }
 
 resource "google_secret_manager_secret" "secret" {
-  provider = google-beta
   secret_id = "{{index $.ResourceIdVars "secret_name"}}"
 
   replication {
@@ -17,28 +14,24 @@ resource "google_secret_manager_secret" "secret" {
 }
 
 resource "google_secret_manager_secret_version" "secret_version" {
-  provider = google-beta
   secret = google_secret_manager_secret.secret.id
 
   secret_data = "{{index $.ResourceIdVars "data"}}"
 }
 
 resource "google_kms_key_ring" "keyring" {
-  provider = google-beta
   
   name     = "{{index $.ResourceIdVars "key_ring_name"}}"
   location = "us-central1"
 }
 
 resource "google_kms_crypto_key" "example_key" {
-  provider = google-beta
   
   name            = "{{index $.ResourceIdVars "crypto_key_name"}}"
   key_ring        = google_kms_key_ring.keyring.id
 }
 
 resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
-  provider = google-beta
 
   crypto_key_id = google_kms_crypto_key.example_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
@@ -49,7 +42,6 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
 }
 
 resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name = "{{index $.ResourceIdVars "dataform_repository_name"}}"
   display_name = "{{index $.ResourceIdVars "dataform_repository_name"}}"
   npmrc_environment_variables_secret_version = google_secret_manager_secret_version.secret_version.id

--- a/mmv1/templates/terraform/samples/services/dataform/dataform_repository_with_cloudsource_repo_and_ssh.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dataform/dataform_repository_with_cloudsource_repo_and_ssh.tf.tmpl
@@ -1,10 +1,8 @@
 resource "google_sourcerepo_repository" "git_repository" {
-  provider = google-beta
   name = "{{index $.ResourceIdVars "git_repository_name"}}"
 }
 
 resource "google_secret_manager_secret" "secret" {
-  provider = google-beta
   secret_id = "{{index $.ResourceIdVars "secret_name"}}"
 
   replication {
@@ -13,14 +11,12 @@ resource "google_secret_manager_secret" "secret" {
 }
 
 resource "google_secret_manager_secret_version" "secret_version" {
-  provider = google-beta
   secret = google_secret_manager_secret.secret.id
 
   secret_data = "{{index $.ResourceIdVars "data"}}"
 }
 
 resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name = "{{index $.ResourceIdVars "dataform_repository_name"}}"
 
   git_remote_settings {
@@ -42,5 +38,4 @@ resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
 }
 
 data "google_project" "project" {
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/samples/services/dataform/dataform_repository_with_developer_connect.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dataform/dataform_repository_with_developer_connect.tf.tmpl
@@ -1,19 +1,16 @@
 resource "google_project_service_identity" "devconnect_p4sa" {
-  provider = google-beta
 
   project  = "{{index $.TestEnvVars "project_id"}}"
   service  = "developerconnect.googleapis.com"
 }
 
 resource "google_project_iam_member" "devconnect_secret" {
-  provider = google-beta
   project  = "{{index $.TestEnvVars "project_id"}}"
   role     = "roles/secretmanager.admin"
   member   = google_project_service_identity.devconnect_p4sa.member
 }
 
 resource "google_developer_connect_connection" "my_connection" {
-  provider = google-beta
   project  = "{{index $.TestEnvVars "project_id"}}"
   location = "us-central1"
   connection_id = "{{index $.ResourceIdVars "connection_name"}}"
@@ -24,7 +21,6 @@ resource "google_developer_connect_connection" "my_connection" {
 }
 
 resource "google_developer_connect_git_repository_link" "my_repository" {
-  provider = google-beta
   project  = "{{index $.TestEnvVars "project_id"}}"
   location = "us-central1"
   git_repository_link_id = "{{index $.ResourceIdVars "repository_link_name"}}"
@@ -33,7 +29,6 @@ resource "google_developer_connect_git_repository_link" "my_repository" {
 }
 
 resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name = "{{index $.ResourceIdVars "dataform_repository_name"}}"
   display_name = "{{index $.ResourceIdVars "dataform_repository_name"}}"
 

--- a/mmv1/third_party/terraform/services/dataform/resource_dataform_repository_test.go
+++ b/mmv1/third_party/terraform/services/dataform/resource_dataform_repository_test.go
@@ -1,5 +1,4 @@
 package dataform_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -7,9 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/sourcerepo"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/secretmanager"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/dataform"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/secretmanager"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/sourcerepo"
 )
 
 func TestAccDataformRepository_updated(t *testing.T) {
@@ -21,7 +20,7 @@ func TestAccDataformRepository_updated(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataformRepositoryDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -49,12 +48,10 @@ func TestAccDataformRepository_updated(t *testing.T) {
 func testAccDataformRepository_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_sourcerepo_repository" "git_repository" {
-  provider = google-beta
   name = "my/repository%{random_suffix}"
 }
 
 resource "google_secret_manager_secret" "secret" {
-  provider = google-beta
   secret_id = "secret"
 
   replication {
@@ -63,14 +60,12 @@ resource "google_secret_manager_secret" "secret" {
 }
 
 resource "google_secret_manager_secret_version" "secret_version" {
-  provider = google-beta
   secret = google_secret_manager_secret.secret.id
 
   secret_data = "tf-test-secret-data%{random_suffix}"
 }
 
 resource "google_dataform_repository" "dataform_repository" {
-  provider = google-beta
   name = "tf_test_dataform_repository%{random_suffix}"
 
   git_remote_settings {
@@ -91,12 +86,10 @@ resource "google_dataform_repository" "dataform_repository" {
 func testAccDataformRepository_updated(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_sourcerepo_repository" "git_repository" {
-  provider = google-beta
   name = "my/repository%{random_suffix}"
 }
 
 resource "google_secret_manager_secret" "secret" {
-  provider = google-beta
   secret_id = "tf-test-secret%{random_suffix}"
 
   replication {
@@ -105,14 +98,12 @@ resource "google_secret_manager_secret" "secret" {
 }
 
 resource "google_secret_manager_secret_version" "secret_version" {
-  provider = google-beta
   secret = google_secret_manager_secret.secret.id
 
   secret_data = "tf-test-secret-data%{random_suffix}"
 }
 
 resource "google_dataform_repository" "dataform_repository" {
-  provider = google-beta
   name = "tf_test_dataform_repository%{random_suffix}"
 
   git_remote_settings {
@@ -128,4 +119,3 @@ resource "google_dataform_repository" "dataform_repository" {
 }
 `, context)
 }
-{{- end }}


### PR DESCRIPTION
Promotes the Dataform Repository resource (`google_dataform_repository`), its associated IAM resources (`google_dataform_repository_iam_*`), and all properties from Beta to GA.

### Changes
- **`Repository.yaml`**:
  - Removed `min_version: beta` from the top-level resource, IAM policy config, samples, and all fields/parameters.
  - Updated API and `tokenStatus` reference URLs from `v1beta1` to `v1`.
- **Terraform Sample Templates**: Removed `provider = google-beta` from all sample `.tf.tmpl` files so valid GA documentation and test configurations are generated.
- **Handwritten VCR Tests**: Removed Beta version guards (`{{- if ne $.TargetVersionName "ga" }}`), updated provider factories to `ProtoV5ProviderFactories`, and removed `provider = google-beta` in `resource_dataform_repository_test.go.tmpl`.

### Verification & Testing
1. **Provider Generation**: Generated clean provider code across all services for both GA and Beta.
2. **Binary Build**: Executed `make build` (`go install`, `go vet`, and `gofmtcheck`) in both `terraform-provider-google` (GA) and `terraform-provider-google-beta` (Beta). Both built cleanly without errors.
3. **Test Package Compilation**: Executed `go test -c ./google/services/dataform` in GA and `go test -c ./google-beta/services/dataform` in Beta. All test suites and sample configurations compiled successfully.


```release-note:new-resource
`google_dataform_repository`
```
```release-note:new-resource
`google_dataform_repository_iam_policy`
```
```release-note:new-resource
`google_dataform_repository_iam_binding`
```
```release-note:new-resource
`google_dataform_repository_iam_member`
```
