### PR TITLE
apigee,networksecurity: add list resources for 8 resources with non-standard scope params

### DIFF
--- a/mmv1/products/apigee/EnvKeystore.yaml
+++ b/mmv1/products/apigee/EnvKeystore.yaml
@@ -30,6 +30,8 @@ import_format:
   - '{{env_id}}/keystores/{{name}}'
   - '{{env_id}}/{{name}}'
 # Resource creation race
+generate_list_resource: true
+
 timeouts:
   insert_minutes: 1
   update_minutes: 20

--- a/mmv1/products/apigee/EnvReferences.yaml
+++ b/mmv1/products/apigee/EnvReferences.yaml
@@ -29,6 +29,8 @@ import_format:
   - '{{env_id}}/references/{{name}}'
   - '{{env_id}}/{{name}}'
 # Resource creation race
+generate_list_resource: true
+
 timeouts:
   insert_minutes: 1
   update_minutes: 20

--- a/mmv1/products/apigee/EnvironmentAddonsConfig.yaml
+++ b/mmv1/products/apigee/EnvironmentAddonsConfig.yaml
@@ -28,6 +28,8 @@ update_verb: POST
 id_format: '{{env_id}}'
 import_format:
   - '{{env_id}}'
+generate_list_resource: true
+
 timeouts:
   insert_minutes: 5
   update_minutes: 5

--- a/mmv1/products/apigee/KeystoresAliasesSelfSignedCert.yaml
+++ b/mmv1/products/apigee/KeystoresAliasesSelfSignedCert.yaml
@@ -29,6 +29,8 @@ delete_url: organizations/{{org_id}}/environments/{{environment}}/keystores/{{ke
 import_format:
   - organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}
 # Resource creation race
+generate_list_resource: true
+
 timeouts:
   insert_minutes: 30
   update_minutes: 20

--- a/mmv1/products/networksecurity/AddressGroup.yaml
+++ b/mmv1/products/networksecurity/AddressGroup.yaml
@@ -28,6 +28,8 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - '{{%parent}}/locations/{{location}}/addressGroups/{{name}}'
+generate_list_resource: true
+
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/networksecurity/GatewaySecurityPolicyRule.yaml
+++ b/mmv1/products/networksecurity/GatewaySecurityPolicyRule.yaml
@@ -27,6 +27,8 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies/{{gateway_security_policy}}/rules/{{name}}
+generate_list_resource: true
+
 timeouts:
   insert_minutes: 30
   update_minutes: 30

--- a/mmv1/products/networksecurity/SecurityProfile.yaml
+++ b/mmv1/products/networksecurity/SecurityProfile.yaml
@@ -27,6 +27,8 @@ update_verb: 'PATCH'
 update_mask: true
 import_format:
   - '{{%parent}}/locations/{{location}}/securityProfiles/{{name}}'
+generate_list_resource: true
+
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -28,6 +28,8 @@ update_verb: 'PATCH'
 update_mask: true
 import_format:
   - '{{%parent}}/locations/{{location}}/securityProfileGroups/{{name}}'
+generate_list_resource: true
+
 timeouts:
   insert_minutes: 20
   update_minutes: 20


### PR DESCRIPTION
Adds `generate_list_resource: true` for 8 resources that have non-standard scope params in their list URL and that are not covered by any other open PR.

These resources have non-`exclude_test` samples that declare scope params via `test_env_vars` (e.g. `org_id: ORG_ID`, `billing_account: BILLING_ACCT`). The `listScope.Capture` + `AsConfigVariables()` mechanism wires scope values captured from the created resource directly into the generated list query test step, so no template changes are needed.

Not included in this PR (covered by other open PRs):
- `apigee`: 21 resources in #18432
- `networksecurity`: 22 resources in #18433

**apigee (4 resources):**

```release-note:new-list-resource
`google_apigee_env_keystore`
```

```release-note:new-list-resource
`google_apigee_env_references`
```

```release-note:new-list-resource
`google_apigee_environment_addons_config`
```

```release-note:new-list-resource
`google_apigee_keystores_aliases_self_signed_cert`
```

**networksecurity (4 resources):**

```release-note:new-list-resource
`google_network_security_address_group`
```

```release-note:new-list-resource
`google_network_security_gateway_security_policy_rule`
```

```release-note:new-list-resource
`google_network_security_security_profile`
```

```release-note:new-list-resource
`google_network_security_security_profile_group`
```