### PR TITLE
Migrate `data_source_google_compute_instance_serial_port.go` data source to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_serial_port.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_serial_port.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/registry"
@@ -61,16 +62,29 @@ func computeInstanceSerialPortRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error setting zone: %s", err)
 	}
 
-	port := int64(d.Get("port").(int))
-	output, err := NewClient(config, userAgent).Instances.GetSerialPortOutput(project, zone, d.Get("instance").(string)).Port(port).Do()
+	port := d.Get("port").(int)
+	url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/serialPort",
+		transport_tpg.BaseUrl(Product, config), project, zone, d.Get("instance").(string))
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"port": strconv.Itoa(port)})
+	if err != nil {
+		return err
+	}
+	output, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return err
 	}
 
-	if err := d.Set("contents", output.Contents); err != nil {
+	if err := d.Set("contents", output["contents"]); err != nil {
 		return fmt.Errorf("Error setting contents: %s", err)
 	}
-	d.SetId(output.SelfLink)
+	selfLink, _ := output["selfLink"].(string)
+	d.SetId(selfLink)
 	return nil
 }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Part of the ongoing migration of handwritten compute files from the Apiary client library to direct HTTP calls (`transport_tpg.SendRequest`). Same pattern as #18444 and the merged data source migrations #17090 / #17117.

- Replaces `NewClient(...).Instances.GetSerialPortOutput(project, zone, instance).Port(port).Do()` with `GET projects/{project}/zones/{zone}/instances/{instance}/serialPort?port=N` via `transport_tpg.SendRequest` + `transport_tpg.AddQueryParams`.
- Error handling is unchanged: the call had no 404 handler before and still returns the raw error.
- No schema, test, or documentation changes. The recorded VCR cassette stays replay-compatible: after the matcher strips `alt`/`prettyPrint`, both the old and the new request reduce to the same URL with `port=N`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_instance_serial_port` data source to use direct HTTP rather than a client library
```
