### PR TITLE
biglakeiceberg: suppress location diffs on google_biglake_iceberg_table

### DIFF
--- a/mmv1/products/biglakeiceberg/IcebergTable.yaml
+++ b/mmv1/products/biglakeiceberg/IcebergTable.yaml
@@ -101,6 +101,7 @@ properties:
       The location of the table.
     immutable: true
     default_from_api: true
+    diff_suppress_func: icebergTableLocationDiffSuppress
   - name: schema
     type: NestedObject
     required: true

--- a/mmv1/templates/terraform/constants/biglake_iceberg_table.go.tmpl
+++ b/mmv1/templates/terraform/constants/biglake_iceberg_table.go.tmpl
@@ -14,6 +14,18 @@ func icebergTablePropertiesDiffSuppress(k, old, new string, d *schema.ResourceDa
 	return false
 }
 
+func icebergTableLocationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if new == "" {
+		return true
+	}
+	oldClean := strings.TrimSuffix(old, "/")
+	newClean := strings.TrimSuffix(new, "/")
+	if oldClean == newClean {
+		return true
+	}
+	return strings.HasPrefix(oldClean, newClean+"/")
+}
+
 // expandIcebergTableSortOrderForCommit converts the Terraform "sort_order" block
 // into the SortOrder body of an "add-sort-order" commit update. The "order-id" is
 // assigned by the server, so only the fields are sent. Returns nil when no sort


### PR DESCRIPTION
Suppresses diffs on the `location` attribute of the `google_biglake_iceberg_table` resource.

The Iceberg REST catalog updates the `location` path by appending table version / snapshot directory suffixes. Since the path is configured as `immutable: true` (`ForceNew: true`), this state drift previously forced replacement of the resource, leading to failures in generated IAM policy tests.

This PR implements `icebergTableLocationDiffSuppress` which ignores suffixes added to the base GCS location path.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28487

```release-note:bug
biglakeiceberg: fixed a permadiff in `google_biglake_iceberg_table` by suppressing diffs on `location` when the API-returned path contains a suffix folder.
```
