### PR TITLE
add identity connector field to exadbvmcluster for cmek

### DIFF
--- a/mmv1/products/oracledatabase/ExadbVmCluster.yaml
+++ b/mmv1/products/oracledatabase/ExadbVmCluster.yaml
@@ -179,6 +179,28 @@ properties:
       projects/{project}/locations/{location}/odbNetworks/{odb_network}/odbSubnets/{odb_subnet}
     immutable: true
     required: true
+  - name: identityConnector
+    type: NestedObject
+    output: true
+    description: |-
+      The identity connector details which will allow OCI to securely access
+      the resources in the customer project.
+    properties:
+      - name: serviceAgentEmail
+        type: String
+        output: true
+        description: A google managed service account on which customers can grant roles to access resources in the customer project.
+      - name: connectionState
+        type: String
+        output: true
+        description: |-
+          The connection state of the identity connector.
+          Possible values:
+          CONNECTION_STATE_UNSPECIFIED
+          CONNECTED
+          PARTIALLY_CONNECTED
+          DISCONNECTED
+          UNKNOWN
   - name: properties
     type: NestedObject
     description: The properties of an ExadbVmCluster.


### PR DESCRIPTION
```release-note:enhancement
oracledatabase: added `identity_connector` to `google_oracle_database_exadb_vm_cluster` for CMEK support
```

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/28491

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
