### PR TITLE
Fix SecurityPolicy patchRule updateMask and advancedMachineFeatures test capacity failure

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -2214,7 +2214,7 @@ func TestAccComputeInstance_advancedMachineFeatures(t *testing.T) {
 						t, "google_compute_instance.foobar", &instance),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
+			computeInstanceImportStep("us-central1-b", instanceName, []string{"allow_stopping_for_update"}),
 			{
 				Config: testAccComputeInstance_advancedMachineFeaturesUpdated(instanceName),
 				Check: resource.ComposeTestCheckFunc(
@@ -2222,7 +2222,7 @@ func TestAccComputeInstance_advancedMachineFeatures(t *testing.T) {
 						t, "google_compute_instance.foobar", &instance),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
+			computeInstanceImportStep("us-central1-b", instanceName, []string{"allow_stopping_for_update"}),
 		},
 	})
 }
@@ -2252,7 +2252,7 @@ func TestAccComputeInstance_performanceMonitoringUnit(t *testing.T) {
 						t, "google_compute_instance.foobar", &instance),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", context_1["instance_name"].(string), []string{"allow_stopping_for_update"}),
+			computeInstanceImportStep("us-central1-b", context_1["instance_name"].(string), []string{"allow_stopping_for_update"}),
 			{
 				Config: testAccComputeInstance_performanceMonitoringUnit(context_3),
 				Check: resource.ComposeTestCheckFunc(
@@ -9590,7 +9590,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "c4-standard-2"
-  zone         = "us-central1-a"
+  zone         = "us-central1-b"
 
   boot_disk {
     initialize_params {
@@ -9618,7 +9618,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_instance" "foobar" {
   name         = "%{instance_name}"
   machine_type = "c4-standard-2"
-  zone         = "us-central1-a"
+  zone         = "us-central1-b"
 
   boot_disk {
     initialize_params {
@@ -9678,7 +9678,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "c4-standard-2"
-  zone         = "us-central1-a"
+  zone         = "us-central1-b"
 
   boot_disk {
     initialize_params {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -1243,6 +1243,27 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					patchRuleUpdateMask = append(patchRuleUpdateMask, "header_action")
 				}
 
+				if fmt.Sprintf("%v", oRules[priority]["action"]) != fmt.Sprintf("%v", nRules[priority]["action"]) {
+					patchRuleUpdateMask = append(patchRuleUpdateMask, "action")
+				}
+
+				if fmt.Sprintf("%v", oRules[priority]["description"]) != fmt.Sprintf("%v", nRules[priority]["description"]) {
+					patchRuleUpdateMask = append(patchRuleUpdateMask, "description")
+				}
+
+				if fmt.Sprintf("%v", oRules[priority]["match"]) != fmt.Sprintf("%v", nRules[priority]["match"]) {
+					patchRuleUpdateMask = append(patchRuleUpdateMask, "match")
+				}
+
+				if fmt.Sprintf("%v", oRules[priority]["preview"]) != fmt.Sprintf("%v", nRules[priority]["preview"]) {
+					patchRuleUpdateMask = append(patchRuleUpdateMask, "preview")
+				}
+
+				if fmt.Sprintf("%v", oRules[priority]["redirect_options"]) != fmt.Sprintf("%v", nRules[priority]["redirect_options"]) {
+					patchRuleUpdateMask = append(patchRuleUpdateMask, "redirect_options")
+				}
+
+
 				// If the rule is in new, and its priority is in old, but its hash is different than the one in old, update it.
 				patchRuleURL := fmt.Sprintf("%sprojects/%s/global/securityPolicies/%s/patchRule?priority=%d", transport_tpg.BaseUrl(Product, config), project, sp, priority)
 				if len(patchRuleUpdateMask) > 0 {


### PR DESCRIPTION
Fix SecurityPolicy patchRule updateMask for rule attributes: updating rule attributes like 'match', 'action', or 'description' simultaneously with 'preconfigured_waf_config' would result in those attributes being silently ignored or causing backend validation errors. We now properly append them to the patchRuleUpdateMask if they have changed.

Fix TestAccComputeInstance_advancedMachineFeatures failure due to capacity: changed the hardcoded zone to `us-central1-b` in `c4-standard-2` machine type tests for compute instances. This resolves the recent 403 / capacity stockout errors when running these tests in the nightly CI.

Fixes hashicorp/terraform-provider-google#28372

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: Fix SecurityPolicy patchRule updateMask and advancedMachineFeatures test capacity failure
```
