### PR TITLE
container: invalidate IGM cache on node pool update/delete

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -158,6 +158,24 @@ func (instanceGroupManagerCache *instanceGroupManagerCache) needsRefresh(fullyQu
 	return time.Since(igm.updateTime) > instanceGroupManagerCache.ttl
 }
 
+func (instanceGroupManagerCache *instanceGroupManagerCache) remove(igmUrl string) {
+	instanceGroupManagerCache.mutex.Lock()
+	defer instanceGroupManagerCache.mutex.Unlock()
+
+	matches := instanceGroupManagerURL.FindStringSubmatch(igmUrl)
+	if len(matches) < 4 {
+		return
+	}
+	delete(instanceGroupManagerCache.instanceGroupManagers, matches[0])
+}
+
+func (instanceGroupManagerCache *instanceGroupManagerCache) clear() {
+	instanceGroupManagerCache.mutex.Lock()
+	defer instanceGroupManagerCache.mutex.Unlock()
+
+	instanceGroupManagerCache.instanceGroupManagers = make(map[string]*instanceGroupManagerWithUpdateTime)
+}
+
 // We need to set ttl to 0 to disable caching in VCR testing.
 // This ensure all NP/MIG LIST requests are made consistently,
 // preventing non-deterministic behavior that would break VCR.
@@ -1040,6 +1058,12 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
+	if np, err := npCache.get(nodePoolInfo.fullyQualifiedName(name)); err == nil {
+		for _, url := range np.InstanceGroupUrls {
+			igmCache.remove(url)
+		}
+	}
+	igmCache.clear()
 	npCache.remove(nodePoolInfo.fullyQualifiedName(name))
 
 	return resourceContainerNodePoolRead(d, meta)
@@ -1129,6 +1153,12 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId("")
 
+	if np, err := npCache.get(nodePoolInfo.fullyQualifiedName(name)); err == nil {
+		for _, url := range np.InstanceGroupUrls {
+			igmCache.remove(url)
+		}
+	}
+	igmCache.clear()
 	npCache.remove(nodePoolInfo.fullyQualifiedName(name))
 
 	return nil


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27957

In `google_container_node_pool`, when reading the resource state immediately after an update or delete in the same Terraform execution, `igmCache` was not invalidated. This caused `flattenNodePool` to read stale target sizes from the in-memory cache, resulting in state drift where `node_count` reflected the pre-update size.

This change adds `remove()` and `clear()` methods to `instanceGroupManagerCache` and invalidates `igmCache` during `resourceContainerNodePoolUpdate` and `resourceContainerNodePoolDelete`, resolving the `TestAccContainerNodePool_resize` acceptance test failure.

```release-note:bug
container: fixed stale cache in `google_container_node_pool` causing incorrect `node_count` in state after update
```
