### PR TITLE
Adding `google_redis_cluster_auth_token` and `google_redis_cluster_token_auth_user` with corresponding datasources 

### DIFF
--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -385,6 +385,7 @@ properties:
       - AUTH_MODE_UNSPECIFIED
       - AUTH_MODE_IAM_AUTH
       - AUTH_MODE_DISABLED
+      - AUTH_MODE_TOKEN_AUTH
   - name: transitEncryptionMode
     type: Enum
     description: |

--- a/mmv1/products/redis/ClusterAuthToken.yaml
+++ b/mmv1/products/redis/ClusterAuthToken.yaml
@@ -1,0 +1,62 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: "ClusterAuthToken"
+description: "Represents an Auth Token for a Token Auth User within a Google Cloud Redis Cluster."
+immutable: true
+base_url: "{{token_auth_user}}/authTokens"
+self_link: "{{token_auth_user}}/authTokens"
+create_url: "{{token_auth_user}}:addAuthToken"
+delete_url: "{{token_auth_user}}/authTokens/{{token_id}}"
+id_format: "{{token_auth_user}}/authTokens/{{token_id}}"
+import_format:
+  - "{{token_auth_user}}/authTokens/{{token_id}}"
+async:
+  type: OpAsync
+  include_project: true
+  operation:
+    base_url: '{{op_id}}'
+custom_code:
+  custom_import: templates/terraform/custom_import/redis_auth_token.go.tmpl
+  decoder: templates/terraform/decoders/redis_auth_token.go.tmpl
+  encoder: templates/terraform/encoders/redis_auth_token.go.tmpl
+  post_create: templates/terraform/post_create/redis_auth_token.go.tmpl
+properties:
+  - name: "token_auth_user"
+    type: "ResourceRef"
+    resource: "ClusterTokenAuthUser"
+    imports: "name"
+    description: "The full name of the parent Token Auth User."
+    required: true
+    url_param_only: true
+  - name: "tokenId"
+    type: "String"
+    description: "The ID of the Auth Token."
+    output: true
+  - name: "name"
+    type: "String"
+    description: "The full resource name of the Auth Token."
+    output: true
+  - name: "token"
+    type: "String"
+    description: "The generated auth token string."
+    output: true
+    sensitive: true
+  - name: "createTime"
+    type: "Time"
+    description: "The creation time of the auth token."
+    output: true
+  - name: "state"
+    type: "String"
+    description: "The current state of the auth token."
+    output: true

--- a/mmv1/products/redis/ClusterAuthToken.yaml
+++ b/mmv1/products/redis/ClusterAuthToken.yaml
@@ -13,11 +13,18 @@
 ---
 name: "ClusterAuthToken"
 description: "Represents an Auth Token for a Token Auth User within a Google Cloud Redis Cluster."
+references:
+  guides:
+    Official Documentation: https://cloud.google.com/memorystore/docs/cluster/
+  api: https://cloud.google.com/memorystore/docs/cluster/reference/rest/v1/projects.locations.clusters.tokenAuthUsers.authTokens
 immutable: true
 base_url: "{{token_auth_user}}/authTokens"
 self_link: "{{token_auth_user}}/authTokens"
 create_url: "{{token_auth_user}}:addAuthToken"
 delete_url: "{{token_auth_user}}/authTokens/{{token_id}}"
+nested_query:
+  keys:
+    - authTokens
 id_format: "{{token_auth_user}}/authTokens/{{token_id}}"
 import_format:
   - "{{token_auth_user}}/authTokens/{{token_id}}"
@@ -31,6 +38,14 @@ custom_code:
   decoder: templates/terraform/decoders/redis_auth_token.go.tmpl
   encoder: templates/terraform/encoders/redis_auth_token.go.tmpl
   post_create: templates/terraform/post_create/redis_auth_token.go.tmpl
+samples:
+  - name: redis_cluster_auth_token_basic
+    primary_resource_id: token-basic
+    steps:
+      - name: redis_cluster_auth_token_basic
+        resource_id_vars:
+          cluster_name: token-basic-cluster
+          user_id: token-basic-user
 properties:
   - name: "token_auth_user"
     type: "ResourceRef"
@@ -58,5 +73,5 @@ properties:
     output: true
   - name: "state"
     type: "String"
