### PR TITLE
Add google_secret_manager_secret_versions data source

### DIFF
--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_versions.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_versions.go
@@ -1,0 +1,187 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+package secretmanager
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceSecretManagerSecretVersions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceSecretManagerSecretVersionsRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"secret": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"destroy_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSecretManagerSecretVersionsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for SecretVersion: %s", err)
+	}
+
+	secret := d.Get("secret").(string)
+	if !strings.HasPrefix(secret, "projects/") {
+		secret = fmt.Sprintf("projects/%s/secrets/%s", project, secret)
+	}
+
+	url := fmt.Sprintf("%s%s/versions", transport_tpg.BaseUrl(Product, config), secret)
+
+	filter, hasFilter := d.GetOk("filter")
+	if hasFilter {
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"filter": filter.(string)})
+		if err != nil {
+			return err
+		}
+	}
+
+	billingProject := project
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	allVersions := make([]interface{}, 0)
+	token := ""
+	for paginate := true; paginate; {
+		if token != "" {
+			url, err = transport_tpg.AddQueryParams(url, map[string]string{"pageToken": token})
+			if err != nil {
+				return err
+			}
+		}
+		resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   billingProject,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("SecretManagerSecretVersions %q", d.Id()))
+		}
+		versionsInterface := resp["versions"]
+		if versionsInterface == nil {
+			break
+		}
+		allVersions = append(allVersions, versionsInterface.([]interface{})...)
+		tokenInterface := resp["nextPageToken"]
+		if tokenInterface == nil {
+			paginate = false
+		} else {
+			paginate = true
+			token = tokenInterface.(string)
+		}
+	}
+
+	if err := d.Set("versions", flattenSecretManagerSecretVersionsList(allVersions)); err != nil {
+		return fmt.Errorf("error setting versions: %s", err)
+	}
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("error setting project: %s", err)
+	}
+
+	id := fmt.Sprintf("%s/versions", secret)
+	if hasFilter {
+		id += "/filter=" + filter.(string)
+	}
+	d.SetId(id)
+
+	return nil
+}
+
+func flattenSecretManagerSecretVersionsList(v interface{}) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			continue
+		}
+		name := ""
+		if n, ok := original["name"].(string); ok {
+			name = n
+		}
+		version := ""
+		if name != "" {
+			parts := strings.Split(name, "/")
+			version = parts[len(parts)-1]
+		}
+		enabled := false
+		if state, ok := original["state"].(string); ok {
+			enabled = state == "ENABLED"
+		}
+		transformed = append(transformed, map[string]interface{}{
+			"name":         name,
+			"version":      version,
+			"enabled":      enabled,
+			"create_time":  original["createTime"],
+			"destroy_time": original["destroyTime"],
+		})
+	}
+	return transformed
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_secret_manager_secret_versions",
+		ProductName: "secretmanager",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceSecretManagerSecretVersions(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_versions_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_versions_test.go
@@ -1,0 +1,54 @@
+package secretmanager_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceSecretManagerSecretVersions_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSecretManagerSecretVersions_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_secret_manager_secret_versions.versions", "versions.#"),
+					resource.TestCheckResourceAttrSet("data.google_secret_manager_secret_versions.versions", "versions.0.name"),
+					resource.TestCheckResourceAttrSet("data.google_secret_manager_secret_versions.versions", "versions.0.version"),
+					resource.TestCheckResourceAttr("data.google_secret_manager_secret_versions.versions", "versions.0.enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSecretManagerSecretVersions_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_secret" "secret" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "version" {
+  secret = google_secret_manager_secret.secret.id
+  secret_data = "my-secret-data"
+}
+
+data "google_secret_manager_secret_versions" "versions" {
+  secret  = google_secret_manager_secret.secret.secret_id
+  project = google_secret_manager_secret.secret.project
+  depends_on = [google_secret_manager_secret_version.version]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_versions.html.markdown
@@ -1,0 +1,32 @@
+---
+subcategory: "Secret Manager"
+description: |-
+  List all versions for a Secret Manager secret.
+---
+
+# google_secret_manager_secret_versions
+
+List all versions of a Secret Manager secret.
+
+## Example Usage
+
+\`\`\`hcl
+data "google_secret_manager_secret_versions" "versions" {
+  secret = "my-secret"
+}
+\`\`\`
+
+## Argument Reference
+
+* `secret` - (Required) The secret to list versions for. Can be the secret_id or the full resource name.
+* `project` - (Optional) The project in which the resource belongs. If not set, the provider project is used.
+* `filter` - (Optional) Filter string for listing versions.
+
+## Attributes Reference
+
+* `versions` - A list of versions. Each version contains:
+  * `name` - The full resource name of the version.
+  * `version` - The version number.
+  * `enabled` - Whether the version is enabled.
+  * `create_time` - The time the version was created.
+  * `destroy_time` - The time the version was destroyed (if applicable).


### PR DESCRIPTION
Adds a new `google_secret_manager_secret_versions` list data source for Secret Manager, allowing users to list all versions of a given secret using `terraform query` (Terraform 1.14+).

## Changes
- Adds `google_secret_manager_secret_versions` data source with pagination via `ListPages`
- Supports `filter` to narrow results
- Exposes `name`, `version`, `enabled`, `create_time`, and `destroy_time` per version
- Adds acceptance test `TestAccDataSourceSecretManagerSecretVersions_basic`
- Adds documentation at `website/docs/d/secret_manager_secret_versions.html.markdown`

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/
If your PR is still work in progress, please create it in draft mode.
-->

### Release Note Template for Downstream PRs (will be copied)
```release-note:new-datasource
`google_secret_manager_secret_versions`
```