### PR TITLE
apigee: add space field to google_apigee_api and google_apigee_sharedflow

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_api.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_api.go
@@ -65,6 +65,18 @@ func ResourceApigeeApi() *schema.Resource {
 				ForceNew:    true,
 				Description: `The Apigee Organization name associated with the Apigee instance.`,
 			},
+			"space": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Description: `The ID of the space associated with this API proxy. Any IAM ` +
+					`policies applied to the space will affect access to this proxy. If ` +
+					`not set, the proxy is created at the organization level. This field ` +
+					`is only respected when creating a new proxy; it has no effect when ` +
+					`creating a new revision for an existing proxy. Changing this field ` +
+					`forces the resource to be recreated.`,
+			},
 			"latest_revision_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -181,6 +193,14 @@ func resourceApigeeApiCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	// The space of a proxy is set via the `space` query parameter at import time
+	// (it is only honored when creating a new proxy, not a new revision).
+	if space, ok := d.GetOk("space"); ok {
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"space": space.(string)})
+		if err != nil {
+			return err
+		}
+	}
 	billingProject := ""
 
 	// err == nil indicates that the billing_project value was found
@@ -271,6 +291,13 @@ func resourceApigeeApiRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err := d.Set("latest_revision_id", flattenApigeeApiLatestRevisionId(res["latestRevisionId"], d, config)); err != nil {
 		return fmt.Errorf("Error reading API proxy: %s", err)
+	}
+	// `space` is returned on the ApiProxy object; only set it when present so a
+	// proxy at the organization level (no space) doesn't get a spurious value.
+	if v, ok := res["space"]; ok && v != nil && v != "" {
+		if err := d.Set("space", v); err != nil {
+			return fmt.Errorf("Error reading API proxy: %s", err)
+		}
 	}
 
 	//setting hash to suggest update

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_api_meta.yaml
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_api_meta.yaml
@@ -14,5 +14,6 @@ fields:
   - api_field: 'name'
   - field: 'org_id'
   - api_field: 'revision'
+  - field: 'space'
   - field: 'deletion_policy'
     provider_only: true

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_api_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_api_test.go
@@ -246,3 +246,88 @@ resource "google_apigee_api" "test_apigee_api" {
 }
 `, context)
 }
+
+// TestAccApigeeApi_space verifies that an API proxy can be created inside an
+// Apigee Space via the `space` field, and that the value round-trips
+// (hashicorp/terraform-provider-google#26841 / b/504538523).
+func TestAccApigeeApi_space(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
+
+	resourceName := "google_apigee_api.test_apigee_api"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeApiDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeApi_space(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "space", fmt.Sprintf("tf-test-space%s", context["random_suffix"])),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config_bundle", "detect_md5hash", "md5hash"},
+			},
+		},
+	})
+}
+
+func testAccApigeeApi_space(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "time_sleep" "wait_120_seconds" {
+  create_duration = "120s"
+  depends_on      = [google_project_service.apigee]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region    = "us-central1"
+  project_id          = google_project.project.project_id
+  disable_vpc_peering = true
+  depends_on          = [
+    google_project_service.apigee,
+    time_sleep.wait_120_seconds,
+  ]
+}
+
+resource "google_apigee_space" "space" {
+  space_id     = "tf-test-space%{random_suffix}"
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "tf-test-space"
+}
+
+resource "google_apigee_api" "test_apigee_api" {
+  name          = "tf-test-apigee-api"
+  org_id        = google_project.project.project_id
+  config_bundle = "./test-fixtures/apigee_api_bundle.zip"
+  space         = google_apigee_space.space.space_id
+  depends_on    = [google_apigee_organization.apigee_org]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
@@ -65,6 +65,18 @@ func ResourceApigeeSharedFlow() *schema.Resource {
 				ForceNew:    true,
 				Description: `The Apigee Organization name associated with the Apigee instance.`,
 			},
+			"space": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Description: `The ID of the space associated with this shared flow. Any IAM ` +
+					`policies applied to the space will affect access to this shared ` +
+					`flow. If not set, the shared flow is created at the organization ` +
+					`level. This field is only respected when creating a new shared ` +
+					`flow; it has no effect when creating a new revision for an existing ` +
+					`shared flow. Changing this field forces the resource to be recreated.`,
+			},
 			"latest_revision_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -175,6 +187,15 @@ func resourceApigeeSharedFlowCreate(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
+	// The space of a shared flow is set via the `space` query parameter at import
+	// time (it is only honored when creating a new shared flow, not a new
+	// revision).
+	if space, ok := d.GetOk("space"); ok {
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"space": space.(string)})
+		if err != nil {
+			return err
+		}
+	}
 	billingProject := ""
 
 	// err == nil indicates that the billing_project value was found
@@ -263,6 +284,14 @@ func resourceApigeeSharedFlowRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	if err := d.Set("latest_revision_id", flattenApigeeSharedFlowLatestRevisionId(res["latestRevisionId"], d, config)); err != nil {
 		return fmt.Errorf("Error reading SharedFlow: %s", err)
+	}
+	// `space` is returned on the SharedFlow object; only set it when present so a
+	// shared flow at the organization level (no space) doesn't get a spurious
+	// value.
+	if v, ok := res["space"]; ok && v != nil && v != "" {
+		if err := d.Set("space", v); err != nil {
+			return fmt.Errorf("Error reading SharedFlow: %s", err)
+		}
 	}
 
 	//setting hash to suggest update

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_meta.yaml
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_meta.yaml
@@ -14,5 +14,6 @@ fields:
   - api_field: 'name'
   - field: 'org_id'
   - api_field: 'revision'
+  - field: 'space'
   - field: 'deletion_policy'
     provider_only: true

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_test.go
@@ -244,3 +244,88 @@ resource "google_apigee_sharedflow" "test_apigee_sharedflow" {
 }
 `, context)
 }
