### PR TITLE
Migrate `image.go` resource to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/image.go
+++ b/mmv1/third_party/terraform/services/compute/image.go
@@ -55,7 +55,14 @@ var ImageMap = map[string]string{
 }
 
 func resolveImageImageExists(c *transport_tpg.Config, project, name, userAgent string) (bool, error) {
-	if _, err := NewClient(c, userAgent).Images.Get(project, name).Do(); err == nil {
+	url := fmt.Sprintf("%sprojects/%s/global/images/%s", transport_tpg.BaseUrl(Product, c), project, name)
+	if _, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    c,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	}); err == nil {
 		return true, nil
 	} else if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 		return false, nil
@@ -65,7 +72,14 @@ func resolveImageImageExists(c *transport_tpg.Config, project, name, userAgent s
 }
 
 func resolveImageFamilyExists(c *transport_tpg.Config, project, name, userAgent string) (bool, error) {
-	if _, err := NewClient(c, userAgent).Images.GetFromFamily(project, name).Do(); err == nil {
+	url := fmt.Sprintf("%sprojects/%s/global/images/family/%s", transport_tpg.BaseUrl(Product, c), project, name)
+	if _, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    c,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	}); err == nil {
 		return true, nil
 	} else if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 		return false, nil

--- a/mmv1/third_party/terraform/services/compute/image.go
+++ b/mmv1/third_party/terraform/services/compute/image.go
@@ -8,8 +8,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
-
-	"google.golang.org/api/googleapi"
 )
 
 const (
@@ -64,7 +62,7 @@ func resolveImageImageExists(c *transport_tpg.Config, project, name, userAgent s
 		UserAgent: userAgent,
 	}); err == nil {
 		return true, nil
-	} else if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+	} else if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
 		return false, nil
 	} else {
 		return false, fmt.Errorf("Error checking if image %s exists: %s", name, err)
@@ -81,7 +79,7 @@ func resolveImageFamilyExists(c *transport_tpg.Config, project, name, userAgent 
 		UserAgent: userAgent,
 	}); err == nil {
 		return true, nil
-	} else if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+	} else if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
 		return false, nil
 	} else {
 		return false, fmt.Errorf("Error checking if family %s exists: %s", name, err)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_image` resource to use direct HTTP rather than a client library
```
