### PR TITLE
bigquery: diagnose incomplete dataset IAM conditions

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/iam_bigquery_member_dataset.go
+++ b/mmv1/third_party/terraform/services/bigquery/iam_bigquery_member_dataset.go
@@ -209,8 +209,21 @@ func accessToPolicyForIamMember(access interface{}) (*cloudresourcemanager.Polic
 
 		var condition *cloudresourcemanager.Expr
 		if rawCondition, ok := memberRole["condition"]; ok {
-			conditionMap := rawCondition.(map[string]interface{})
-			expr := conditionMap["expression"].(string)
+			conditionMap, ok := rawCondition.(map[string]interface{})
+			if !ok {
+				return nil, errors.New("BigQuery dataset IAM condition must be an object")
+			}
+			rawExpr, ok := conditionMap["expression"]
+			if !ok {
+				return nil, errors.New("BigQuery dataset IAM condition is missing expression")
+			}
+			expr, ok := rawExpr.(string)
+			if !ok {
+				return nil, errors.New("BigQuery dataset IAM condition expression must be a non-empty string")
+			}
+			if expr == "" {
+				return nil, errors.New("BigQuery dataset IAM condition expression must not be empty")
+			}
 			condition = &cloudresourcemanager.Expr{Expression: expr}
 			if title, ok := conditionMap["title"].(string); ok {
 				condition.Title = title

--- a/mmv1/third_party/terraform/services/bigquery/iam_bigquery_member_dataset_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/iam_bigquery_member_dataset_test.go
@@ -1,0 +1,113 @@
+package bigquery
+
+import "testing"
+
+func TestAccessToPolicyForIamMemberRejectsConditionWithoutExpression(t *testing.T) {
+	access := []interface{}{
+		map[string]interface{}{
+			"role":        "READER",
+			"userByEmail": "reader@example.com",
+			"condition": map[string]interface{}{
+				"title": "temporary access",
+			},
+		},
+	}
+
+	_, err := accessToPolicyForIamMember(access)
+	if err == nil {
+		t.Fatal("accessToPolicyForIamMember returned nil error for a condition without expression")
+	}
+	if got, want := err.Error(), "BigQuery dataset IAM condition is missing expression"; got != want {
+		t.Fatalf("accessToPolicyForIamMember error = %q, want %q", got, want)
+	}
+}
+
+func TestAccessToPolicyForIamMemberRejectsInvalidConditionExpressions(t *testing.T) {
+	testCases := []struct {
+		name      string
+		condition interface{}
+		errorText string
+	}{
+		{
+			name:      "non-object condition",
+			condition: "not an object",
+			errorText: "BigQuery dataset IAM condition must be an object",
+		},
+		{
+			name: "non-string expression",
+			condition: map[string]interface{}{
+				"expression": 1,
+			},
+			errorText: "BigQuery dataset IAM condition expression must be a non-empty string",
+		},
+		{
+			name: "empty expression",
+			condition: map[string]interface{}{
+				"expression": "",
+			},
+			errorText: "BigQuery dataset IAM condition expression must not be empty",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			access := []interface{}{
+				map[string]interface{}{
+					"role":        "READER",
+					"userByEmail": "reader@example.com",
+					"condition":   testCase.condition,
+				},
+			}
+
+			_, err := accessToPolicyForIamMember(access)
+			if err == nil {
+				t.Fatal("accessToPolicyForIamMember returned nil error for an invalid condition")
+			}
+			if got, want := err.Error(), testCase.errorText; got != want {
+				t.Fatalf("accessToPolicyForIamMember error = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestAccessToPolicyForIamMemberPreservesValidCondition(t *testing.T) {
+	access := []interface{}{
+		map[string]interface{}{
+			"role":        "READER",
+			"userByEmail": "reader@example.com",
+			"condition": map[string]interface{}{
+				"expression":  "request.time < timestamp('2030-01-01T00:00:00Z')",
+				"title":       "temporary access",
+				"description": "access expires in 2030",
+			},
+		},
+	}
+
+	policy, err := accessToPolicyForIamMember(access)
+	if err != nil {
+		t.Fatalf("accessToPolicyForIamMember returned unexpected error: %v", err)
+	}
+	if len(policy.Bindings) != 1 {
+		t.Fatalf("accessToPolicyForIamMember returned %d bindings, want 1", len(policy.Bindings))
+	}
+
+	binding := policy.Bindings[0]
+	if binding.Role != "roles/bigquery.dataViewer" {
+		t.Errorf("binding role = %q, want %q", binding.Role, "roles/bigquery.dataViewer")
+	}
+	if len(binding.Members) != 1 || binding.Members[0] != "user:reader@example.com" {
+		t.Errorf("binding members = %#v, want [user:reader@example.com]", binding.Members)
+	}
+	if binding.Condition == nil {
+		t.Fatal("binding condition is nil")
+	}
+	if binding.Condition.Expression != "request.time < timestamp('2030-01-01T00:00:00Z')" {
+		t.Errorf("binding condition expression = %q, want original expression", binding.Condition.Expression)
+	}
+	if binding.Condition.Title != "temporary access" {
+		t.Errorf("binding condition title = %q, want %q", binding.Condition.Title, "temporary access")
+	}
+	if binding.Condition.Description != "access expires in 2030" {
+		t.Errorf("binding condition description = %q, want %q", binding.Condition.Description, "access expires in 2030")
+	}
+}


### PR DESCRIPTION
## Problem

`accessToPolicyForIamMember` assumes that every BigQuery dataset IAM condition returned by the API has a string `expression`:

```go
expr := conditionMap["expression"].(string)
```

BigQuery can return an access entry with a condition object that has metadata such as `title` but no `expression`. Refreshing an IAM-member resource against such a dataset panics the provider during policy decoding, which aborts the Terraform process and cancels unrelated refreshes.

## Change

Validate the condition object and its expression before constructing `cloudresourcemanager.Expr`:

- malformed non-object conditions return a diagnostic;
- absent, non-string, and empty expressions return distinct diagnostics;
- valid expression/title/description values preserve their current behavior.

The parser deliberately does **not** discard an incomplete condition or reinterpret its member as unconditional. That could silently widen access semantics. The actionable diagnostic lets an operator repair the malformed dataset policy without a provider process crash.

## Tests

Added focused unit coverage for:

- a title-only condition (the panic regression);
- a non-object condition;
- non-string and empty expressions;
- preservation of a valid expression, title, and description.

Copied the handwritten Magic Modules source and unit test into a disposable generated `terraform-provider-google` checkout and verified:

```sh
go test ./google/services/bigquery -run TestAccessToPolicyForIamMember -v
```

All focused tests pass.

```release-note:bug
bigquery: fixed a provider panic when reading incomplete IAM conditions on `google_bigquery_dataset_iam_member`
```
<!-- github-gate:idempotency=magic-modules-18429-release-note-20260728 -->