### PR TITLE
Migrate `google_compute_shared_vpc_host_project.go` file to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_host_project.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_host_project.go
@@ -54,14 +54,21 @@ func resourceComputeSharedVpcHostProjectCreate(d *schema.ResourceData, meta inte
 	}
 
 	hostProject := d.Get("project").(string)
-	op, err := NewClient(config, userAgent).Projects.EnableXpnHost(hostProject).Do()
+	url := fmt.Sprintf("%sprojects/%s/enableXpnHost", transport_tpg.BaseUrl(Product, config), hostProject)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   hostProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return fmt.Errorf("Error enabling Shared VPC Host %q: %s", hostProject, err)
 	}
 
 	d.SetId(hostProject)
 
-	err = ComputeOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Host", userAgent, d.Timeout(schema.TimeoutCreate))
+	err = ComputeOperationWaitTime(config, res, hostProject, "Enabling Shared VPC Host", userAgent, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		d.SetId("")
 		return err
@@ -79,12 +86,19 @@ func resourceComputeSharedVpcHostProjectRead(d *schema.ResourceData, meta interf
 
 	hostProject := d.Id()
 
-	project, err := NewClient(config, userAgent).Projects.Get(hostProject).Do()
+	url := fmt.Sprintf("%sprojects/%s", transport_tpg.BaseUrl(Product, config), hostProject)
+	project, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   hostProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Project data for project %q", hostProject))
 	}
 
-	if project.XpnProjectStatus != "HOST" {
+	if project["xpnProjectStatus"] != "HOST" {
 		log.Printf("[WARN] Removing Shared VPC host resource %q because it's not enabled server-side", hostProject)
 		d.SetId("")
 	}
@@ -124,12 +138,19 @@ func resourceComputeSharedVpcHostProjectDelete(d *schema.ResourceData, meta inte
 
 	hostProject := d.Get("project").(string)
 
-	op, err := NewClient(config, userAgent).Projects.DisableXpnHost(hostProject).Do()
+	url := fmt.Sprintf("%sprojects/%s/disableXpnHost", transport_tpg.BaseUrl(Product, config), hostProject)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   hostProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return fmt.Errorf("Error disabling Shared VPC Host %q: %s", hostProject, err)
 	}
 
-	err = ComputeOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Host", userAgent, d.Timeout(schema.TimeoutDelete))
+	err = ComputeOperationWaitTime(config, res, hostProject, "Disabling Shared VPC Host", userAgent, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/compute"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccComputeSharedVpc_basic(t *testing.T) {
@@ -79,17 +80,25 @@ func testAccCheckComputeSharedVpcHostProject(t *testing.T, hostProject string, e
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
 
-		found, err := compute.NewClient(config, config.UserAgent).Projects.Get(hostProject).Do()
+		url := fmt.Sprintf("%sprojects/%s", transport_tpg.BaseUrl(compute.Product, config), hostProject)
+		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   hostProject,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return fmt.Errorf("Error reading project %s: %s", hostProject, err)
 		}
 
-		if found.Name != hostProject {
+		if found["name"].(string) != hostProject {
 			return fmt.Errorf("Project %s not found", hostProject)
 		}
 
-		if enabled != (found.XpnProjectStatus == "HOST") {
-			return fmt.Errorf("Project %q shared VPC status was not expected, got %q", hostProject, found.XpnProjectStatus)
+		xpnProjectStatus, _ := found["xpnProjectStatus"].(string)
+		if enabled != (xpnProjectStatus == "HOST") {
+			return fmt.Errorf("Project %q shared VPC status was not expected, got %q", hostProject, xpnProjectStatus)
 		}
 
 		return nil
@@ -99,7 +108,14 @@ func testAccCheckComputeSharedVpcHostProject(t *testing.T, hostProject string, e
 func testAccCheckComputeSharedVpcServiceProject(t *testing.T, hostProject, serviceProject string, enabled bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
-		serviceHostProject, err := compute.NewClient(config, config.UserAgent).Projects.GetXpnHost(serviceProject).Do()
+		url := fmt.Sprintf("%sprojects/%s/getXpnHost", transport_tpg.BaseUrl(compute.Product, config), serviceProject)
+		serviceHostProject, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   serviceProject,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			if enabled {
 				return fmt.Errorf("Expected service project to be enabled.")
@@ -107,8 +123,9 @@ func testAccCheckComputeSharedVpcServiceProject(t *testing.T, hostProject, servi
 			return nil
 		}
 
-		if enabled != (serviceHostProject.Name == hostProject) {
-			return fmt.Errorf("Wrong host project for the given service project. Expected '%s', got '%s'", hostProject, serviceHostProject.Name)
+		serviceHostProjectName, _ := serviceHostProject["name"].(string)
+		if enabled != (serviceHostProjectName == hostProject) {
+			return fmt.Errorf("Wrong host project for the given service project. Expected '%s', got '%s'", hostProject, serviceHostProjectName)
 		}
 
 		return nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	"github.com/hashicorp/terraform-provider-google/google/services/compute"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
+
+const computeBaseUrl = "https://compute.googleapis.com/compute/v1/"
 
 func TestAccComputeSharedVpc_basic(t *testing.T) {
 	org := envvar.GetTestOrgFromEnv(t)
@@ -80,7 +81,7 @@ func testAccCheckComputeSharedVpcHostProject(t *testing.T, hostProject string, e
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
 
-		url := fmt.Sprintf("%sprojects/%s", transport_tpg.BaseUrl(compute.Product, config), hostProject)
+		url := fmt.Sprintf("%sprojects/%s", computeBaseUrl, hostProject)
 		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "GET",
@@ -108,7 +109,7 @@ func testAccCheckComputeSharedVpcHostProject(t *testing.T, hostProject string, e
 func testAccCheckComputeSharedVpcServiceProject(t *testing.T, hostProject, serviceProject string, enabled bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
-		url := fmt.Sprintf("%sprojects/%s/getXpnHost", transport_tpg.BaseUrl(compute.Product, config), serviceProject)
+		url := fmt.Sprintf("%sprojects/%s/getXpnHost", computeBaseUrl, serviceProject)
 		serviceHostProject, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "GET",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_shared_vpc_test.go
@@ -8,11 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
-
-const computeBaseUrl = "https://compute.googleapis.com/compute/v1/"
 
 func TestAccComputeSharedVpc_basic(t *testing.T) {
 	org := envvar.GetTestOrgFromEnv(t)
@@ -81,7 +80,7 @@ func testAccCheckComputeSharedVpcHostProject(t *testing.T, hostProject string, e
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
 
-		url := fmt.Sprintf("%sprojects/%s", computeBaseUrl, hostProject)
+		url := fmt.Sprintf("%sprojects/%s", transport_tpg.BaseUrl(registry.GetProduct("compute"), config), hostProject)
 		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "GET",
@@ -109,7 +108,7 @@ func testAccCheckComputeSharedVpcHostProject(t *testing.T, hostProject string, e
 func testAccCheckComputeSharedVpcServiceProject(t *testing.T, hostProject, serviceProject string, enabled bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
-		url := fmt.Sprintf("%sprojects/%s/getXpnHost", computeBaseUrl, serviceProject)
+		url := fmt.Sprintf("%sprojects/%s/getXpnHost", transport_tpg.BaseUrl(registry.GetProduct("compute"), config), serviceProject)
 		serviceHostProject, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "GET",


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: Migrate google_compute_shared_vpc_host_project.go file to use direct HTTP rather than a client library
```
