### PR TITLE
feat(container): Add GKE node pool sandbox type MICROVM

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -774,7 +774,7 @@ func schemaNodeConfig() *schema.Schema {
 							Required:     true,
 {{- end }}
 							Description:  `Type of the sandbox to use for the node (e.g. 'GVISOR').`,
-							ValidateFunc: validation.StringInSlice([]string{"GVISOR"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"GVISOR", "MICROVM"}, false),
 						},
 					},
 				},

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -910,6 +910,31 @@ func TestAccContainerNodePool_withSandboxConfigType(t *testing.T) {
 	})
 }
 
+func TestAccContainerNodePool_withSandboxConfigMicroVM(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withSandboxConfigMicroVM(cluster, np, networkName, subnetworkName),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_sandbox_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 	t.Parallel()
 
@@ -4243,6 +4268,53 @@ resource "google_container_node_pool" "with_sandbox_config" {
 
     sandbox_config {
       type = "GVISOR"
+    }
+
+    labels = {
+      "test.terraform.io/gke-sandbox" = "true"
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+`, cluster, networkName, subnetworkName, np)
+}
+
+func testAccContainerNodePool_withSandboxConfigMicroVM(cluster, np, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+}
+
+resource "google_container_node_pool" "with_sandbox_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+  node_config {
+    machine_type = "n2-standard-2" // N2 supports nested virtualization required for microvm
+    image_type = "COS_CONTAINERD"
+
+    advanced_machine_features {
+      threads_per_core = 2
+      enable_nested_virtualization = true
+    }
+
+    sandbox_config {
+      type = "MICROVM"
     }
 
     labels = {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1628,6 +1628,7 @@ not.
     Accepted values are:
 
     * `"GVISOR"`: Pods run within a gVisor sandbox.
+    * `"MICROVM"`: Pods run within a microVM sandbox.
 
 * `sandbox_type` (Beta, Deprecated) Which sandbox to use for pods in the node pool. `sandbox_config.sandbox_type` is deprecated and will be removed in a future major release. Use `sandbox_config.type` instead.
     Accepted values are:

--- a/mmv1/third_party/tgc_next/pkg/services/container/node_config.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/node_config.go
@@ -724,7 +724,7 @@ func schemaNodeConfig() *schema.Schema {
 								Type:         schema.TypeString,
 								Required:     true,
 								Description:  `Type of the sandbox to use for the node (e.g. 'gvisor')`,
-								ValidateFunc: validation.StringInSlice([]string{"gvisor"}, false),
+								ValidateFunc: validation.StringInSlice([]string{"gvisor", "microvm"}, false),
 							},
 						},
 					},


### PR DESCRIPTION
Adds support for the new MicroVM sandbox type to `google_container_cluster` and `google_container_node_pool` under `sandbox_config.type`.

```release-note:enhancement
container: added `MICROVM` support to `sandbox_config.type` in `google_container_cluster` and `google_container_node_pool`
```
