### PR TITLE
Use the delete timeout when waiting for service networking connection deletion

### DIFF
--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -351,7 +351,7 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	if err := ServiceNetworkingOperationWaitTimeHW(config, op, "Delete Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
+	if err := ServiceNetworkingOperationWaitTimeHW(config, op, "Delete Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutDelete)); err != nil {
 		return errwrap.Wrapf("Unable to remove Service Networking Connection, err: {{err}}", err)
 	}
 


### PR DESCRIPTION
`resourceServiceNetworkingConnectionDelete` passes `schema.TimeoutCreate` to the operation waiter instead of `schema.TimeoutDelete`:

https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go#L354

Create and update already use their own timeouts (`TimeoutCreate` / `TimeoutUpdate`), so delete looks like an oversight.

Effect on users: a configured `delete` timeout is silently ignored, and the `create` timeout governs the delete wait instead.

```hcl
resource "google_service_networking_connection" "default" {
  # ...
  timeouts {
    create = "10m"
    delete = "40m" # ignored today; the wait uses create's 10m
  }
}
```

All three defaults are 10m, so the default behaviour is unchanged and this only surfaces once someone sets a custom timeout. That matters for this resource in particular, since deletes can be slow when service producer resources are still being released.

### Tests

No new test. The bug is not observable through the acceptance test framework — it only changes how long the waiter is allowed to run, and asserting on it would mean a test that deliberately waits out a timeout.

Verified by generating both providers; the downstream diff is this one line in each:

- `google/services/servicenetworking/resource_service_networking_connection.go`
- `google-beta/services/servicenetworking/resource_service_networking_connection.go`

`go build ./...` and `go vet ./google/services/servicenetworking/...` pass.

```release-note:bug
servicenetworking: fixed `google_service_networking_connection` ignoring the configured `delete` timeout, which used the `create` timeout instead
```
