### PR TITLE
Adding `google_chronicle_tenant` Resource

### DIFF
--- a/mmv1/api/resource/examples.go
+++ b/mmv1/api/resource/examples.go
@@ -128,6 +128,7 @@ type Examples struct {
 	//  - IDENTITY_USER
 	//  - CHRONICLE_ID
 	//  - VMWAREENGINE_PROJECT
+	//  - TENANT_GCP_PROJECT
 	// This list corresponds to the `get*FromEnv` methods in provider_test.go.
 	TestEnvVars map[string]string `yaml:"test_env_vars,omitempty"`
 
@@ -281,6 +282,7 @@ func (e *Examples) LoadHCLText(sysfs fs.FS) (err error) {
 		"PAP_DESCRIPTION":      "description",
 		"CHRONICLE_ID":         "00000000-0000-0000-0000-000000000000",
 		"VMWAREENGINE_PROJECT": "my-vmwareengine-project",
+		"TENANT_GCP_PROJECT":   "my-tenant-gcp-project",
 	}
 
 	// Apply doc defaults to test_env_vars from YAML

--- a/mmv1/api/resource/step.go
+++ b/mmv1/api/resource/step.go
@@ -70,6 +70,7 @@ type Step struct {
 	//  - IDENTITY_USER
 	//  - CHRONICLE_ID
 	//  - VMWAREENGINE_PROJECT
+	//  - TENANT_GCP_PROJECT
 	// This list corresponds to the `get*FromEnv` methods in provider_test.go.
 	TestEnvVars map[string]string `yaml:"test_env_vars,omitempty"`
 
@@ -213,6 +214,7 @@ func (s *Step) SetHCLText(sysfs fs.FS) {
 		"PAP_DESCRIPTION":      "description",
 		"CHRONICLE_ID":         "00000000-0000-0000-0000-000000000000",
 		"VMWAREENGINE_PROJECT": "my-vmwareengine-project",
+		"TENANT_GCP_PROJECT":   "my-tenant-gcp-project",
 	}
 
 	// Apply doc defaults to test_env_vars from YAML

--- a/mmv1/api/resource/sweeper.go
+++ b/mmv1/api/resource/sweeper.go
@@ -183,6 +183,8 @@ func (s Sweeper) EnvVarInterpolate(value string) string {
 		return "envvar.GetTestChronicleInstanceIdFromEnv(t)"
 	case "VMWAREENGINE_PROJECT":
 		return "envvar.GetTestVmwareengineProjectFromEnv(t)"
+	case "TENANT_GCP_PROJECT":
+		return "envvar.GetTestTenantGcpProjectFromEnv(t)"
 	case "ZONE":
 		return "envvar.GetTestZoneFromEnv()"
 	}
@@ -194,7 +196,7 @@ func (s Sweeper) EnvVarInterpolate(value string) string {
 		"${ORG_TARGET}", "${BILLING_ACCT}", "${MASTER_BILLING_ACCT}",
 		"${SERVICE_ACCT}", "${PROJECT_NAME}", "${PROJECT_NUMBER}",
 		"${CUST_ID}", "${IDENTITY_USER}", "${PAP_DESCRIPTION}",
-		"${CHRONICLE_ID}", "${VMWAREENGINE_PROJECT}", "${ZONE}",
+		"${CHRONICLE_ID}", "${VMWAREENGINE_PROJECT}", "${TENANT_GCP_PROJECT}", "${ZONE}",
 	} {
 		if strings.Contains(value, pattern) {
 			hasPattern = true
@@ -227,6 +229,7 @@ func (s Sweeper) EnvVarInterpolate(value string) string {
 		"${PAP_DESCRIPTION}":      "\" + envvar.GetTestPublicAdvertisedPrefixDescriptionFromEnv(t) + \"",
 		"${CHRONICLE_ID}":         "\" + envvar.GetTestChronicleInstanceIdFromEnv(t) + \"",
 		"${VMWAREENGINE_PROJECT}": "\" + envvar.GetTestVmwareengineProjectFromEnv(t) + \"",
+		"${TENANT_GCP_PROJECT}":   "\" + envvar.GetTestTenantGcpProjectFromEnv(t) + \"",
 		"${ZONE}":                 "\" + envvar.GetTestZoneFromEnv() + \"",
 	}
 

--- a/mmv1/products/chronicle/Tenant.yaml
+++ b/mmv1/products/chronicle/Tenant.yaml
@@ -1,0 +1,191 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Tenant
+description: The Tenant resource represents a customer tenant in Chronicle.
+min_version: 'beta'
+references:
+  guides:
+    'Google SecOps Guides': 'https://cloud.google.com/chronicle/docs/secops/secops-overview'
+  api: 'https://cloud.google.com/chronicle/docs/reference/rest/v1alpha/projects.locations.instances.tenants'
+base_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/tenants
+self_link: projects/{{project}}/locations/{{location}}/instances/{{instance}}
+create_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/tenants
+update_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/tenants/{{tenant}}
+id_format: projects/{{project}}/locations/{{location}}/instances/{{instance}}/tenants/{{tenant}}
+update_mask: true
+update_verb: PATCH
+exclude_delete: true
+exclude_read: true
+import_format:
+  - projects/{{project}}/locations/{{location}}/instances/{{instance}}/tenants/{{tenant}}
+async:
+  operation:
+    timeouts:
+      insert_minutes: 20
+    path: name
+    full_url: 'https://staging-chronicle.sandbox.googleapis.com/v1alpha/{{op_id}}'
+    wait_ms: 1000
+  actions:
+    - create
+  type: OpAsync
+  result:
+    resource_inside_response: true
+    path: response
+  error:
+    path: error
+    message: message
+  include_project: false
+autogen_status: VGVuYW50
+custom_code:
+  post_create: 'templates/terraform/post_create/chronicle_tenant_id.go.tmpl'
+samples:
+  - name: 'chronicle_tenant_basic'
+    primary_resource_id: chronicle_tenant_create_test
+    exclude_test: true
+    steps:
+      - name: 'chronicle_tenant_basic'
+        exclude_import_test: true
+        test_env_vars:
+          chronicle_id: 'CHRONICLE_ID'
+          tenant_gcp_project: 'TENANT_GCP_PROJECT'
+          billing_account: 'BILLING_ACCT'
+        vars:
+          resource_name: test-resource
+  - name: 'chronicle_tenant_update'
+    primary_resource_id: chronicle_tenant_update_test
+    exclude_basic_doc: true
+    steps:
+      - name: 'chronicle_tenant_update'
+        exclude_import_test: true
+        test_env_vars:
+          chronicle_id: 'CHRONICLE_ID'
+          tenant_gcp_project: 'TENANT_GCP_PROJECT'
+          billing_account: 'BILLING_ACCT'
+        vars:
+          resource_name: test-update
+      - name: 'chronicle_tenant_update_step2'
+        exclude_import_test: true
+        test_env_vars:
+          chronicle_id: 'CHRONICLE_ID'
+          tenant_gcp_project: 'TENANT_GCP_PROJECT'
+          billing_account: 'BILLING_ACCT'
+        vars:
+          resource_name: test-update
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: instance
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: tenant
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    default_from_api: true
+properties:
+  - name: authMethod
+    type: String
+    required: true
+    description: |-
+      Auth Method used by tenant
+      Possible values:
+      WORKFORCE_IDENTITY_FEDERATION
+      CLOUD_IDENTITY
+  - name: billingAccount
+    type: String
+    required: true
+    description: The billing account ID of the customer.
+  - name: customerCode
+    type: String
+    required: true
+    description: Customer code associated with the tenant.
+  - name: displayName
+    type: String
+    required: true
+    description: The display name of the tenant.
+    immutable: true
+  - name: frontendPathConfigs
+    type: Array
+    required: true
+    description: Configuration for the tenant's frontend paths.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: frontendPath
+          type: String
+          required: true
+          description: Frontend path that is part of the instance.
+        - name: workforcePoolProviderId
+          type: String
+          description: |-
+            Workforce pool provider id connected to the frontend path.
+            Format:
+            `locations/{location}/workforcePools/{workforce_pool_id}/providers/{provider_id}`
+  - name: name
+    type: String
+    description: |-
+      Identifier. The resource name of this tenant.
+      Format:
+      projects/{project}/locations/{location}/instances/{instance}/tenants/{tenant_id}
+    output: true
+  - name: provisioningFlow
+    type: String
+    required: false # From proto
+    description: |-
+      The provisioning flow of the tenant.
+      Possible values:
+      BACKSTORY_API_PARITY
+      TENANT_ATTRIBUTION
+  - name: retentionDuration
+    type: String
+    required: true
+    description: |-
+      Customer's contractually agreed data retention duration.
+      Possible values:
+      ONE_YEAR
+      EIGHTEEN_MONTHS
+      SIX_MONTHS
+      TWO_YEARS
+      THREE_YEARS
+      FOUR_YEARS
+      FIVE_YEARS
+      THIRTEEN_MONTHS
+      SIXTY_THREE_DAYS
+      THREE_MONTHS
+      UNLIMITED
+  - name: state
+    type: String
+    description: |-
+      The state of the Tenant.
+      Possible values:
+      ACTIVE
+      SOFT_DELETED
+      SOFT_DELETE_INITIATED
+      UNDELETE_INITIATED
+    output: true
+  - name: tenantGcpProject
+    type: String
+    required: true
+    description: |-
+      Project name of the tenant's BYOP project.
+      Format: projects/{project_id} or projects/{project_number}

--- a/mmv1/products/chronicle/product.yaml
+++ b/mmv1/products/chronicle/product.yaml
@@ -17,7 +17,7 @@ display_name: Chronicle
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 versions:
-  - name: ga
-    base_url: https://{{location}}-chronicle.googleapis.com/v1/
-  - name: beta
-    base_url: https://{{location}}-chronicle.googleapis.com/v1beta/
+ - name: ga
+   base_url: https://{{location}}-chronicle.googleapis.com/v1/
+ - name: beta
+   base_url: https://{{location}}-chronicle.googleapis.com/v1beta/

--- a/mmv1/provider/template_data.go
+++ b/mmv1/provider/template_data.go
@@ -164,6 +164,7 @@ func (td *TemplateData) GenerateTestFile(filePath string, resource api.Resource)
 		PAP_DESCRIPTION:      "description",
 		CHRONICLE_ID:         "00000000-0000-0000-0000-000000000000",
 		VMWAREENGINE_PROJECT: "my-vmwareengine-project",
+		TENANT_GCP_PROJECT:   "my-tenant-gcp-project",
 	}
 
 	td.GenerateFile(filePath, templatePath, tmplInput, true, templates...)
@@ -193,6 +194,7 @@ func (td *TemplateData) GenerateDataSourceTestFile(filePath string, resource api
 		PAP_DESCRIPTION:      "description",
 		CHRONICLE_ID:         "00000000-0000-0000-0000-000000000000",
 		VMWAREENGINE_PROJECT: "my-vmwareengine-project",
+		TENANT_GCP_PROJECT:   "my-tenant-gcp-project",
 	}
 
 	td.GenerateFile(filePath, templatePath, tmplInput, true, templates...)
@@ -342,4 +344,5 @@ type TestInput struct {
 	PAP_DESCRIPTION      string
 	CHRONICLE_ID         string
 	VMWAREENGINE_PROJECT string
+	TENANT_GCP_PROJECT   string
 }

--- a/mmv1/templates/terraform/env_var_context.go.tmpl
+++ b/mmv1/templates/terraform/env_var_context.go.tmpl
@@ -30,6 +30,8 @@
 		"{{$varKey}}": envvar.GetTestChronicleInstanceIdFromEnv(t),
 		{{- else if eq $varVal "VMWAREENGINE_PROJECT" }}
 		"{{$varKey}}": envvar.GetTestVmwareengineProjectFromEnv(t),
+		{{- else if eq $varVal "TENANT_GCP_PROJECT" }}
+		"{{$varKey}}": envvar.GetTestTenantGcpProjectFromEnv(t),
 		{{- else if eq $varVal "ZONE" }}
 		"{{$varKey}}": envvar.GetTestZoneFromEnv(),
 		{{- end }}

--- a/mmv1/templates/terraform/post_create/chronicle_tenant_id.go.tmpl
+++ b/mmv1/templates/terraform/post_create/chronicle_tenant_id.go.tmpl
@@ -1,0 +1,15 @@
+metadata := res["metadata"].(map[string]interface{})
+tenant := metadata["tenant"].(string)
+parts := strings.Split(tenant, "/")
+tenant_id := parts[len(parts)-1]
+log.Printf("[DEBUG] Setting tenant to %s", tenant_id)
+if err := d.Set("tenant", tenant_id); err != nil {
+	return fmt.Errorf("Error setting Tenant ID: %s", err)
+}
+
+// This may have caused the ID to update - update it if so.
+id, err = tpgresource.ReplaceVars(d, config, "projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/instances/{{"{{"}}instance{{"}}"}}/tenants/{{"{{"}}tenant{{"}}"}}")
+if err != nil {
+	return fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_tenant_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_tenant_basic.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_chronicle_tenant" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  location = "us"
+  instance = "{{index $.TestEnvVars "chronicle_id"}}"
+
+  display_name       = "Basic Tenant {{index $.Vars "resource_name"}}"
+  retention_duration = "ONE_YEAR"
+  tenant_gcp_project = "{{index $.TestEnvVars "tenant_gcp_project"}}"
+  billing_account    = "{{index $.TestEnvVars "billing_account"}}"
+  provisioning_flow  = "BACKSTORY_API_PARITY"
+  auth_method        = "CLOUD_IDENTITY"
+  customer_code      = lower("cust%{random_suffix}")
+  frontend_path_configs {
+    frontend_path = "path-%{random_suffix}"
+  }
+}

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_tenant_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_tenant_update.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_chronicle_tenant" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  location = "us"
+  instance = "{{index $.TestEnvVars "chronicle_id"}}"
+
+  display_name       = "Basic Tenant {{index $.Vars "resource_name"}}"
+  retention_duration = "ONE_YEAR"
+  tenant_gcp_project = "{{index $.TestEnvVars "tenant_gcp_project"}}"
+  billing_account    = "{{index $.TestEnvVars "billing_account"}}"
+  provisioning_flow  = "BACKSTORY_API_PARITY"
+  auth_method        = "CLOUD_IDENTITY"
+  customer_code      = lower("cust%{random_suffix}")
+  frontend_path_configs {
+    frontend_path = "path-%{random_suffix}"
+  }
+}

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_tenant_update_step2.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_tenant_update_step2.tf.tmpl
@@ -1,0 +1,23 @@
+resource "google_chronicle_tenant" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  location = "us"
+  instance = "{{index $.TestEnvVars "chronicle_id"}}"
+
+  display_name       = "Basic Tenant {{index $.Vars "resource_name"}}"
+  retention_duration = "ONE_YEAR"
+  tenant_gcp_project = "{{index $.TestEnvVars "tenant_gcp_project"}}"
+  billing_account    = "{{index $.TestEnvVars "billing_account"}}"
+  provisioning_flow  = "BACKSTORY_API_PARITY"
+  auth_method        = "WORKFORCE_IDENTITY_FEDERATION"
+  customer_code      = lower("cust%{random_suffix}")
+
+  frontend_path_configs {
+    frontend_path              = "path-%{random_suffix}"
+    workforce_pool_provider_id = "locations/global/workforcePools/your-pool-id/providers/your-provider-id"
+  }
+
+  frontend_path_configs {
+    frontend_path              = "testingtenant-path-%{random_suffix}"
+    workforce_pool_provider_id = "locations/global/workforcePools/your-pool-id/providers/your-provider-id"
+  }
+}

--- a/mmv1/third_party/terraform/envvar/envvar_utils.go
+++ b/mmv1/third_party/terraform/envvar/envvar_utils.go
@@ -123,6 +123,11 @@ var vmwareengineProjectEnvVars = []string{
 	"GOOGLE_VMWAREENGINE_PROJECT",
 }
 
+// This value is the project used for chronicle tenant tests.
+var TenantGcpProjectEnvVars = []string{
+	"GOOGLE_TENANT_GCP_PROJECT",
+}
+
 // AccTestPreCheck ensures at least one of the project env variables is set.
 func GetTestProjectNumberFromEnv() string {
 	return MultiEnvSearch(ProjectNumberEnvVars)
@@ -230,6 +235,11 @@ func GetTestChronicleInstanceIdFromEnv(t *testing.T) string {
 func GetTestVmwareengineProjectFromEnv(t *testing.T) string {
 	SkipIfEnvNotSet(t, vmwareengineProjectEnvVars...)
 	return MultiEnvSearch(vmwareengineProjectEnvVars)
+}
+
+func GetTestTenantGcpProjectFromEnv(t *testing.T) string {
+	SkipIfEnvNotSet(t, TenantGcpProjectEnvVars...)
+	return MultiEnvSearch(TenantGcpProjectEnvVars)
 }
 
 func SkipIfEnvNotSet(t *testing.T, envs ...string) {

--- a/mmv1/third_party/terraform/services/chronicle/chronicle_operation.go
+++ b/mmv1/third_party/terraform/services/chronicle/chronicle_operation.go
@@ -3,6 +3,7 @@ package chronicle
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -21,10 +22,15 @@ func (w *ChronicleOperationWaiter) QueryOp() (interface{}, error) {
 		return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
 	}
 
-	region := tpgresource.GetRegionFromRegionalSelfLink(w.CommonOperationWaiter.Op.Name)
-
-	// Returns the proper get.
-	url := fmt.Sprintf("https://%s-chronicle.googleapis.com/v1/%s", region, w.CommonOperationWaiter.Op.Name)
+	baseUrl := transport_tpg.BaseUrl(Product, w.Config)
+	var url string
+	if strings.Contains(baseUrl, "v1alpha") {
+		url = fmt.Sprintf("%s%s", baseUrl, w.CommonOperationWaiter.Op.Name)
+	} else {
+		region := tpgresource.GetRegionFromRegionalSelfLink(w.CommonOperationWaiter.Op.Name)
+		baseUrl = strings.ReplaceAll(baseUrl, "{{location}}", region)
+		url = fmt.Sprintf("%s%s", baseUrl, w.CommonOperationWaiter.Op.Name)
+	}
 
 	return transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    w.Config,

--- a/mmv1/third_party/terraform/services/chronicle/chronicle_operation.go
+++ b/mmv1/third_party/terraform/services/chronicle/chronicle_operation.go
@@ -23,14 +23,11 @@ func (w *ChronicleOperationWaiter) QueryOp() (interface{}, error) {
 	}
 
 	baseUrl := transport_tpg.BaseUrl(Product, w.Config)
-	var url string
-	if strings.Contains(baseUrl, "v1alpha") {
-		url = fmt.Sprintf("%s%s", baseUrl, w.CommonOperationWaiter.Op.Name)
-	} else {
+	if strings.Contains(baseUrl, "{{location}}") {
 		region := tpgresource.GetRegionFromRegionalSelfLink(w.CommonOperationWaiter.Op.Name)
 		baseUrl = strings.ReplaceAll(baseUrl, "{{location}}", region)
-		url = fmt.Sprintf("%s%s", baseUrl, w.CommonOperationWaiter.Op.Name)
 	}
+	url := fmt.Sprintf("%s%s", baseUrl, w.CommonOperationWaiter.Op.Name)
 
 	return transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    w.Config,


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR introduces the new `google_chronicle_tenant` resource alongside support for alpha/beta/stable endpoints and associated testing environment variables.

 ### Key Changes
1. **Added `google_chronicle_tenant` Resource**:
- Represents customer tenants in Chronicle (SecOps).
- Configured with properties like `auth_method`, `billing_account`, `customer_code`, `display_name`, `frontend_path_configs`, `provisioning_flow`, `retention_duration`, and `tenant_gcp_project`.
- Defined asynchronous creation handling via `OpAsync` operation waiters.
- Implemented a custom `post_create` script (`chronicle_tenant_id.go.tmpl`) to parse the `tenant_id` from operation metadata and correctly set the resource identifier.

2. **Robust Waiter / Base URL Resolution**:
- Modified `chronicle_operation.go` to dynamically query the configured base URL (`transport_tpg.BaseUrl`) and interpolate regions/locations, rather than relying on a hardcoded regional production URL format.

3. **Test Infrastructure Support**:
- Registered `TENANT_GCP_PROJECT` (backed by the `GOOGLE_TENANT_GCP_PROJECT` environment variable) across MMv1 code generators, sweeper, and test template context to allow robust acceptance testing.
- Added `chronicle_tenant` acceptance test templates (`chronicle_tenant_basic`, `chronicle_tenant_update`, and
      `chronicle_tenant_update_step2`).
***

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

 ```release-note:new-resource
chronicle: added `google_chronicle_tenant` resource to support the Chronicle Tenant service (beta)
```
