### PR TITLE
appengine:  fix test enum values for app_engine_bundled_services

### DIFF
--- a/mmv1/products/appengine/StandardAppVersion.yaml
+++ b/mmv1/products/appengine/StandardAppVersion.yaml
@@ -467,6 +467,7 @@ properties:
       Cannot specify both `app_engine_apis` and `app_engine_bundled_services` together.
     is_set: true
     immutable: true
+    ignore_read: true
     item_type:
       type: Enum
       enum_values:

--- a/mmv1/products/appengine/StandardAppVersion.yaml
+++ b/mmv1/products/appengine/StandardAppVersion.yaml
@@ -136,7 +136,7 @@ properties:
     type: Boolean
     description: |
       Allows App Engine second generation runtimes to access the legacy bundled services.
-      Cannot specify both `app_engine_apis` and 'app_engine_bundled_services` together.
+      Cannot specify both `app_engine_apis` and `app_engine_bundled_services` together.
     immutable: true
     conflicts:
       - app_engine_bundled_services

--- a/mmv1/products/appengine/StandardAppVersion.yaml
+++ b/mmv1/products/appengine/StandardAppVersion.yaml
@@ -460,8 +460,6 @@ properties:
         required: true
   - name: 'appEngineBundledServices'
     type: Array
-    # Developer Note: This field is write-only because the App Engine GET Admin API
-    # does not return it in the response (we use ignore_read: true to prevent state drift to null).
     # It is marked is_set: true to represent the list as a set in Terraform so configuration
     # ordering differences do not trigger spurious plans.
     description: |
@@ -469,7 +467,6 @@ properties:
       Cannot specify both `app_engine_apis` and `app_engine_bundled_services` together.
     is_set: true
     immutable: true
-    ignore_read: true
     item_type:
       type: Enum
       enum_values:

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_standard_app_version_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_standard_app_version_test.go
@@ -480,7 +480,7 @@ resource "google_app_engine_standard_app_version" "foo" {
   service    = "default"
   runtime    = "python310"
 
-  app_engine_bundled_services = ["mail", "user"]
+  app_engine_bundled_services = ["BUNDLED_SERVICE_TYPE_MAIL", "BUNDLED_SERVICE_TYPE_USERS"]
 
   entrypoint {
     shell = "gunicorn -b :$PORT main:app"


### PR DESCRIPTION
### Description
This PR fixes acceptance test enum values and ensures proper state tracking for `app_engine_bundled_services` on `google_app_engine_standard_app_version`:

1. **Fix Inconsistent Enum Values in Acceptance Tests:** Updates `testAccAppEngineStandardAppVersion_bundledServicesUpdate` to use full `BUNDLED_SERVICE_TYPE_...` enum values (`BUNDLED_SERVICE_TYPE_MAIL`, `BUNDLED_SERVICE_TYPE_USERS`) instead of short strings, resolving schema validation errors in tests.
2. **Ignore Read Drift:** Retains `ignore_read: true` to prevent state drift when the GCP API Gateway omits `appEngineBundledServices` in GET responses.
3. **Doc Formatting:** Fixed mixed quote formatting in `StandardAppVersion.yaml` description.

### Testing
- Built local `google-beta` provider and verified clean generation.
- Validated acceptance tests with full enum strings.

```release-note:bug
appengine: fixed acceptance test enum values for `app_engine_bundled_services` in `google_app_engine_standard_app_version`
```