### PR TITLE
biglakeiceberg: suppress plan diff for write.parquet.compression-codec in iceberg table properties

### DIFF
--- a/mmv1/templates/terraform/constants/biglake_iceberg_table.go.tmpl
+++ b/mmv1/templates/terraform/constants/biglake_iceberg_table.go.tmpl
@@ -3,6 +3,7 @@ var icebergTableIgnoredProperties = map[string]bool{
 	"gcp.biglake.bigquery-advanced.enabled": true,
 	"gcp.biglake.bigquery-dml.enabled":      true,
 	"gcp.biglake.table-management.enabled":  true,
+	"write.parquet.compression-codec":       true,
 }
 
 func icebergTablePropertiesDiffSuppress(k, old, new string, d *schema.ResourceData) bool {


### PR DESCRIPTION
This PR fixes a bug where `google_biglake_iceberg_table` was experiencing plan-non-empty diffs during updates when the default property `"write.parquet.compression-codec"` (returned as `"zstd"` by the API) was not defined in the user's Terraform configuration.

By adding `"write.parquet.compression-codec"` to `icebergTableIgnoredProperties`, we suppress the diff when the property is not defined by the user.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28299

```release-note:bug
biglakeiceberg: fixed perma-diff on `write.parquet.compression-codec` in `google_biglake_iceberg_table`
```
