### PR TITLE
`cloudrunv2`: fix perpetual diff in `templates.container.resources.limits` block

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -644,6 +644,7 @@ properties:
                   description: |-
                     Only memory, CPU, and nvidia.com/gpu are supported. Use key `cpu` for CPU limit, `memory` for memory limit, `nvidia.com/gpu` for gpu limit. Note: The only supported values for CPU are '1', '2', '4', '6' and '8'. Setting 4 CPU requires at least 2Gi of memory, setting 6 or more CPU requires at least 4Gi of memory. The values of the map is string form of the 'quantity' k8s type: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
                   default_from_api: true
+                  diff_suppress_func: 'cloudRunV2ServiceResourceLimitsDiffSuppress'
                 - name: 'cpuIdle'
                   type: Boolean
                   description: |-

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -2082,3 +2082,60 @@ resource "google_cloud_run_v2_service" "default" {
 }
 `, context)
 }
+
+// TestAccCloudRunV2Service_noPermadiffWithMemoryLimitOnly verifies that setting
+// only the memory key in template.containers.resources.limits does not produce a
+// perpetual diff. The API automatically adds a default cpu limit which should be
+// silently accepted. Regression test for:
+// https://github.com/hashicorp/terraform-provider-google/issues/20399
+func TestAccCloudRunV2Service_noPermadiffWithMemoryLimitOnly(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudRunV2ServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunV2Service_memoryLimitOnly(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "deletion_protection"},
+			},
+			// Second plan must produce no diff (no permadiff on cpu limit key).
+			{
+				Config:   testAccCloudRunV2Service_memoryLimitOnly(context),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccCloudRunV2Service_memoryLimitOnly(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name                = "tf-test-cloudrun-service%{random_suffix}"
+  location            = "us-central1"
+  deletion_protection = false
+  ingress             = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      resources {
+        limits = {
+          memory = "1Gi"
+        }
+      }
+    }
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_utils.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_utils.go
@@ -1,0 +1,25 @@
+package cloudrunv2
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// cloudRunV2ServiceResourceLimitsDiffSuppress suppresses diffs for the `cpu`
+// key in the container resources.limits map when it was added by the API but
+// not specified in the user's config. When only `memory` is set, the Cloud Run
+// API automatically populates a default `cpu` value. Without this suppression
+// the provider would produce a perpetual diff trying to clear that API-set key.
+//
+// Only the `cpu` key is suppressed because it is the only key the API
+// auto-populates. Other keys such as `nvidia.com/gpu` must never be suppressed
+// so that intentional removals (e.g. switching from GPU to non-GPU) are applied.
+func cloudRunV2ServiceResourceLimitsDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// Only suppress the auto-populated cpu key, not user-set keys like nvidia.com/gpu.
+	if !strings.HasSuffix(k, "limits.cpu") {
+		return false
+	}
+	// Suppress when the user did not set cpu (new == "") but the API populated it (old != "").
+	return new == "" && old != ""
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

When a google_cloud_run_v2_service container sets only memory in resources.limits, the Cloud Run v2 API automatically populates a default cpu value server-side. On subsequent plans, Terraform sees cpu in state but not in config and proposes to remove it — a perpetual diff with no way for the user to resolve it.

The fix adds a DiffSuppressFunc on the limits field that silently accepts any key the API added but the user did not configure. A regression test deploys a service with memory-only limits, imports it, then asserts the second plan produces no diff.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/20399

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
cloudrunv2: fix perpetual diff in `templates.container.resources.limits` block in `google_cloud_run_v2_service` resource
```
