### PR TITLE
feat(workflows): make source_contents required for 8.0.0

### DIFF
--- a/mmv1/products/workflows/Workflow.yaml
+++ b/mmv1/products/workflows/Workflow.yaml
@@ -139,6 +139,7 @@ properties:
     diff_suppress_func: tpgresource.CompareSelfLinkOrResourceName
   - name: sourceContents
     type: String
+    required: true
     description: |
       Workflow code to be executed. The size limit is 128KB.
   - name: revisionId

--- a/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
@@ -112,3 +112,9 @@ upgrading.
 ### `scale_tier` has been removed
 
 The `scale_tier` argument has been removed from this resource. It was previously deprecated in favor of `scale_type`. When upgrading to version 8.0.0, remove any usage of `scale_tier` from your `google_netapp_storage_pool` configurations. You should use the `scale_type` argument instead for specifying the scale type.
+
+## Resource: `google_workflows_workflow`
+
+### `source_contents` is now Required
+
+The `source_contents` argument is now Required. Previously, this field was marked as Optional in Terraform, but omitting it led to runtime errors. When upgrading to version 8.0.0, you must ensure this argument is populated in your `google_workflows_workflow` configurations. 


### PR DESCRIPTION
This PR makes the `source_contents` field **Required** on the `google_workflows_workflow` resource. 

Currently, the field is marked as Optional in the provider schema, but the underlying Google Workflows API strictly requires source code to be present upon resource creation. Omitting it leads to runtime API errors today. 
    
This breaking change aligns with the API for the `8.0.0` major release. It also updates the Version 8.0.0 Upgrade Guide with instructions for users on how to adjust their configurations.

Warning about this change to be added in GoogleCloudPlatform/magic-modules/pull/18367
    
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28234
    
```release-note:breaking-change
workflows: `source_contents` is now required on `google_workflows_workflow`
```