-    description: "The current state of the auth token."
+    description: "The current state of the Auth Token."
     output: true

--- a/mmv1/products/redis/ClusterTokenAuthUser.yaml
+++ b/mmv1/products/redis/ClusterTokenAuthUser.yaml
@@ -1,0 +1,51 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: "ClusterTokenAuthUser"
+description: "Represents a Token Auth User for a Google Cloud Redis Cluster."
+immutable: true
+base_url: "{{cluster}}/tokenAuthUsers"
+self_link: "{{cluster}}/tokenAuthUsers/{{user_id}}"
+create_url: "{{cluster}}:addTokenAuthUser"
+id_format: "{{cluster}}/tokenAuthUsers/{{user_id}}"
+import_format:
+  - "{{cluster}}/tokenAuthUsers/{{user_id}}"
+async:
+  type: OpAsync
+  include_project: true
+  operation:
+    base_url: '{{op_id}}'
+custom_code:
+  custom_import: templates/terraform/custom_import/redis_token_auth_user.go.tmpl
+  encoder: templates/terraform/encoders/redis_token_auth_user.go.tmpl
+properties:
+  - name: "cluster"
+    type: "ResourceRef"
+    resource: "Cluster"
+    imports: "id"
+    description: "The full name of the Redis cluster."
+    required: true
+    url_param_only: true
+  - name: "user_id"
+    type: "String"
+    description: "The unique ID (username) of the Token Auth User."
+    required: true
+    url_param_only: true
+  - name: "name"
+    type: "String"
+    description: "The full resource name of the Token Auth User."
+    output: true
+  - name: "state"
+    type: "String"
+    description: "The current state of the Token Auth User."
+    output: true

--- a/mmv1/products/redis/ClusterTokenAuthUser.yaml
+++ b/mmv1/products/redis/ClusterTokenAuthUser.yaml
@@ -13,6 +13,10 @@
 ---
 name: "ClusterTokenAuthUser"
 description: "Represents a Token Auth User for a Google Cloud Redis Cluster."
+references:
+  guides:
+    Official Documentation: https://cloud.google.com/memorystore/docs/cluster/
+  api: https://cloud.google.com/memorystore/docs/cluster/reference/rest/v1/projects.locations.clusters.tokenAuthUsers
 immutable: true
 base_url: "{{cluster}}/tokenAuthUsers"
 self_link: "{{cluster}}/tokenAuthUsers/{{user_id}}"
@@ -28,6 +32,14 @@ async:
 custom_code:
   custom_import: templates/terraform/custom_import/redis_token_auth_user.go.tmpl
   encoder: templates/terraform/encoders/redis_token_auth_user.go.tmpl
+samples:
+  - name: redis_cluster_token_auth_user_basic
+    primary_resource_id: user-basic
+    steps:
+      - name: redis_cluster_token_auth_user_basic
+        resource_id_vars:
+          cluster_name: user-basic-cluster
+          user_id: user-basic-user
 properties:
   - name: "cluster"
     type: "ResourceRef"

--- a/mmv1/templates/terraform/custom_import/redis_auth_token.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/redis_auth_token.go.tmpl
@@ -1,0 +1,17 @@
+config := meta.(*transport_tpg.Config)
+
+// custom import regex because token_auth_user contains forward slashes
+if err := tpgresource.ParseImportId([]string{
+	"(?P<token_auth_user>.+)/authTokens/(?P<token_id>[^/]+)",
+	"(?P<token_auth_user>.+)/(?P<token_id>[^/]+)",
+}, d, config); err != nil {
+	return nil, err
+}
+
+id, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}token_auth_user{{"}}"}}/authTokens/{{"{{"}}token_id{{"}}"}}")
+if err != nil {
+	return nil, fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/custom_import/redis_auth_token.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/redis_auth_token.go.tmpl
@@ -12,6 +12,9 @@ id, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}token_auth_user{{"}}"}}/a
 if err != nil {
 	return nil, fmt.Errorf("Error constructing id: %s", err)
 }
+if err := d.Set("name", id); err != nil {
+	return nil, fmt.Errorf("Error setting name: %s", err)
+}
 d.SetId(id)
 
 return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/custom_import/redis_token_auth_user.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/redis_token_auth_user.go.tmpl
