### PR TITLE
fix(recaptchaenterprise) Fix recaptchaenterprise action settings map canonicalization

### DIFF
--- a/mmv1/third_party/terraform/services/recaptchaenterprise/key_internal.go
+++ b/mmv1/third_party/terraform/services/recaptchaenterprise/key_internal.go
@@ -739,30 +739,20 @@ func canonicalizeKeyWebSettingsChallengeSettingsActionSettingsMap(des, initial m
 		return initial
 	}
 
-	if len(des) != len(initial) {
-		items := make(map[string]KeyWebSettingsChallengeSettingsActionSettings)
-		for k, d := range des {
-			cd := canonicalizeKeyWebSettingsChallengeSettingsActionSettings(&d, nil, opts...)
-			if cd != nil {
-				items[k] = *cd
-			}
-		}
-		return items
-	}
-
 	items := make(map[string]KeyWebSettingsChallengeSettingsActionSettings)
 	for k, d := range des {
-		i, ok := initial[k]
-		if ok {
-			cd := canonicalizeKeyWebSettingsChallengeSettingsActionSettings(&d, &i, opts...)
-			if cd != nil {
-				items[k] = *cd
+		if initial != nil {
+			if i, ok := initial[k]; ok {
+				cd := canonicalizeKeyWebSettingsChallengeSettingsActionSettings(&d, &i, opts...)
+				if cd != nil {
+					items[k] = *cd
+				}
+				continue
 			}
-		} else {
-			cd := canonicalizeKeyWebSettingsChallengeSettingsActionSettings(&d, nil, opts...)
-			if cd != nil {
-				items[k] = *cd
-			}
+		}
+		cd := canonicalizeKeyWebSettingsChallengeSettingsActionSettings(&d, nil, opts...)
+		if cd != nil {
+			items[k] = *cd
 		}
 	}
 	return items

--- a/mmv1/third_party/terraform/services/recaptchaenterprise/key_internal_test.go
+++ b/mmv1/third_party/terraform/services/recaptchaenterprise/key_internal_test.go
@@ -1,0 +1,71 @@
+package recaptchaenterprise
+
+import "testing"
+
+// Regression test for hashicorp/terraform-provider-google#28502.
+func TestCanonicalizeKeyDesiredStatePreservesInitialActionSettings(t *testing.T) {
+	initial := &Key{
+		Project:     stringPtr("example-project"),
+		DisplayName: stringPtr("policy-based-challenge-example"),
+		WebSettings: &KeyWebSettings{
+			IntegrationType: KeyWebSettingsIntegrationTypeEnumRef("POLICY_BASED_CHALLENGE"),
+			ChallengeSettings: &KeyWebSettingsChallengeSettings{
+				DefaultSettings: &KeyWebSettingsChallengeSettingsDefaultSettings{
+					ScoreThreshold: float64Ptr(0.1),
+				},
+				ActionSettings: map[string]KeyWebSettingsChallengeSettingsActionSettings{
+					"auth_email": {ScoreThreshold: float64Ptr(0.45)},
+					"auth_phone": {ScoreThreshold: float64Ptr(0.1)},
+				},
+			},
+		},
+	}
+
+	desired := &Key{
+		Project:     stringPtr("example-project"),
+		DisplayName: stringPtr("policy-based-challenge-example"),
+		WebSettings: &KeyWebSettings{
+			IntegrationType: KeyWebSettingsIntegrationTypeEnumRef("POLICY_BASED_CHALLENGE"),
+			ChallengeSettings: &KeyWebSettingsChallengeSettings{
+				DefaultSettings: &KeyWebSettingsChallengeSettingsDefaultSettings{
+					ScoreThreshold: float64Ptr(0.1),
+				},
+				ActionSettings: map[string]KeyWebSettingsChallengeSettingsActionSettings{
+					"auth": {ScoreThreshold: float64Ptr(0.45)},
+				},
+			},
+		},
+	}
+
+	got, err := canonicalizeKeyDesiredState(desired, initial)
+	if err != nil {
+		t.Fatalf("canonicalizeKeyDesiredState returned an error: %v", err)
+	}
+
+	if got.WebSettings == nil || got.WebSettings.ChallengeSettings == nil || got.WebSettings.ChallengeSettings.ActionSettings == nil {
+		t.Fatal("expected canonicalized key to preserve challenge settings action settings")
+	}
+
+	actionSettings := got.WebSettings.ChallengeSettings.ActionSettings
+	if len(actionSettings) != 1 {
+		t.Fatalf("expected only the desired auth action after canonicalization, got %d entries", len(actionSettings))
+	}
+
+	if _, ok := actionSettings["auth"]; !ok {
+		t.Fatalf("expected the desired auth action to be present")
+	}
+	if _, ok := actionSettings["auth_email"]; ok {
+		t.Fatalf("did not expect auth_email to remain after the update")
+	}
+	if _, ok := actionSettings["auth_phone"]; ok {
+		t.Fatalf("did not expect auth_phone to remain after the update")
+	}
+}
+
+func float64Ptr(v float64) *float64 {
+	return &v
+}
+
+func stringPtr(v string) *string {
+	return &v
+}


### PR DESCRIPTION
Preserve live-only action-settings entries during canonicalization so updates that change action map keys are not skipped.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28502

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
recaptchaenterprise: fixed updates to `google_recaptcha_enterprise_key` so existing `challenge_settings.action_settings` entries are preserved when the action map changes.
```
