### PR TITLE
Added service_account field to google_apigee_api_deployment

### DIFF
--- a/mmv1/products/apigee/ApiDeployment.yaml
+++ b/mmv1/products/apigee/ApiDeployment.yaml
@@ -22,7 +22,7 @@ references:
 base_url: organizations/{{org_id}}/environments/{{environment}}/apis/{{proxy_id}}/revisions/{{revision}}/deployments
 immutable: true
 self_link: organizations/{{org_id}}/environments/{{environment}}/apis/{{proxy_id}}/revisions/{{revision}}/deployments
-create_url: organizations/{{org_id}}/environments/{{environment}}/apis/{{proxy_id}}/revisions/{{revision}}/deployments
+create_url: organizations/{{org_id}}/environments/{{environment}}/apis/{{proxy_id}}/revisions/{{revision}}/deployments?serviceAccount={{service_account}}
 update_mask: false
 update_verb: POST
 import_format:
@@ -85,3 +85,8 @@ properties:
     description: |
       The ID of the API deployment in the format `organizations/{{org_id}}/environments/{{environment}}/apis/{{proxy_id}}/revisions/{{revision}}/deployments`.
     output: true
+  - name: service_account
+    type: String
+    description: |
+      The service account represents the identity of the deployed proxy, and determines what permissions it has. The format must be `{ACCOUNT_ID}@{PROJECT}.iam.gserviceaccount.com`.
+    url_param_only: true

--- a/mmv1/templates/terraform/samples/services/apigee/apigee_api_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/apigee/apigee_api_deployment_basic.tf.tmpl
@@ -23,6 +23,11 @@ data "archive_file" "bundle" {
 }
 
 
+resource "google_service_account" "proxy_sa" {
+  account_id   = "apigee-proxy-sa"
+  display_name = "Apigee Proxy Service Account"
+}
+
 resource "google_apigee_api" "test_apigee_api" {
   name            = "apigee-proxy"
   org_id          = google_project.project.project_id
@@ -31,8 +36,9 @@ resource "google_apigee_api" "test_apigee_api" {
 }
 
 resource "google_apigee_api_deployment" "test_apigee_api_deployment" {
-  environment = google_apigee_environment.apigee_environment.name
-  org_id = google_apigee_api.test_apigee_api.org_id
-  revision = google_apigee_api.test_apigee_api.latest_revision_id
-  proxy_id = google_apigee_api.test_apigee_api.name
+  environment     = google_apigee_environment.apigee_environment.name
+  org_id          = google_apigee_api.test_apigee_api.org_id
+  revision        = google_apigee_api.test_apigee_api.latest_revision_id
+  proxy_id        = google_apigee_api.test_apigee_api.name
+  service_account = google_service_account.proxy_sa.email
 }

--- a/mmv1/templates/terraform/samples/services/apigee/apigee_api_deployment_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/apigee/apigee_api_deployment_basic_test.tf.tmpl
@@ -67,6 +67,12 @@ resource "google_apigee_environment" "apigee_environment" {
   display_name = "environment-1"
 }
 
+resource "google_service_account" "proxy_sa" {
+  account_id   = "proxy-sa-%{random_suffix}"
+  display_name = "TF Proxy Test SA"
+  project      = google_project.project.project_id
+}
+
 resource "google_apigee_api" "test_apigee_api" {
   name            = "test-proxy"
   org_id          = google_project.project.project_id
@@ -75,8 +81,9 @@ resource "google_apigee_api" "test_apigee_api" {
 }
 
 resource "google_apigee_api_deployment" "{{$.PrimaryResourceId}}" {
-  environment = google_apigee_environment.apigee_environment.name
-  org_id = google_apigee_api.test_apigee_api.org_id
-  revision = google_apigee_api.test_apigee_api.latest_revision_id
-  proxy_id = google_apigee_api.test_apigee_api.name
+  environment     = google_apigee_environment.apigee_environment.name
+  org_id          = google_apigee_api.test_apigee_api.org_id
+  revision        = google_apigee_api.test_apigee_api.latest_revision_id
+  proxy_id        = google_apigee_api.test_apigee_api.name
+  service_account = google_service_account.proxy_sa.email
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
apigee: added `service_account` field to `google_compute_foo` resource
```