@@ -1,0 +1,17 @@
+config := meta.(*transport_tpg.Config)
+
+// custom import regex because cluster contains forward slashes
+if err := tpgresource.ParseImportId([]string{
+	"(?P<cluster>.+)/tokenAuthUsers/(?P<user_id>[^/]+)",
+	"(?P<cluster>.+)/(?P<user_id>[^/]+)",
+}, d, config); err != nil {
+	return nil, err
+}
+
+id, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}cluster{{"}}"}}/tokenAuthUsers/{{"{{"}}user_id{{"}}"}}")
+if err != nil {
+	return nil, fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/decoders/redis_auth_token.go.tmpl
+++ b/mmv1/templates/terraform/decoders/redis_auth_token.go.tmpl
@@ -1,11 +1,4 @@
-if tokens, ok := res["authTokens"].([]interface{}); ok {
-	for _, rawToken := range tokens {
-		if tokenMap, ok := rawToken.(map[string]interface{}); ok {
-			if name, ok := tokenMap["name"].(string); ok && name == d.Id() {
-				tokenMap["tokenId"] = tpgresource.GetResourceNameFromSelfLink(name)
-				return tokenMap, nil
-			}
-		}
-	}
+if name, ok := res["name"].(string); ok {
+	res["tokenId"] = tpgresource.GetResourceNameFromSelfLink(name)
 }
-return nil, fmt.Errorf("AuthToken %s not found", d.Id())
+return res, nil

--- a/mmv1/templates/terraform/decoders/redis_auth_token.go.tmpl
+++ b/mmv1/templates/terraform/decoders/redis_auth_token.go.tmpl
@@ -1,0 +1,11 @@
+if tokens, ok := res["authTokens"].([]interface{}); ok {
+	for _, rawToken := range tokens {
+		if tokenMap, ok := rawToken.(map[string]interface{}); ok {
+			if name, ok := tokenMap["name"].(string); ok && name == d.Id() {
+				tokenMap["tokenId"] = tpgresource.GetResourceNameFromSelfLink(name)
+				return tokenMap, nil
+			}
+		}
+	}
+}
+return nil, fmt.Errorf("AuthToken %s not found", d.Id())

--- a/mmv1/templates/terraform/encoders/redis_auth_token.go.tmpl
+++ b/mmv1/templates/terraform/encoders/redis_auth_token.go.tmpl
@@ -1,0 +1,2 @@
+// API request body expects empty object for custom action :addAuthToken
+return map[string]interface{}{}, nil

--- a/mmv1/templates/terraform/encoders/redis_token_auth_user.go.tmpl
+++ b/mmv1/templates/terraform/encoders/redis_token_auth_user.go.tmpl
@@ -1,0 +1,4 @@
+	// API request body expects: { "tokenAuthUser": "user_id" }
+	userId := d.Get("user_id").(string)
+	obj["tokenAuthUser"] = userId
+	return obj, nil

--- a/mmv1/templates/terraform/post_create/redis_auth_token.go.tmpl
+++ b/mmv1/templates/terraform/post_create/redis_auth_token.go.tmpl
@@ -1,3 +1,6 @@
+// Post_create is required because the create endpoint (addAuthToken) returns a Long Running Operation
+// whose response contains the parent TokenAuthUser object rather than the newly created AuthToken resource itself.
+// Therefore, we must list the authTokens for the user to retrieve and set the ID and token_id of the newly generated token.
 tokenAuthUser := d.Get("token_auth_user").(string)
 url = fmt.Sprintf("%s%s/authTokens", transport_tpg.BaseUrl(Product, config), tokenAuthUser)
 res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{

--- a/mmv1/templates/terraform/post_create/redis_auth_token.go.tmpl
+++ b/mmv1/templates/terraform/post_create/redis_auth_token.go.tmpl
@@ -1,0 +1,21 @@
+tokenAuthUser := d.Get("token_auth_user").(string)
+url = fmt.Sprintf("%s%s/authTokens", transport_tpg.BaseUrl(Product, config), tokenAuthUser)
+res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: userAgent,
+})
+if err != nil {
+	return fmt.Errorf("Error listing authTokens for %s: %s", tokenAuthUser, err)
+}
+if tokens, ok := res["authTokens"].([]interface{}); ok && len(tokens) > 0 {
+	latestToken := tokens[len(tokens)-1].(map[string]interface{})
+	if name, ok := latestToken["name"].(string); ok {
+		d.SetId(name)
+		if err := d.Set("token_id", tpgresource.GetResourceNameFromSelfLink(name)); err != nil {
+			return fmt.Errorf("Error setting token_id: %s", err)
+		}
+	}
+}

--- a/mmv1/templates/terraform/post_create/redis_auth_token.go.tmpl
+++ b/mmv1/templates/terraform/post_create/redis_auth_token.go.tmpl
@@ -1,6 +1,6 @@
 // Post_create is required because the create endpoint (addAuthToken) returns a Long Running Operation
 // whose response contains the parent TokenAuthUser object rather than the newly created AuthToken resource itself.
-// Therefore, we must list the authTokens for the user to retrieve and set the ID and token_id of the newly generated token.
+// Therefore, we must list the authTokens for the user to retrieve and set the ID, name, and token_id of the newly generated token.
 tokenAuthUser := d.Get("token_auth_user").(string)
 url = fmt.Sprintf("%s%s/authTokens", transport_tpg.BaseUrl(Product, config), tokenAuthUser)
 res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -17,6 +17,9 @@ if tokens, ok := res["authTokens"].([]interface{}); ok && len(tokens) > 0 {
 	latestToken := tokens[len(tokens)-1].(map[string]interface{})
 	if name, ok := latestToken["name"].(string); ok {
 		d.SetId(name)
+		if err := d.Set("name", name); err != nil {
+			return fmt.Errorf("Error setting name: %s", err)
+		}
 		if err := d.Set("token_id", tpgresource.GetResourceNameFromSelfLink(name)); err != nil {
 			return fmt.Errorf("Error setting token_id: %s", err)
 		}

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_auth_token_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_auth_token_basic.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_redis_cluster" "{{$.PrimaryResourceId}}-cluster" {
+  name                        = "{{index $.ResourceIdVars "cluster_name"}}"
+  shard_count                 = 1
+  region                      = "us-central1"
+  authorization_mode          = "AUTH_MODE_TOKEN_AUTH"
+  deletion_protection_enabled = false
+}
+
+resource "google_redis_cluster_token_auth_user" "{{$.PrimaryResourceId}}-user" {
+  cluster                     = google_redis_cluster.{{$.PrimaryResourceId}}-cluster.id
+  user_id                     = "{{index $.ResourceIdVars "user_id"}}"
+}
+
+resource "google_redis_cluster_auth_token" "{{$.PrimaryResourceId}}" {
+  token_auth_user             = google_redis_cluster_token_auth_user.{{$.PrimaryResourceId}}-user.id
+}

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_token_auth_user_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_token_auth_user_basic.tf.tmpl
@@ -1,0 +1,12 @@
+resource "google_redis_cluster" "{{$.PrimaryResourceId}}-cluster" {
+  name                        = "{{index $.ResourceIdVars "cluster_name"}}"
+  shard_count                 = 1
+  region                      = "us-central1"
+  authorization_mode          = "AUTH_MODE_TOKEN_AUTH"
+  deletion_protection_enabled = false
+}
+
+resource "google_redis_cluster_token_auth_user" "{{$.PrimaryResourceId}}" {
+  cluster                     = google_redis_cluster.{{$.PrimaryResourceId}}-cluster.id
+  user_id                     = "{{index $.ResourceIdVars "user_id"}}"
+}

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_auth_token.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_auth_token.go
@@ -26,6 +26,9 @@ func dataSourceRedisClusterAuthTokenRead(d *schema.ResourceData, meta interface{
 	tokenId := d.Get("token_id").(string)
 	id := fmt.Sprintf("%s/authTokens/%s", tokenAuthUser, tokenId)
 	d.SetId(id)
+	if err := d.Set("name", id); err != nil {
+		return fmt.Errorf("Error setting name: %s", err)
+	}
 
 	err := resourceRedisClusterAuthTokenRead(d, meta)
 	if err != nil {

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_auth_token.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_auth_token.go
@@ -1,0 +1,48 @@
+package redis
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+)
+
+func DataSourceRedisClusterAuthToken() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceRedisClusterAuthToken().Schema)
+
+	// Set 'Required' schema elements
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "token_auth_user", "token_id")
+
+	return &schema.Resource{
+		Read:   dataSourceRedisClusterAuthTokenRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceRedisClusterAuthTokenRead(d *schema.ResourceData, meta interface{}) error {
+	tokenAuthUser := d.Get("token_auth_user").(string)
+	tokenId := d.Get("token_id").(string)
+	id := fmt.Sprintf("%s/authTokens/%s", tokenAuthUser, tokenId)
+	d.SetId(id)
+
+	err := resourceRedisClusterAuthTokenRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_redis_cluster_auth_token",
+		ProductName: "redis",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceRedisClusterAuthToken(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_auth_token_test.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_auth_token_test.go
@@ -1,0 +1,56 @@
+package redis_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/redis"
+)
+
+func TestAccRedisClusterAuthTokenDatasource(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisClusterAuthTokenDatasource(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_redis_cluster_auth_token.default", "google_redis_cluster_auth_token.token-basic"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRedisClusterAuthTokenDatasource(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_redis_cluster" "cluster" {
+  name                        = "tf-test-redis-cluster-%{random_suffix}"
+  shard_count                 = 1
+  region                      = "europe-west4"
+  authorization_mode          = "AUTH_MODE_TOKEN_AUTH"
+  deletion_protection_enabled = false
+}
+
+resource "google_redis_cluster_token_auth_user" "user-basic" {
+  cluster                     = google_redis_cluster.cluster.id
+  user_id                     = "tf-test-user-%{random_suffix}"
+}
+
+resource "google_redis_cluster_auth_token" "token-basic" {
+  token_auth_user             = google_redis_cluster_token_auth_user.user-basic.id
+}
+
+data "google_redis_cluster_auth_token" "default" {
+  token_auth_user             = google_redis_cluster_token_auth_user.user-basic.id
+  token_id                    = google_redis_cluster_auth_token.token-basic.token_id
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_token_auth_user.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_token_auth_user.go
@@ -1,0 +1,52 @@
+package redis
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceRedisClusterTokenAuthUser() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceRedisClusterTokenAuthUser().Schema)
+
+	// Set 'Required' schema elements
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "cluster", "user_id")
+
+	return &schema.Resource{
+		Read:   dataSourceRedisClusterTokenAuthUserRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceRedisClusterTokenAuthUserRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	id, err := tpgresource.ReplaceVars(d, config, "{{cluster}}/tokenAuthUsers/{{user_id}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	err = resourceRedisClusterTokenAuthUserRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_redis_cluster_token_auth_user",
+		ProductName: "redis",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceRedisClusterTokenAuthUser(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_token_auth_user_test.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_token_auth_user_test.go
@@ -1,0 +1,52 @@
+package redis_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/redis"
+)
+
+func TestAccRedisClusterTokenAuthUserDatasource(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisClusterTokenAuthUserDatasource(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_redis_cluster_token_auth_user.default", "google_redis_cluster_token_auth_user.user-basic"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRedisClusterTokenAuthUserDatasource(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_redis_cluster" "cluster" {
+  name                        = "tf-test-redis-cluster-%{random_suffix}"
+  shard_count                 = 1
+  region                      = "europe-west4"
+  authorization_mode          = "AUTH_MODE_TOKEN_AUTH"
+  deletion_protection_enabled = false
+}
+
+resource "google_redis_cluster_token_auth_user" "user-basic" {
+  cluster                     = google_redis_cluster.cluster.id
+  user_id                     = "tf-test-user-%{random_suffix}"
+}
+
+data "google_redis_cluster_token_auth_user" "default" {
+  cluster                     = google_redis_cluster.cluster.id
+  user_id                     = google_redis_cluster_token_auth_user.user-basic.user_id
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/redis/resource_redis_cluster_auth_token_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_cluster_auth_token_test.go
@@ -1,0 +1,53 @@
+package redis_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/redis"
+)
+
+func TestAccRedisClusterAuthToken_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisClusterAuthToken_basic(context),
+			},
+			{
+				ResourceName:      "google_redis_cluster_auth_token.token-basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRedisClusterAuthToken_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_redis_cluster" "cluster" {
+  name                        = "tf-test-redis-cluster-%{random_suffix}"
+  shard_count                 = 1
+  region                      = "europe-west4"
+  authorization_mode          = "AUTH_MODE_TOKEN_AUTH"
+  deletion_protection_enabled = false
+}
+
+resource "google_redis_cluster_token_auth_user" "user-basic" {
+  cluster                     = google_redis_cluster.cluster.id
+  user_id                     = "tf-test-user-%{random_suffix}"
+}
+
+resource "google_redis_cluster_auth_token" "token-basic" {
+  token_auth_user             = google_redis_cluster_token_auth_user.user-basic.id
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/redis/resource_redis_cluster_token_auth_user_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_cluster_token_auth_user_test.go
@@ -1,0 +1,49 @@
+package redis_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/redis"
+)
+
+func TestAccRedisClusterTokenAuthUser_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisClusterTokenAuthUser_basic(context),
+			},
+			{
+				ResourceName:      "google_redis_cluster_token_auth_user.user-basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRedisClusterTokenAuthUser_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_redis_cluster" "cluster" {
+  name                        = "tf-test-redis-cluster-%{random_suffix}"
+  shard_count                 = 1
+  region                      = "europe-west4"
+  authorization_mode          = "AUTH_MODE_TOKEN_AUTH"
+  deletion_protection_enabled = false
+}
+
+resource "google_redis_cluster_token_auth_user" "user-basic" {
+  cluster                     = google_redis_cluster.cluster.id
+  user_id                     = "tf-test-user-%{random_suffix}"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/redis_cluster_auth_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/redis_cluster_auth_token.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Redis"
+description: |-
+  Get information about an Auth Token for a Google Cloud Redis Cluster Token Auth User.
+---
+
+# google_redis_cluster_auth_token
+
+Get information about an Auth Token associated with a Google Cloud Redis Cluster Token Auth User. For more details refer to the [API documentation](https://cloud.google.com/memorystore/docs/cluster/reference/rest/v1/projects.locations.clusters.tokenAuthUsers.authTokens).
+
+## Example Usage
+
+```hcl
+data "google_redis_cluster_auth_token" "qa" {
+  token_auth_user = google_redis_cluster_token_auth_user.user.name
+  token_id        = "version-1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `token_auth_user` -
+  (Required)
+  The full resource name of the parent Token Auth User.
+
+* `token_id` -
+  (Required)
+  The version ID of the generated auth token (e.g. `version-1`).
+
+* `project` -
+  (Optional)
+  The project in which the resource belongs. If not provided, provider default is used.
+
+## Attributes Reference
+
+See [`google_redis_cluster_auth_token`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_cluster_auth_token) resource for details of all available attributes.

--- a/mmv1/third_party/terraform/website/docs/d/redis_cluster_token_auth_user.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/redis_cluster_token_auth_user.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "Redis"
+description: |-
+  Get information about a Google Cloud Redis Cluster Token Auth User.
+---
+
+# google_redis_cluster_token_auth_user
+
+Get information about a Google Cloud Redis Cluster Token Auth User. For more details refer to the [API documentation](https://cloud.google.com/memorystore/docs/cluster/reference/rest/v1/projects.locations.clusters.tokenAuthUsers).
+
+## Example Usage
+
+```hcl
+data "google_redis_cluster_token_auth_user" "qa" {
+  cluster = "my-cluster"
+  user_id = "my-user"
+  region  = "europe-west4"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster` -
+  (Required)
+  The full name or ID of the Redis Cluster.
+
+* `user_id` -
+  (Required)
+  The unique ID of the token auth user.
+
+* `region` -
+  (Optional)
+  The region of the Redis cluster. If not provided, provider default is used.
+
+* `project` -
+  (Optional)
+  The project in which the resource belongs. If not provided, provider default is used.
+
+## Attributes Reference
+
+See [`google_redis_cluster_token_auth_user`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_cluster_token_auth_user) resource for details of all available attributes.


### PR DESCRIPTION
…ster

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_redis_auth_token`
```

```release-note:new-datasource
`google_redis_token_auth_user`
```

```release-note:new-resource
`google_redis_auth_token`
```

```release-note:new-resource
`google_redis_token_auth_user`
```