### PR TITLE
add pull request comment webhook event type to secure source manager

### DIFF
--- a/mmv1/products/securesourcemanager/Hook.yaml
+++ b/mmv1/products/securesourcemanager/Hook.yaml
@@ -123,6 +123,7 @@ properties:
       enum_values:
         - PUSH
         - PULL_REQUEST
+        - PULL_REQUEST_COMMENT
     default_from_api: true
   - name: createTime
     type: Time

--- a/mmv1/templates/terraform/samples/services/securesourcemanager/secure_source_manager_hook_with_fields.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/securesourcemanager/secure_source_manager_hook_with_fields.tf.tmpl
@@ -25,5 +25,5 @@ resource "google_secure_source_manager_hook" "default" {
     push_option {
         branch_filter = "main"
     }
-    events = ["PUSH", "PULL_REQUEST"]
+    events = ["PUSH", "PULL_REQUEST", "PULL_REQUEST_COMMENT"]
 }

--- a/mmv1/third_party/terraform/services/securesourcemanager/resource_secure_source_manager_hook_update_test.go
+++ b/mmv1/third_party/terraform/services/securesourcemanager/resource_secure_source_manager_hook_update_test.go
@@ -65,7 +65,7 @@ resource "google_secure_source_manager_hook" "default" {
     hook_id = "tf-test-my-initial-hook%{random_suffix}"
     location = google_secure_source_manager_repository.repository.location
     repository_id = google_secure_source_manager_repository.repository.repository_id
-    events = ["PUSH", "PULL_REQUEST"]
+    events = ["PUSH", "PULL_REQUEST", "PULL_REQUEST_COMMENT"]
     push_option {
         branch_filter = "main"
     }


### PR DESCRIPTION
  This PR adds support for the `PULL_REQUEST_COMMENT` event type in the `events` field of the `google_secure_source_manager_hook` resource.

```release-note:enhancement
securesourcemanager: added `PULL_REQUEST_COMMENT` enum to `events` field to `google_secure_source_manager_hook`
```