### PR TITLE
Migrate `data_source_google_compute_interconnect_location.go` data source to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_interconnect_location.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_interconnect_location.go
@@ -124,42 +124,50 @@ func dataSourceGoogleComputeInterconnectLocationRead(d *schema.ResourceData, met
 	}
 	name := d.Get("name").(string)
 	id := fmt.Sprintf("projects/%s/global/interconnectlocations/%s", project, name)
-	location, err := NewClient(config, userAgent).InterconnectLocations.Get(project, name).Do()
+	// The REST URL uses camelCase interconnectLocations; the Terraform ID keeps
+	// the historical lowercase interconnectlocations form.
+	url := fmt.Sprintf("%sprojects/%s/global/interconnectLocations/%s", transport_tpg.BaseUrl(Product, config), project, name)
+	location, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("InterconnectLocation Not Found : %s", name), id)
 	}
-	d.SetId(location.Name)
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-	if err := d.Set("self_link", location.SelfLink); err != nil {
+	if err := d.Set("self_link", location["selfLink"]); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
-	if err := d.Set("description", location.Description); err != nil {
+	if err := d.Set("description", location["description"]); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
-	if err := d.Set("peeringdb_facility_id", location.PeeringdbFacilityId); err != nil {
+	if err := d.Set("peeringdb_facility_id", location["peeringdbFacilityId"]); err != nil {
 		return fmt.Errorf("Error setting peeringdb_facility_id: %s", err)
 	}
-	if err := d.Set("address", location.Address); err != nil {
+	if err := d.Set("address", location["address"]); err != nil {
 		return fmt.Errorf("Error setting address: %s", err)
 	}
-	if err := d.Set("facility_provider", location.FacilityProvider); err != nil {
+	if err := d.Set("facility_provider", location["facilityProvider"]); err != nil {
 		return fmt.Errorf("Error setting facility_provider: %s", err)
 	}
-	if err := d.Set("facility_provider_facility_id", location.FacilityProviderFacilityId); err != nil {
+	if err := d.Set("facility_provider_facility_id", location["facilityProviderFacilityId"]); err != nil {
 		return fmt.Errorf("Error setting facility_provider_facility_id: %s", err)
 	}
-	if err := d.Set("continent", location.Continent); err != nil {
+	if err := d.Set("continent", location["continent"]); err != nil {
 		return fmt.Errorf("Error setting continent: %s", err)
 	}
-	if err := d.Set("city", location.City); err != nil {
+	if err := d.Set("city", location["city"]); err != nil {
 		return fmt.Errorf("Error setting city: %s", err)
 	}
-	if err := d.Set("availability_zone", location.AvailabilityZone); err != nil {
+	if err := d.Set("availability_zone", location["availabilityZone"]); err != nil {
 		return fmt.Errorf("Error setting availability_zone: %s", err)
 	}
-	if err := d.Set("status", location.Status); err != nil {
+	if err := d.Set("status", location["status"]); err != nil {
 		return fmt.Errorf("Error setting status: %s", err)
 	}
 	d.SetId(id)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Part of the ongoing migration of handwritten compute files from the Apiary client library to direct HTTP calls (`transport_tpg.SendRequest`). Same pattern as #18444 and the merged data source migrations #17090 / #17117.

- Replaces `NewClient(...).InterconnectLocations.Get(project, name).Do()` with a `GET` to `projects/{project}/global/interconnectLocations/{name}`. Note the REST URL uses camelCase `interconnectLocations` (same path the typed client used); the Terraform resource ID keeps its historical lowercase `interconnectlocations` form, so state is unaffected.
- All consumed response fields are plain JSON strings (including `peeringdbFacilityId`, which is a genuine string in the API), so they are passed to `d.Set` directly.
- Removes a dead `d.SetId(location.Name)` that was unconditionally overwritten by the final `d.SetId(id)` a few lines below.
- No schema, test, or documentation changes. The recorded VCR cassette stays replay-compatible (the matcher strips `alt`/`prettyPrint`; the URL path is unchanged).

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_interconnect_location` data source to use direct HTTP rather than a client library
```
