### PR TITLE
fix stale IGM cache in node pool

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -158,6 +158,19 @@ func (instanceGroupManagerCache *instanceGroupManagerCache) needsRefresh(fullyQu
 	return time.Since(igm.updateTime) > instanceGroupManagerCache.ttl
 }
 
+// invalidateItem removes a specific Instance Group Manager from the cache by its URL.
+// This is called when a node pool is resized or when ignore_node_count_changes is active,
+// ensuring that stale cached target sizes are not served on subsequent lookups.
+func (instanceGroupManagerCache *instanceGroupManagerCache) invalidateItem(igmUrl string) {
+	instanceGroupManagerCache.mutex.Lock()
+	defer instanceGroupManagerCache.mutex.Unlock()
+
+	matches := instanceGroupManagerURL.FindStringSubmatch(igmUrl)
+	if len(matches) >= 4 {
+		delete(instanceGroupManagerCache.instanceGroupManagers, matches[0])
+	}
+}
+
 // We need to set ttl to 0 to disable caching in VCR testing.
 // This ensure all NP/MIG LIST requests are made consistently,
 // preventing non-deterministic behavior that would break VCR.
@@ -1524,6 +1537,7 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 		// or leave them empty. Passing the API URLs to igmUrls at least populates them for basic usage.
 		for _, url := range np.InstanceGroupUrls {
 			igmUrls = append(igmUrls, url)
+			igmCache.invalidateItem(url)
 		}
 	} else {
 		for _, url := range np.InstanceGroupUrls {
@@ -1866,6 +1880,11 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 		}
 		if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
 				return err
+		}
+		if urls, ok := d.GetOk(prefix + "instance_group_urls"); ok {
+			for _, u := range urls.([]interface{}) {
+				igmCache.invalidateItem(u.(string))
+			}
 		}
 		log.Printf("[INFO] GKE node pool %s size has been updated to %d", name, newSize)
 	}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27966
Splits https://github.com/GoogleCloudPlatform/magic-modules/pull/18397

This PR fixes a bug where stale Instance Group Manager target sizes were served from the client-side provider cache after GKE node count updates or when `ignore_node_count_changes` was active.

To solve stale IGM target sizes, this PR:
1. Adds an `invalidateItem(igmUrl)` method to `instanceGroupManagerCache` to allow removing specific IGM entries.
2. Calls the invalidation inside `flattenNodePool` when `ignore_node_count_changes` is active, as the cache isn't needed if we are ignoring the count.
3. Calls invalidation in `nodePoolUpdate` after a size update, ensuring subsequent reads fetch fresh GCE API data.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.
```release-note:bug
container: fixed a bug where `google_container_node_pool` and `google_container_cluster` failed to invalidate their Instance Group Manager cache when a resize occurred or when `ignore_node_count_changes` was active
```