### PR TITLE
container: fix ignore_node_count_changes flattener permadiff 

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -664,6 +664,10 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 						Optional: true,
 						Elem:     &schema.Resource{Schema: map[string]*schema.Schema{"create_pod_range": {Type: schema.TypeBool}}},
 					},
+					"ignore_node_count_changes": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
 				},
 			},
 			Optional: true,
@@ -701,6 +705,7 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 					"managed_instance_group_urls": []string{},
 					"version":                     "",
 					"network_config":              []map[string]interface{}{},
+					"ignore_node_count_changes":   false,
 				},
 				{
 					"name":                        "pool-2",
@@ -713,6 +718,7 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 					"managed_instance_group_urls": []string{},
 					"version":                     "",
 					"network_config":              []map[string]interface{}{},
+					"ignore_node_count_changes":   false,
 				},
 			},
 			expectError: false,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1992,7 +1992,9 @@ func TestAccContainerCluster_regionalWithNodePool(t *testing.T) {
 				ResourceName:		 "google_container_cluster.regional",
 				ImportState:		 true,
 				ImportStateVerify:	 true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_node_count_changes", "node_pool.0.ignore_node_count_changes"},
+				// Virtual fields like ignore_node_count_changes are not loaded on import. When import runs with default
+				// false for ignore_node_count_changes, managed_instance_group_urls is populated from the API, causing an import diff.
+				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_node_count_changes", "node_pool.0.ignore_node_count_changes", "node_pool.0.managed_instance_group_urls"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -1562,7 +1562,8 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 		"instance_group_urls": igmUrls,
 		"managed_instance_group_urls": managedIgmUrls,
 		"version":             np.Version,
-		"network_config":      flattenNodeNetworkConfig(np.NetworkConfig, d, prefix),
+		"network_config":              flattenNodeNetworkConfig(np.NetworkConfig, d, prefix),
+		"ignore_node_count_changes":   d.Get(prefix + "ignore_node_count_changes"),
 	}
 
 	if np.Autoscaling != nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27946
Splits https://github.com/GoogleCloudPlatform/magic-modules/pull/18397

The failing test was caused by a real permadiff where the `ignore_node_count_changes` flag was not persisted in `google_container_cluster.node_pool`.

Unlike top-level fields in `google_container_node_pool` which automatically persist their state in `ResourceData` during Read, unset nested fields in `google_container_cluster.node_pool` blocks get nulled out during Read.

To resolve the permadiff and fix the test, this PR:
1. Explicitly maps `ignore_node_count_changes` from `ResourceData` inside GKE's `flattenNodePool` using the block prefix.
2. Adds `node_pool.0.managed_instance_group_urls` to `ImportStateVerifyIgnore` in `TestAccContainerCluster_regionalWithNodePool`. Since virtual fields are not loaded during import, `ignore_node_count_changes` defaults to `false` and the API populates `managed_instance_group_urls`, causing an import verify diff.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
container: fixed a permadiff where `ignore_node_count_changes` was not persisted in `google_container_cluster.node_pool`
```
