### PR TITLE
workbench: diff-suppress server-injected version-description metadata

### DIFF
--- a/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
@@ -83,6 +83,7 @@ var WorkbenchInstanceProvidedMetadata = []string{
     "enable-guest-attributes",
     "enable-oslogin",
     "proxy-registration-url",
+    "versionDescription",
 }
 
 func WorkbenchInstanceMetadataDiffSuppress(k, old, new string, d *schema.ResourceData) bool {

--- a/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
@@ -83,7 +83,7 @@ var WorkbenchInstanceProvidedMetadata = []string{
     "enable-guest-attributes",
     "enable-oslogin",
     "proxy-registration-url",
-    "versionDescription",
+    "version-description",
 }
 
 func WorkbenchInstanceMetadataDiffSuppress(k, old, new string, d *schema.ResourceData) bool {


### PR DESCRIPTION
The Workbench backend surfaces a system-owned instance metadata key `version-description` (a human-readable image description derived from the VmImage release configs, e.g. `Debian 11, Python 3.10`). Users can never set this key, so the `google_workbench_instance` provider must diff-suppress it; otherwise every Terraform-managed Workbench instance gets a permadiff (same class of issue as `new-proxy-agent-enabled`, #17310).

This adds `version-description` to `WorkbenchInstanceProvidedMetadata` (purely server-owned, always injected, not EUC-specific).

Context (Google-internal): b/539638368.

```release-note:bug
workbench: suppressed a diff on `google_workbench_instance` for the server-injected `version-description` metadata key
```