### PR TITLE
Set GOPRIVATE for tgc-push step

### DIFF
--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -131,6 +131,7 @@ steps:
       waitFor: ["tpgb-push"]
       env:
         - BASE_BRANCH=$BRANCH_NAME
+        - GOPRIVATE=github.com/hashicorp/terraform-provider-google-beta
       args:
           - 'generate-downstream'
           - 'downstream'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

`tgc-push` runs `go get` on the beta provider commit that `tpgb-push` merged seconds earlier. We're in a race condition for sum.golang.org's indexing the new version, and lately it is likely to have slowed, causing 500 errors.

This fix sets `GOPRIVATE` for the beta provider in that step, so Go fteches it directly from Github and skips the proxy & checksum database. Skipping this is fine since we generated and pushed the exact commit ourselves one step earlier.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
