### PR TITLE
compute: fix panic in google_compute_shared_vpc_service_project when host link is removed outside Terraform

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_service_project.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_service_project.go
@@ -127,8 +127,9 @@ func resourceComputeSharedVpcServiceProjectRead(d *schema.ResourceData, meta int
 		return nil
 	}
 
-	if hostProject != associatedHostProject["name"].(string) {
-		log.Printf("[WARN] Removing shared VPC service. Expected associated host project to be '%s', got '%s'", hostProject, associatedHostProject["name"].(string))
+	associatedHostProjectName, _ := associatedHostProject["name"].(string)
+	if hostProject != associatedHostProjectName {
+		log.Printf("[WARN] Removing shared VPC service. Expected associated host project to be '%s', got '%s'", hostProject, associatedHostProjectName)
 		d.SetId("")
 		return nil
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/28528

Fixes a crash in google_compute_shared_vpc_service_project that happened during terraform plan when the shared VPC link had been removed outside of Terraform, instead of just cleaning up the resource like it used to.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed a panic in `google_compute_shared_vpc_service_project` during `terraform plan/refresh` when the shared VPC link had been removed outside of Terraform
```
