### PR TITLE
test: fix flaky ANY_RESERVATION_THEN_FAIL node pool test

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -4061,13 +4061,15 @@ resource "google_compute_reservation" "gce_reservation" {
   zone = "us-central1-a"
 
   specific_reservation {
-    count = 1
+    count = 3
     instance_properties {
-      machine_type     = "n1-standard-1"
+      machine_type     = "n1-standard-2"
     }
   }
 
   specific_reservation_required = false
+
+  depends_on = [google_container_cluster.cluster] 
 }
 
 resource "google_container_node_pool" "with_reservation_affinity" {
@@ -4076,7 +4078,7 @@ resource "google_container_node_pool" "with_reservation_affinity" {
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 1
   node_config {
-    machine_type    = "n1-standard-1"
+    machine_type    = "n1-standard-2"
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
@@ -4085,6 +4087,7 @@ resource "google_container_node_pool" "with_reservation_affinity" {
       consume_reservation_type = "ANY_RESERVATION_THEN_FAIL"
     }
   }
+  depends_on = [google_compute_reservation.gce_reservation]
 }
 `, cluster, networkName, subnetworkName, reservation, np)
 }


### PR DESCRIPTION
The `TestAccContainerNodePool_withReservationAffinityAnyReservationThenFail` test was frequently failing in the nightly test suite with the error: "All automatic reservations in your project, or shared with your project, are fully consumed."

Root cause:
The `google_compute_reservation` and `google_container_cluster` were being created concurrently. Because the cluster takes several minutes to create, the automatic reservation was sitting idle and being stolen by other tests running concurrently in the shared CI project.
When the `google_container_node_pool` eventually attempted to create and consume the reservation using `ANY_RESERVATION_THEN_FAIL`, the API correctly failed the request because the reservation was fully utilized.

Fix:
1. Added `depends_on` blocks to strictly order the resource creation: Cluster -> Reservation -> Node Pool. This eliminates the idle window by ensuring the reservation is created immediately before the node pool requests it.
2. Changed the instance type from `n1-standard-1` to `n2-standard-2` to further reduce the likelihood of another test competing for the same automatic reservation capacity during the narrow creation window.
3. Increased capacity of the reservation to 3 instances.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28378

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
