### PR TITLE
Migrate `data_source_google_compute_global_address.go` data source to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_global_address.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_global_address.go
@@ -92,36 +92,45 @@ func dataSourceGoogleComputeGlobalAddressRead(d *schema.ResourceData, meta inter
 	name := d.Get("name").(string)
 	id := fmt.Sprintf("projects/%s/global/addresses/%s", project, name)
 
-	address, err := NewClient(config, userAgent).GlobalAddresses.Get(project, name).Do()
+	url := fmt.Sprintf("%sprojects/%s/global/addresses/%s", transport_tpg.BaseUrl(Product, config), project, name)
+	address, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Global Address Not Found : %s", name), id)
 	}
 
-	if err := d.Set("address", address.Address); err != nil {
+	if err := d.Set("address", address["address"]); err != nil {
 		return fmt.Errorf("Error setting address: %s", err)
 	}
-	if err := d.Set("address_type", address.AddressType); err != nil {
+	if err := d.Set("address_type", address["addressType"]); err != nil {
 		return fmt.Errorf("Error setting address_type: %s", err)
 	}
-	if err := d.Set("network", address.Network); err != nil {
+	if err := d.Set("network", address["network"]); err != nil {
 		return fmt.Errorf("Error setting network: %s", err)
 	}
-	if err := d.Set("network_tier", address.NetworkTier); err != nil {
+	if err := d.Set("network_tier", address["networkTier"]); err != nil {
 		return fmt.Errorf("Error setting network_tier: %s", err)
 	}
-	if err := d.Set("prefix_length", address.PrefixLength); err != nil {
+	// prefixLength is a plain JSON number and is absent for addresses without a prefix.
+	prefixLength, _ := address["prefixLength"].(float64)
+	if err := d.Set("prefix_length", int(prefixLength)); err != nil {
 		return fmt.Errorf("Error setting prefix_length: %s", err)
 	}
-	if err := d.Set("purpose", address.Purpose); err != nil {
+	if err := d.Set("purpose", address["purpose"]); err != nil {
 		return fmt.Errorf("Error setting purpose: %s", err)
 	}
-	if err := d.Set("subnetwork", address.Subnetwork); err != nil {
+	if err := d.Set("subnetwork", address["subnetwork"]); err != nil {
 		return fmt.Errorf("Error setting subnetwork: %s", err)
 	}
-	if err := d.Set("status", address.Status); err != nil {
+	if err := d.Set("status", address["status"]); err != nil {
 		return fmt.Errorf("Error setting status: %s", err)
 	}
-	if err := d.Set("self_link", address.SelfLink); err != nil {
+	if err := d.Set("self_link", address["selfLink"]); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Part of the ongoing migration of handwritten compute files from the Apiary client library to direct HTTP calls (`transport_tpg.SendRequest`). Same pattern as #18444 and the merged data source migrations #17090 / #17117.

- Replaces `NewClient(...).GlobalAddresses.Get(project, name).Do()` with a `GET` to `projects/{project}/global/addresses/{name}`.
- Response fields are read from the JSON map. `prefixLength` is a plain JSON number and is converted explicitly; when the field is absent (addresses without a prefix) the attribute stays `0`, matching the previous client's zero value.
- No schema, test, or documentation changes. The recorded VCR cassette stays replay-compatible: the request matcher strips `alt`/`prettyPrint`, and the URL path is unchanged.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_global_address` data source to use direct HTTP rather than a client library
```
