### PR TITLE
Migrate `utils.go` resource to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/utils.go
+++ b/mmv1/third_party/terraform/services/compute/utils.go
@@ -9,12 +9,22 @@ import (
 
 func GetInterconnectAttachmentLink(config *transport_tpg.Config, project, region, ic, userAgent string) (string, error) {
 	if !strings.Contains(ic, "/") {
-		icData, err := NewClient(config, userAgent).InterconnectAttachments.Get(
-			project, region, ic).Do()
+		url := fmt.Sprintf("%sprojects/%s/regions/%s/interconnectAttachments/%s", transport_tpg.BaseUrl(Product, config), project, region, ic)
+		icData, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
 		if err != nil {
 			return "", fmt.Errorf("Error reading interconnect attachment: %s", err)
 		}
-		ic = icData.SelfLink
+		selfLink, ok := icData["selfLink"].(string)
+		if !ok {
+			return "", fmt.Errorf("Error reading interconnect attachment: selfLink not found in response")
+		}
+		ic = selfLink
 	}
 
 	return ic, nil


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated google_compute_router_interface interconnect attachment fetching to use direct HTTP rather than a client library
```
