### PR TITLE
Add weight field to Chronicle Environment

### DIFF
--- a/mmv1/products/chronicle/Environment.yaml
+++ b/mmv1/products/chronicle/Environment.yaml
@@ -119,3 +119,8 @@ properties:
     required: true
     immutable: true
     description: Environment data retention in months.
+  - name: weight
+    type: Integer
+    description: |-
+      The weight of the environment, enabling customers to control distribution of resources between the separate environments in a single instance of Chronicle SOAR.
+

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_environment_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_environment_full.tf.tmpl
@@ -10,6 +10,7 @@ resource "google_chronicle_environment" "{{$.PrimaryResourceId}}" {
   aliases_json            = jsonencode([])
   data_access_scopes_json = jsonencode([])
   retention_duration = 3
+  weight             = 2
 
   deletion_protection  = false
 }


### PR DESCRIPTION
This PR adds Terraform support for the missing `weight` field in `google_chronicle_environment`.

Fixes b/538658507