### PR TITLE
Promote host_error_timeout_seconds to GA in compute instance and templates

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -219,7 +219,6 @@ func expandScheduling(v interface{}) (map[string]interface{}, error) {
 			result["onInstanceStopAction"] = transformedOnInstanceStopAction
 		}
 	}
-{{- if ne $.TargetVersionName "ga" }}
 	if v, ok := original["host_error_timeout_seconds"]; ok {
 		//host_error_timeout_seconds doesn't get removed correctly due to an API bug on instances.SetScheduling.
 		//We need to send null as a workaround because nil is rounded to 0
@@ -229,6 +228,7 @@ func expandScheduling(v interface{}) (map[string]interface{}, error) {
 			result["hostErrorTimeoutSeconds"] = int64(v.(int))
 		}
 	}
+{{- if ne $.TargetVersionName "ga" }}
 
 	if v, ok := original["maintenance_interval"]; ok && v.(string) != "" {
 		result["maintenanceInterval"] = v.(string)
@@ -423,12 +423,12 @@ func flattenScheduling(resp map[string]interface{}) []map[string]interface{} {
 		schedulingMap["on_instance_stop_action"] = flattenOnInstanceStopAction(ois)
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
-	schedulingMap["skip_guest_os_shutdown"] = resp["skipGuestOsShutdown"]
-
 	if h := getInt(resp["hostErrorTimeoutSeconds"]); h != 0 {
 		schedulingMap["host_error_timeout_seconds"] = h
 	}
+
+{{ if ne $.TargetVersionName `ga` -}}
+	schedulingMap["skip_guest_os_shutdown"] = resp["skipGuestOsShutdown"]
 
 	if mi, ok := resp["maintenanceInterval"].(string); ok && mi != "" {
 		schedulingMap["maintenance_interval"] = mi
@@ -1224,10 +1224,10 @@ func schedulingHasChangeWithoutReboot(d *schema.ResourceData) bool {
 	if oScheduling["availability_domain"] != newScheduling["availability_domain"] {
 			return true
 	}
-{{- if ne $.TargetVersionName "ga" }}
 	if oScheduling["host_error_timeout_seconds"] != newScheduling["host_error_timeout_seconds"] {
 		return true
 	}
+{{- if ne $.TargetVersionName "ga" }}
 
 	if oScheduling["skip_guest_os_shutdown"] != newScheduling["skip_guest_os_shutdown"] {
 		return true

--- a/mmv1/third_party/terraform/services/compute/compute_instance_http_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_http_helpers.go.tmpl
@@ -192,8 +192,8 @@ func FlattenSchedulingHTTP(resp map[string]interface{}) []map[string]interface{}
 	schedulingMap["skip_guest_os_shutdown"] = v_sgos
 {{- if ne $.TargetVersionName "ga" }}
 	if v, ok := resp["maintenanceInterval"]; ok { schedulingMap["maintenance_interval"] = v }
-	if v, ok := resp["hostErrorTimeoutSeconds"]; ok { schedulingMap["host_error_timeout_seconds"] = ParseIntHTTP(v) }
 {{- end }}
+	if v, ok := resp["hostErrorTimeoutSeconds"]; ok { schedulingMap["host_error_timeout_seconds"] = ParseIntHTTP(v) }
 
 	if maxDurRaw, ok := resp["maxRunDuration"]; ok && maxDurRaw != nil {
 		maxDur := maxDurRaw.(map[string]interface{})

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -119,9 +119,9 @@ var (
 		"scheduling.0.availability_domain",
 		"scheduling.0.max_run_duration",
 		"scheduling.0.on_instance_stop_action",
+		"scheduling.0.host_error_timeout_seconds",
 {{- if ne $.TargetVersionName "ga" }}
 		"scheduling.0.maintenance_interval",
-		"scheduling.0.host_error_timeout_seconds",
 		"scheduling.0.graceful_shutdown",
 		"scheduling.0.skip_guest_os_shutdown",
 		"scheduling.0.preemption_notice_duration",
@@ -1264,12 +1264,12 @@ be from 0 to 999,999,999 inclusive.`,
 								},
 							},
 						},
-{{- if ne $.TargetVersionName "ga" }}
 						"host_error_timeout_seconds": {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: `Specify the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.`,
 						},
+{{- if ne $.TargetVersionName "ga" }}
 
 						"maintenance_interval": {
 							Type:          schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_meta.yaml.tmpl
@@ -234,9 +234,7 @@ fields:
   - api_field: 'scheduling.gracefulShutdown.maxDuration.nanos'
   - api_field: 'scheduling.gracefulShutdown.maxDuration.seconds'
 {{- end }}
-{{- if ne $.TargetVersionName "ga" }}
   - api_field: 'scheduling.hostErrorTimeoutSeconds'
-{{- end }}
   - api_field: 'scheduling.instanceTerminationAction'
   - api_field: 'scheduling.localSsdRecoveryTimeout.nanos'
   - api_field: 'scheduling.localSsdRecoveryTimeout.seconds'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_meta.yaml.tmpl
@@ -237,9 +237,7 @@ fields:
   - api_field: 'scheduling.gracefulShutdown.maxDuration.nanos'
   - api_field: 'scheduling.gracefulShutdown.maxDuration.seconds'
 {{- end }}
-{{- if ne $.TargetVersionName "ga" }}
   - api_field: 'scheduling.hostErrorTimeoutSeconds'
-{{- end }}
   - api_field: 'scheduling.instanceTerminationAction'
   - api_field: 'scheduling.localSsdRecoveryTimeout.nanos'
   - api_field: 'scheduling.localSsdRecoveryTimeout.seconds'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -40,9 +40,9 @@ var (
 		"scheduling.0.max_run_duration",
 		"scheduling.0.on_instance_stop_action",
 		"scheduling.0.termination_time",
+		"scheduling.0.host_error_timeout_seconds",
 {{- if ne $.TargetVersionName "ga" }}
 		"scheduling.0.maintenance_interval",
-		"scheduling.0.host_error_timeout_seconds",
 		"scheduling.0.graceful_shutdown",
 		"scheduling.0.skip_guest_os_shutdown",
 		"scheduling.0.preemption_notice_duration",
@@ -904,13 +904,13 @@ be from 0 to 999,999,999 inclusive.`,
 in RFC3339 text format. If specified, the instance termination action
 will be performed at the termination time.`,
 						},
-{{- if ne $.TargetVersionName "ga" }}
 						"host_error_timeout_seconds": {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							ForceNew:    true,
 							Description: `Specify the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.`,
 						},
+{{- if ne $.TargetVersionName "ga" }}
 
 						"maintenance_interval" : {
 							Type:        schema.TypeString,
@@ -2358,7 +2358,6 @@ func expandResourceComputeInstanceTemplateScheduling(d *schema.ResourceData, met
 			schedulingTyped.ForceSendFields = append(schedulingTyped.ForceSendFields, pair[1])
 		}
 	}
-{{- if ne $.TargetVersionName "ga" }}
 	if v, ok := expanded["hostErrorTimeoutSeconds"]; ok {
 		if v == nil {
 			schedulingTyped.NullFields = append(schedulingTyped.NullFields, "HostErrorTimeoutSeconds")
@@ -2366,7 +2365,6 @@ func expandResourceComputeInstanceTemplateScheduling(d *schema.ResourceData, met
 			schedulingTyped.ForceSendFields = append(schedulingTyped.ForceSendFields, "HostErrorTimeoutSeconds")
 		}
 	}
-{{- end }}
 	return schedulingTyped, nil
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_meta.yaml.tmpl
@@ -209,10 +209,8 @@ fields:
   - api_field: 'properties.scheduling.gracefulShutdown.maxDuration.seconds'
     field: 'scheduling.graceful_shutdown.max_duration.seconds'
 {{- end }}
-{{- if ne $.TargetVersionName "ga" }}
   - field: 'scheduling.host_error_timeout_seconds'
     api_field: 'properties.scheduling.hostErrorTimeoutSeconds'
-{{- end }}
   - field: 'scheduling.instance_termination_action'
     api_field: 'properties.scheduling.instanceTerminationAction'
   - field: 'scheduling.local_ssd_recovery_timeout.nanos'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -218,7 +218,6 @@ func TestAccComputeInstanceTemplate_maintenance_interval(t *testing.T) {
 }
 {{- end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeInstanceTemplate_hostErrorTimeoutSeconds(t *testing.T) {
 	t.Parallel()
 
@@ -254,7 +253,6 @@ func TestAccComputeInstanceTemplate_hostErrorTimeoutSeconds(t *testing.T) {
 		},
 	})
 }
-{{- end }}
 
 func TestAccComputeInstanceTemplate_IP(t *testing.T) {
 	t.Parallel()
@@ -3462,6 +3460,7 @@ resource "google_compute_instance_template" "foobar" {
 }
 `, suffix)
 }
+{{ end }}
 
 func testAccComputeInstanceTemplate_hostErrorTimeoutSeconds(suffix string) string {
 	return fmt.Sprintf(`
@@ -3504,8 +3503,6 @@ resource "google_compute_instance_template" "foobar" {
 }
 `, suffix)
 }
-
-{{ end }}
 
 func testAccComputeInstanceTemplate_ip(suffix string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -2363,7 +2363,6 @@ func TestAccComputeInstance_reservationAffinities(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeInstance_hostErrorTimeoutSecconds(t *testing.T) {
 	t.Parallel()
 
@@ -2440,7 +2439,6 @@ func TestAccComputeInstance_hostErrorTimeoutSecconds(t *testing.T) {
 		},
 	})
 }
-{{- end }}
 
 func TestAccComputeInstance_subnet_auto(t *testing.T) {
 	t.Parallel()
@@ -11038,7 +11036,6 @@ resource "google_compute_instance" "foobar" {
 `, instanceName)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeInstance_hostErrorTimeoutSeconds(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
@@ -11067,7 +11064,6 @@ resource "google_compute_instance" "foobar" {
 }
 `, context)
 }
-{{- end }}
 
 func testAccComputeInstance_shieldedVmConfig(instance string, enableSecureBoot bool, enableVtpm bool, enableIntegrityMonitoring bool) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -865,13 +865,13 @@ be from 0 to 999,999,999 inclusive.`,
 								},
 							},
 						},
-{{- if ne $.TargetVersionName "ga" }}
 						"host_error_timeout_seconds": {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							ForceNew:    true,
 							Description: `Specify the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.`,
 						},
+{{- if ne $.TargetVersionName "ga" }}
 
 						"maintenance_interval" : {
 							Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_meta.yaml.tmpl
@@ -207,10 +207,8 @@ fields:
   - api_field: 'properties.scheduling.gracefulShutdown.maxDuration.seconds'
     field: 'scheduling.graceful_shutdown.max_duration.seconds'
 {{- end }}
-{{- if ne $.TargetVersionName "ga" }}
   - field: 'scheduling.host_error_timeout_seconds'
     api_field: 'properties.scheduling.hostErrorTimeoutSeconds'
-{{- end }}
   - field: 'scheduling.instance_termination_action'
     api_field: 'properties.scheduling.instanceTerminationAction'
   - field: 'scheduling.local_ssd_recovery_timeout.nanos'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -57,6 +57,42 @@ func TestAccComputeRegionInstanceTemplate_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionInstanceTemplate_hostErrorTimeoutSeconds(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate map[string]interface{}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories:    acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_hostErrorTimeoutSeconds(acctest.RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "scheduling.0.host_error_timeout_seconds", "120"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccComputeRegionInstanceTemplate_basic(acctest.RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "scheduling.0.host_error_timeout_seconds", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeRegionInstanceTemplate_imageShorthand(t *testing.T) {
 	t.Parallel()
 
@@ -2859,6 +2895,49 @@ resource "google_compute_region_instance_template" "foobar" {
   scheduling {
     preemptible       = false
     automatic_restart = true
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  labels = {
+    my_label = "foobar"
+  }
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_hostErrorTimeoutSeconds(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  region         = "us-central1"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    host_error_timeout_seconds = 120
   }
 
   metadata = {

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -192,7 +192,7 @@ The following arguments are supported:
 
 <a name="nested_scheduling"></a>The `scheduling` block supports:
 
-* `host_error_timeout_seconds` - [Beta](../guides/provider_versions.html.markdown) Time in seconds for host error detection.
+* `host_error_timeout_seconds` - Time in seconds for host error detection.
 
 * `preemptible` - Whether the instance is preemptible.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
@@ -279,7 +279,7 @@ The `disk_encryption_key` block supports:
    [here](https://cloud.google.com/compute/docs/nodes/create-nodes).
    Structure [documented below](#nested_node_affinities).
 
-* `host_error_timeout_seconds` - [Beta](../guides/provider_versions.html.markdown) Time in seconds for host error detection.
+* `host_error_timeout_seconds` - Time in seconds for host error detection.
 
 * `provisioning_model` - Describe the type of provisioning model for the instance. Can be `STANDARD`, `SPOT`, `FLEX_START`, or `RESERVATION_BOUND`.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
@@ -263,7 +263,7 @@ The `disk_encryption_key` block supports:
    [here](https://cloud.google.com/compute/docs/nodes/create-nodes).
    Structure [documented below](#nested_node_affinities).
 
-* `host_error_timeout_seconds` - [Beta](../guides/provider_versions.html.markdown) Time in seconds for host error detection.
+* `host_error_timeout_seconds` - Time in seconds for host error detection.
 
 * `provisioning_model` - Describe the type of provisioning model for the instance. Can be `STANDARD`, `SPOT`, `FLEX_START`, or `RESERVATION_BOUND`.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -605,7 +605,7 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `on_instance_stop_action` - (Optional) Specifies the action to be performed when the instance is terminated using `max_run_duration` and `STOP` `instance_termination_action`. Only support `true` `discard_local_ssd` at this point. Structure is [documented below](#nested_on_instance_stop_action).
 
-* `host_error_timeout_seconds` - (Optional) [Beta](../guides/provider_versions.html.markdown) Specifies the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.
+* `host_error_timeout_seconds` - (Optional) Specifies the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.
 
 * `maintenance_interval` - (Optional) [Beta](../guides/provider_versions.html.markdown) Specifies the frequency of planned maintenance events. The accepted values are: `PERIODIC`.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -699,7 +699,7 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `on_instance_stop_action` - (Optional) Specifies the action to be performed when the instance is terminated using `max_run_duration` and `STOP` `instance_termination_action`. Only support `true` `discard_local_ssd` at this point. Structure is [documented below](#nested_on_instance_stop_action).
 
-* `host_error_timeout_seconds` - (Optional) [Beta](../guides/provider_versions.html.markdown) Specifies the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.
+* `host_error_timeout_seconds` - (Optional) Specifies the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.
 
 * `maintenance_interval` - (Optional) [Beta](../guides/provider_versions.html.markdown) Specifies the frequency of planned maintenance events. The accepted values are: `PERIODIC`.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -668,7 +668,7 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `availability_domain` - (Optional) Specifies the availability domain to place the instance in. The value must be a number between 1 and the number of availability domains specified in the spread placement policy attached to the instance.
 
-* `host_error_timeout_seconds` - (Optional) [Beta](../guides/provider_versions.html.markdown) Specifies the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.
+* `host_error_timeout_seconds` - (Optional) Specifies the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.
 
 * `max_run_duration` -  (Optional)  The duration of the instance. Instance will run and be terminated after then, the termination action could be defined in `instance_termination_action`. Only support `DELETE` `instance_termination_action` at this point. Structure is [documented below](#nested_max_run_duration).
 


### PR DESCRIPTION
Promotes `scheduling.host_error_timeout_seconds` from beta to GA for:
- `google_compute_instance` (and `google_compute_instance_from_template` via shared schema)
- `google_compute_instance_template`
- `google_compute_region_instance_template`

The field is GA in the compute v1 API (`scheduling.hostErrorTimeoutSeconds`,
see https://docs.cloud.google.com/compute/docs/instances/setting-vm-host-options#available_host_maintenance_properties),
but the provider still gated it behind the beta version guards added in #11652.
The null-send workaround for the `instances.setScheduling` API bug (#11798) is preserved unchanged.

Changes:
- Moved the field out of `TargetVersionName` guards in the handwritten compute
  templates (schema, expand, flatten, no-reboot diff detection, ForceSendFields/NullFields).
- Unguarded the field in the `_meta.yaml.tmpl` files (instance, instance_from_template,
  instance_template, region_instance_template).
- Unguarded the existing acceptance tests `TestAccComputeInstance_hostErrorTimeoutSecconds`
  and `TestAccComputeInstanceTemplate_hostErrorTimeoutSeconds`; both already used
  GA-style provider factories and configs.
- Added `TestAccComputeRegionInstanceTemplate_hostErrorTimeoutSeconds` (the region
  template previously had no coverage for this field).
- Removed the `[Beta]` annotation from the six resource/datasource docs pages.

Still-beta scheduling fields (`maintenance_interval`, `graceful_shutdown`,
`skip_guest_os_shutdown`, `preemption_notice_duration`) remain guarded.

Fixes hashicorp/terraform-provider-google#27536

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: promoted `host_error_timeout_seconds` field in `google_compute_instance`, `google_compute_instance_template` and `google_compute_region_instance_template` to GA
```
