### PR TITLE
bigquery: added resource identity support to `google_bigquery_table`

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -657,6 +657,27 @@ func ResourceBigQueryTable() *schema.Resource {
 			resourceBigQueryTableSchemaCustomizeDiff,
 			tpgresource.SetLabelsDiff,
 		),
+
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+					},
+					"dataset_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"table_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			// TableId: [Required] The ID of the table. The ID must contain only
 			// letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum
@@ -2198,9 +2219,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("BigQuery table %q", tableID))
 	}
 
-	if err := d.Set("project", project); err != nil {
-		return fmt.Errorf("Error setting project: %s", err)
-	}
 	if err := d.Set("description", rawRes["description"]); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
@@ -2225,15 +2243,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		for k, v := range labelsRaw {
 			labels[k] = v.(string)
 		}
-	}
-	if err := tpgresource.SetLabels(labels, d, "labels"); err != nil {
-		return fmt.Errorf("Error setting labels: %s", err)
-	}
-	if err := tpgresource.SetLabels(labels, d, "terraform_labels"); err != nil {
-		return fmt.Errorf("Error setting terraform_labels: %s", err)
-	}
-	if err := d.Set("effective_labels", labels); err != nil {
-		return fmt.Errorf("Error setting effective_labels: %s", err)
 	}
 	if v, ok := rawRes["creationTime"].(string); ok && v != "" {
 		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
@@ -2262,12 +2271,13 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
+	var datasetID, tableIDFromRef string
 	if tableRef, ok := rawRes["tableReference"].(map[string]interface{}); ok {
-		if err := d.Set("table_id", tableRef["tableId"]); err != nil {
-			return fmt.Errorf("Error setting table_id: %s", err)
+		if v, ok := tableRef["tableId"].(string); ok {
+			tableIDFromRef = v
 		}
-		if err := d.Set("dataset_id", tableRef["datasetId"]); err != nil {
-			return fmt.Errorf("Error setting dataset_id: %s", err)
+		if v, ok := tableRef["datasetId"].(string); ok {
+			datasetID = v
 		}
 	}
 	if v, ok := rawRes["numLongTermBytes"].(string); ok && v != "" {
@@ -2287,8 +2297,9 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("self_link", rawRes["selfLink"]); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
-	if err := d.Set("type", rawRes["type"]); err != nil {
-		return fmt.Errorf("Error setting type: %s", err)
+	tableType, _ := rawRes["type"].(string)
+	if err := populateBigQueryTableCommonResourceData(d, config, project, datasetID, tableIDFromRef, tableType, labels); err != nil {
+		return err
 	}
 
 	// determine whether the deprecated require_partition_filter field is used
@@ -2466,6 +2477,51 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func populateBigQueryTableCommonResourceData(d *schema.ResourceData, config *transport_tpg.Config, project, datasetID, tableID, tableType string, labels map[string]string) error {
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting project: %s", err)
+	}
+	if err := d.Set("dataset_id", datasetID); err != nil {
+		return fmt.Errorf("Error setting dataset_id: %s", err)
+	}
+	if err := d.Set("table_id", tableID); err != nil {
+		return fmt.Errorf("Error setting table_id: %s", err)
+	}
+	if err := tpgresource.SetLabels(labels, d, "labels"); err != nil {
+		return fmt.Errorf("Error setting labels: %s", err)
+	}
+	terraformLabels := make(map[string]string)
+	if config != nil {
+		for key, value := range config.DefaultLabels {
+			terraformLabels[key] = value
+		}
+	}
+	if configuredLabels, ok := d.GetOk("labels"); ok {
+		for key, value := range configuredLabels.(map[string]interface{}) {
+			terraformLabels[key] = value.(string)
+		}
+	}
+	if _, hasAttributionLabel := labels[transport_tpg.AttributionKey]; hasAttributionLabel {
+		terraformLabels[transport_tpg.AttributionKey] = transport_tpg.AttributionValue
+	}
+	if err := d.Set("terraform_labels", terraformLabels); err != nil {
+		return fmt.Errorf("Error setting terraform_labels: %s", err)
+	}
+	if err := d.Set("effective_labels", labels); err != nil {
+		return fmt.Errorf("Error setting effective_labels: %s", err)
+	}
+	if err := d.Set("type", tableType); err != nil {
+		return fmt.Errorf("Error setting type: %s", err)
+	}
+	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", project, datasetID, tableID))
+
+	return tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project":    project,
+		"dataset_id": datasetID,
+		"table_id":   tableID,
+	})
 }
 
 type TableReference struct {
@@ -3969,6 +4025,9 @@ func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*s
 	}
 
 	// Explicitly set virtual fields with default values to their default values on import
+	if err := d.Set("ignore_auto_generated_schema", false); err != nil {
+		return nil, fmt.Errorf("Error setting ignore_auto_generated_schema: %s", err)
+	}
 
 	// Replace import id for the resource id
 	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/bigquery"
@@ -49,6 +50,41 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_auto_generated_schema", "generated_schema_columns"},
+			},
+		},
+	})
+}
+
+func TestAccBigQueryTable_importBlockWithResourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableBasicSchemaForIdentityImport(datasetID, tableID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_bigquery_table.test", "project", project),
+					resource.TestCheckResourceAttr("google_bigquery_table.test", "dataset_id", datasetID),
+					resource.TestCheckResourceAttr("google_bigquery_table.test", "table_id", tableID),
+				),
+			},
+			{
+				ResourceName:    "google_bigquery_table.test",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+			},
+			{
+				Config: testAccBigQueryTableBasicSchema(datasetID, tableID),
 			},
 		},
 	})
@@ -2416,6 +2452,29 @@ resource "google_bigquery_table" "test" {
     "name": "id",
     "type": "INTEGER"
   }
+]
+EOH
+
+}
+`, datasetID, tableID)
+}
+
+func testAccBigQueryTableBasicSchemaForIdentityImport(datasetID, tableID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "test" {
+	dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "test" {
+	table_id   = "%s"
+	dataset_id = google_bigquery_dataset.test.dataset_id
+
+	schema = <<EOH
+[
+	{
+		"name": "id",
+		"type": "INTEGER"
+	}
 ]
 EOH
 

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -641,6 +641,19 @@ import {
 }
 ```
 
+In Terraform v1.12.0 and later, use an [`identity` block](https://developer.hashicorp.com/terraform/language/block/import#identity) to import BigQuery tables using identity values. For example:
+
+```tf
+import {
+  identity = {
+    project    = "{{project}}"
+    dataset_id = "{{dataset_id}}"
+    table_id   = "{{table_id}}"
+  }
+  to = google_bigquery_table.default
+}
+```
+
 When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), BigQuery tables can be imported using one of the formats above. For example:
 
 ```


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Adds identity to bigquery

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigquery: added resource identity support to `google_bigquery_table`
```
