### PR TITLE
container: invalidate igmCache on node pool update and delete [default]

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -158,6 +158,17 @@ func (instanceGroupManagerCache *instanceGroupManagerCache) needsRefresh(fullyQu
 	return time.Since(igm.updateTime) > instanceGroupManagerCache.ttl
 }
 
+func (instanceGroupManagerCache *instanceGroupManagerCache) remove(igmUrl string) {
+	instanceGroupManagerCache.mutex.Lock()
+	defer instanceGroupManagerCache.mutex.Unlock()
+
+	matches := instanceGroupManagerURL.FindStringSubmatch(igmUrl)
+	if len(matches) < 4 {
+		return
+	}
+	delete(instanceGroupManagerCache.instanceGroupManagers, matches[0])
+}
+
 // We need to set ttl to 0 to disable caching in VCR testing.
 // This ensure all NP/MIG LIST requests are made consistently,
 // preventing non-deterministic behavior that would break VCR.
@@ -1041,6 +1052,13 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	npCache.remove(nodePoolInfo.fullyQualifiedName(name))
+	if v, ok := d.GetOk("instance_group_urls"); ok {
+		for _, url := range v.([]interface{}) {
+			if strVal, ok := url.(string); ok {
+				igmCache.remove(strVal)
+			}
+		}
+	}
 
 	return resourceContainerNodePoolRead(d, meta)
 }
@@ -1130,6 +1148,13 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 	d.SetId("")
 
 	npCache.remove(nodePoolInfo.fullyQualifiedName(name))
+	if v, ok := d.GetOk("instance_group_urls"); ok {
+		for _, url := range v.([]interface{}) {
+			if strVal, ok := url.(string); ok {
+				igmCache.remove(strVal)
+			}
+		}
+	}
 
 	return nil
 }
@@ -2122,6 +2147,21 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				return err
 		}
 		log.Printf("[INFO] Updated node_drain_config in Node Pool %s", name)
+	}
+
+	if v, ok := d.GetOk(prefix + "instance_group_urls"); ok {
+		for _, url := range v.([]interface{}) {
+			if strVal, ok := url.(string); ok {
+				igmCache.remove(strVal)
+			}
+		}
+	}
+	if v, ok := d.GetOk("instance_group_urls"); ok {
+		for _, url := range v.([]interface{}) {
+			if strVal, ok := url.(string); ok {
+				igmCache.remove(strVal)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR fixes the 100% nightly acceptance test failure of `TestAccContainerNodePool_resize` in `google_container_node_pool` (issue #27957).

### Root Cause
Commit `06b4f2d43f` (#17968) increased the non-recording VCR cache TTL (`getCacheTTL()`) for node pools and instance group managers from 30 seconds to 5 minutes. When `google_container_node_pool` is updated or resized, `resourceContainerNodePoolUpdate` and `resourceContainerNodePoolDelete` call `npCache.remove(...)` to clear cached node pool metadata, but **never invalidated `igmCache`**.

Consequently, when `resourceContainerNodePoolRead` runs immediately after resizing a node pool, `igmCache.refreshIfNeeded(...)` sees that the cached IGMs are less than 5 minutes old (`needsRefresh` returns `false`) and returns the stale pre-resize IGMs, causing `node_count` to be calculated with the old target size (e.g. `node_count = 2` instead of `"3"`).

### Fix
1. Added `remove(igmUrl string)` to `*instanceGroupManagerCache` so individual IGM cache entries can be evicted.
2. In `resourceContainerNodePoolUpdate`, `resourceContainerNodePoolDelete`, and `nodePoolUpdate`, iterate over the node pool's `instance_group_urls` (and `prefix + "instance_group_urls"` for inline cluster node pools) and call `igmCache.remove(url)` on each IGM URL.
3. This ensures that when a node pool is updated, resized, or deleted, cached IGM target sizes are evicted, forcing any subsequent read within 5 minutes to fetch updated IGM target sizes from the GCE API.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27957

```release-note:bug
container: fixed `node_count` perma-diff in `google_container_node_pool` when resizing a node pool within 5 minutes of creation
```
