### PR TITLE
Hide NetApp Trial resource until official API launch

### DIFF
--- a/mmv1/products/netapp/Trial.yaml
+++ b/mmv1/products/netapp/Trial.yaml
@@ -13,6 +13,7 @@
 
 ---
 name: Trial
+exclude_resource: true
 description: "A 30-day free trial for Google Cloud NetApp Volumes.\nIt is global in scope for a project but requires to be created in a valid cloud region in which Google Cloud NetApp Volumes is available.\n\n**Note:** Modifying the `location` of this resource will cause Terraform to destroy and recreate the trial. \nBecause Google Cloud enforces a limit of one free trial per project every 12 months, this recreation will fail. \nIt is highly recommended to use the `lifecycle { prevent_destroy = true }` block on this resource.\n"
 references:
   guides:


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```

### Implementation Details:
- Launch Embargo Enforcement: The `google_netapp_trial` resource was recently merged, but the official GA launch for the backend API is August 17th. Added the `exclude_resource: true` flag to the Trial YAML schema to temporarily hide the resource and instruct the compiler to actively skip it. This ensures the unreleased API does not leak into the public Terraform Provider release or registry documentation prior to launch.
- Verification: Ran make provider locally against the downstream google-beta repository and verified that the compiler successfully ignores the YAML and excludes all `resource_netapp_trial.go` footprints from the generated provider codebase.