+
+// TestAccApigeeSharedFlow_space verifies that a shared flow can be created inside
+// an Apigee Space via the `space` field, and that the value round-trips
+// (hashicorp/terraform-provider-google#26841 / b/504538523).
+func TestAccApigeeSharedFlow_space(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
+
+	resourceName := "google_apigee_sharedflow.test_apigee_sharedflow"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeSharedFlowDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeSharedFlow_space(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "space", fmt.Sprintf("tf-test-space%s", context["random_suffix"])),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config_bundle", "detect_md5hash", "md5hash"},
+			},
+		},
+	})
+}
+
+func testAccApigeeSharedFlow_space(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "time_sleep" "wait_120_seconds" {
+  create_duration = "120s"
+  depends_on      = [google_project_service.apigee]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region    = "us-central1"
+  project_id          = google_project.project.project_id
+  disable_vpc_peering = true
+  depends_on          = [
+    google_project_service.apigee,
+    time_sleep.wait_120_seconds,
+  ]
+}
+
+resource "google_apigee_space" "space" {
+  space_id     = "tf-test-space%{random_suffix}"
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "tf-test-space"
+}
+
+resource "google_apigee_sharedflow" "test_apigee_sharedflow" {
+  name          = "tf-test-apigee-sharedflow"
+  org_id        = google_project.project.project_id
+  config_bundle = "./test-fixtures/apigee_sharedflow_bundle.zip"
+  space         = google_apigee_space.space.space_id
+  depends_on    = [google_apigee_organization.apigee_org]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/r/apigee_api.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/apigee_api.html.markdown
@@ -63,6 +63,14 @@ The following arguments are supported:
 
 - - -
 
+* `space` -
+  (Optional)
+  The ID of the space associated with this API proxy. Any IAM policies applied
+  to the space will affect access to this proxy. If not set, the proxy is
+  created at the organization level. This field is only respected when creating
+  a new proxy; it has no effect when creating a new revision for an existing
+  proxy. Changing this field forces the resource to be recreated.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:

--- a/mmv1/third_party/terraform/website/docs/r/apigee_sharedflow.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/apigee_sharedflow.html.markdown
@@ -136,7 +136,14 @@ The following arguments are supported:
 
 - - -
 
-
+* `space` -
+  (Optional)
+  The ID of the space associated with this shared flow. Any IAM policies applied
+  to the space will affect access to this shared flow. If not set, the shared
+  flow is created at the organization level. This field is only respected when
+  creating a new shared flow; it has no effect when creating a new revision for
+  an existing shared flow. Changing this field forces the resource to be
+  recreated.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary

`google_apigee_api` and `google_apigee_sharedflow` could not manage proxies / shared flows that belong to an Apigee **Space**. Creating or updating one that lives under a Space failed with:

```
Error 403: ApiProxy "..." belongs to space "test-space-verification"
Error 403: shared flow "..." belongs to space "test-space-verification"
```

because the provider only called the organization-level endpoints with no way to specify the parent Space (hashicorp/terraform-provider-google#26841).

## Changes

Adds an optional, `ForceNew` `space` field to both resources, mirroring the existing `space` field on `google_apigee_api_product`:

- **Create:** passes the space ID via the `space` **query parameter** on the import `POST` (per the API, `space` is only honored when creating a *new* proxy/shared flow, not a new revision).
- **Read:** reads the `space` field back from the `ApiProxy` / `SharedFlow` object so it round-trips (org-level resources report no space).
- Changing `space` forces recreation, consistent with the API (space is only respected at creation) and with `google_apigee_api_product`.

Also adds `space` to the resource docs.

## Test evidence

New acceptance tests create each resource inside a `google_apigee_space` and verify the value round-trips (+ ImportStateVerify). Both pass against a real Apigee org:

```
--- PASS: TestAccApigeeApi_space (488.36s)
--- PASS: TestAccApigeeSharedFlow_space (462.14s)
```

Fixes hashicorp/terraform-provider-google#26841

```release-note:enhancement
apigee: added `space` field to `google_apigee_api` and `google_apigee_sharedflow`
```
