### PR TITLE
feat: Add resource identity to google_secret_manager_secret_version

### DIFF
--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -34,7 +34,7 @@ create_url: '{{secret}}:addVersion'
 delete_url: '{{name}}:destroy'
 delete_verb: 'POST'
 import_format:
-  - 'projects/{{%project}}/secrets/{{%secret_id}}/versions/{{%version}}'
+  - 'projects/{{%project}}/secrets/{{%secret}}/versions/{{%version}}'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -52,8 +52,6 @@ custom_code:
   constants: 'templates/terraform/constants/secret_version.go.tmpl'
 # Sweeper skipped as this resource has customized deletion.
 exclude_sweeper: true
-# exluding resource_identity due to custom_import
-exclude_identity_generation: true
 deletion_policy_custom_docs: true
 samples:
   - name: 'secret_version_basic'

--- a/mmv1/templates/terraform/custom_import/secret_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/secret_version.go.tmpl
@@ -1,11 +1,10 @@
 	config := meta.(*transport_tpg.Config)
+	_ = config
 
-	// current import_formats can't import fields with forward slashes in their value
-	if err := tpgresource.ParseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
-		return nil, err
+	name := d.Id()
+	if err := d.Set("name", name); err != nil {
+		return nil, fmt.Errorf("Error setting name: %s", err)
 	}
-
-	name := d.Get("name").(string)
 	secretRegex := regexp.MustCompile("(projects/.+/secrets/.+)/versions/.+$")
 	versionRegex := regexp.MustCompile("projects/(.+)/secrets/(.+)/versions/(.+)$")
 
@@ -26,6 +25,14 @@
 	// Explicitly set virtual fields to default values on import
 	if err := d.Set("deletion_policy", "DELETE"); err != nil {
 		return nil, fmt.Errorf("Error setting version: %s", err)
+	}
+
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project": parts[1],
+		"secret":  parts[2],
+		"version": parts[3],
+	}); err != nil {
+		return nil, err
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/custom_update/secret_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_update/secret_version.go.tmpl
@@ -10,6 +10,14 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 */ -}}
+if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+	"project": d.Get("project"),
+	"secret":  d.Get("secret"),
+	"version": d.Get("version"),
+}); err != nil {
+	return err
+}
+
 err := setEnabled(d.Get("enabled"), d, config)
 if err != nil {
 	return err


### PR DESCRIPTION
Adds resource identity support to `google_secret_manager_secret_version` by:

- Removing `exclude_identity_generation: true` from `SecretVersion.yaml` to re-enable MMv1 identity generation
- Updating the custom import template to call `SetResourceIdentityAttributes` with `project`, `secret`, and `version` parsed from the version name

The custom import was previously excluded from identity generation due to its regex-based name parsing. The import template now sets identity attributes directly from the already-parsed `versionRegex` match groups after import.

This is a prerequisite for adding a `google_secret_manager_secret_version` list resource.

```release-note:none
```