### PR TITLE
Fix workload identity pool ID validation to strip the literal .svc.id.goog suffix

### DIFF
--- a/mmv1/templates/terraform/constants/iam_workload_identity_pool.go.tmpl
+++ b/mmv1/templates/terraform/constants/iam_workload_identity_pool.go.tmpl
@@ -9,9 +9,7 @@ func ValidateWorkloadIdentityPoolId(v interface{}, k string) (ws []string, error
             "%q (%q) can not start with \"gcp-\"", k, value))
     }
 
-    if strings.HasSuffix(value, defaultWorkloadIdentityPoolIdSuffix) {
-        value = strings.TrimRight(value, defaultWorkloadIdentityPoolIdSuffix)
-    }
+    value = strings.TrimSuffix(value, defaultWorkloadIdentityPoolIdSuffix)
 
     if !regexp.MustCompile(workloadIdentityPoolIdRegexp).MatchString(value) {
        errors = append(errors, fmt.Errorf(

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_id_test.go
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_id_test.go
@@ -17,6 +17,7 @@ func TestValidateIAMBetaWorkloadIdentityPoolId(t *testing.T) {
 		{TestName: "long", Value: "12345678901234567890123456789012"},
 		{TestName: "has a hyphen", Value: "foo-bar"},
 		{TestName: "default pool format", Value: "foo-bar.svc.id.goog"},
+		{TestName: "default pool format with base name ending in a suffix character", Value: "goods.svc.id.goog"},
 
 		// With errors
 		{TestName: "empty", Value: "", ExpectError: true},
@@ -26,6 +27,7 @@ func TestValidateIAMBetaWorkloadIdentityPoolId(t *testing.T) {
 		{TestName: "has an backslash", Value: "foo\bar", ExpectError: true},
 		{TestName: "too short", Value: "foo", ExpectError: true},
 		{TestName: "too long", Value: strings.Repeat("f", 33), ExpectError: true},
+		{TestName: "too long with suffix", Value: strings.Repeat("a", 32) + "g.svc.id.goog", ExpectError: true},
 	}
 
 	es := verify.TestStringValidationCases(x, iambeta.ValidateWorkloadIdentityPoolId)


### PR DESCRIPTION
### Bug

`ValidateWorkloadIdentityPoolId` (used by `google_iam_workload_identity_pool`) strips the optional `.svc.id.goog` suffix before its regex/length checks, but uses `strings.TrimRight`:

```go
if strings.HasSuffix(value, defaultWorkloadIdentityPoolIdSuffix) {
    value = strings.TrimRight(value, defaultWorkloadIdentityPoolIdSuffix)
}
```

`strings.TrimRight(s, cutset)` treats its second argument as a **set of characters** (`{'.','s','v','c','i','d','g','o'}`), not a literal suffix. It greedily removes *every* trailing character in that set, not the 12-char `.svc.id.goog` suffix.

Concrete effects (base name = the ID before the suffix):

| Input | after `TrimRight` | result today | correct |
|---|---|---|---|
| `goods.svc.id.goog` | `""` | **rejected** (regex + too short) | accepted (`goods`) |
| `foods.svc.id.goog` | `"f"` | **rejected** (too short) | accepted (`foods`) |
| 33-char id + `.svc.id.goog` | trailing `g` also eaten | **accepted** | should be rejected (too long) |

So valid pool IDs whose base name ends in any of `s v c i d g o` are wrongly rejected, and an over-length ID can slip through. The existing `foo-bar.svc.id.goog` test passes only by luck (`foo-bar` ends in `r`, outside the cutset), which is why this went unnoticed.

### Fix

Use `strings.TrimSuffix`, which removes exactly the literal `.svc.id.goog` suffix (and is a no-op when absent, so the `HasSuffix` guard is no longer needed). No behavior change for valid inputs; the buggy rejections/acceptance are corrected.

### Test

Added a case to `TestValidateIAMBetaWorkloadIdentityPoolId`: `goods.svc.id.goog` (a valid ID whose base name ends in a cutset character) is expected to pass. It fails under the old `TrimRight` code and passes with `TrimSuffix`; all existing cases still pass.

```release-note:bug
iam: fixed validation of `google_iam_workload_identity_pool` IDs ending in `.svc.id.goog` where the base name ends in one of the suffix's characters
```
