### PR TITLE
Tag binding on google_workbench_instance fails with 403 due to missing numeric instance ID attribute

### DIFF
--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -178,6 +178,12 @@ properties:
       The definition of how to configure a VM instance outside of Resources and Identity.
     default_from_api: true
     properties:
+      - name: 'computeInstanceId'
+        api_name: 'instanceId'
+        type: String
+        description: |
+          Output only. The unique numeric identifier of the underlying Compute Engine VM instance.
+        output: true
       - name: 'machineType'
         type: String
         description: |

--- a/mmv1/third_party/terraform/services/workbench/resource_workbench_instance_test.go
+++ b/mmv1/third_party/terraform/services/workbench/resource_workbench_instance_test.go
@@ -27,6 +27,8 @@ func TestAccWorkbenchInstance_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_workbench_instance.instance", "state", "ACTIVE"),
+					resource.TestCheckResourceAttrSet(
+						"google_workbench_instance.instance", "gce_setup.0.compute_instance_id"),
 				),
 			},
 			{


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/28510

Passing a google_workbench_instance's name into google_tags_location_tag_binding's parent field fails with a misleading 403, since the Tags API actually requires the backing Compute Engine VM's numeric instance ID, which google_workbench_instance had no way to expose.

Adds a new compute_instance_id output field, so that ID can be referenced directly in Terraform instead of looked up manually.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
workbench: added `compute_instance_id` field to `google_workbench_instance` resource
```
