### PR TITLE
ces: add modality field to google_ces_deployment resource

### DIFF
--- a/mmv1/products/ces/Deployment.yaml
+++ b/mmv1/products/ces/Deployment.yaml
@@ -30,6 +30,8 @@ samples:
         resource_id_vars:
           app_display_name: my-app
           app_id: app-id
+          app_version_display_name: my-version
+          app_version_id: version-id
           deployment_display_name: my-deployment
   - name: ces_deployment_full
     primary_resource_id: my-deployment
@@ -38,6 +40,8 @@ samples:
         resource_id_vars:
           app_display_name: my-app
           app_id: app-id
+          app_version_display_name: my-version
+          app_version_id: version-id
           deployment_display_name: my-deployment
 parameters:
   - name: location
@@ -171,6 +175,14 @@ properties:
       operation. If the etag is empty, the update will overwrite any concurrent
       changes.
     output: true
+  - name: modality
+    type: String
+    description: |-
+      The modality of the deployment.
+      Possible values:
+      MODALITY_TEXT
+      MODALITY_VOICE
+      MODALITY_VIDEO
   - name: name
     type: String
     description: |-

--- a/mmv1/templates/terraform/samples/services/ces/ces_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_deployment_basic.tf.tmpl
@@ -6,11 +6,18 @@ resource "google_ces_app" "my-app" {
         time_zone = "America/Los_Angeles"
     }
 }
+resource "google_ces_app_version" "my-version" {
+    location       = "us"
+    display_name   = "{{index $.ResourceIdVars "app_version_display_name"}}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "{{index $.ResourceIdVars "app_version_id"}}"
+    description    = "example-app-version"
+}
 resource "google_ces_deployment" "{{$.PrimaryResourceId}}" {
     location     = "us"
     display_name = "{{index $.ResourceIdVars "deployment_display_name"}}"
     app          = google_ces_app.my-app.name
-    app_version  = "projects/example-project/locations/us/apps/example-app/versions/example-version"
+    app_version  = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/versions/${google_ces_app_version.my-version.app_version_id}"
     channel_profile {
         channel_type = "API"
         disable_barge_in_control = true

--- a/mmv1/templates/terraform/samples/services/ces/ces_deployment_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_deployment_full.tf.tmpl
@@ -6,11 +6,19 @@ resource "google_ces_app" "my-app" {
         time_zone = "America/Los_Angeles"
     }
 }
+resource "google_ces_app_version" "my-version" {
+    location       = "us"
+    display_name   = "{{index $.ResourceIdVars "app_version_display_name"}}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "{{index $.ResourceIdVars "app_version_id"}}"
+    description    = "example-app-version"
+}
 resource "google_ces_deployment" "{{$.PrimaryResourceId}}" {
     location     = "us"
     display_name = "{{index $.ResourceIdVars "deployment_display_name"}}"
     app          = google_ces_app.my-app.name
-    app_version  = "projects/example-project/locations/us/apps/example-app/versions/example-version"
+    app_version  = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/versions/${google_ces_app_version.my-version.app_version_id}"
+    modality     = "MODALITY_TEXT"
     channel_profile {
         channel_type = "API"
         disable_barge_in_control = true

--- a/mmv1/third_party/terraform/services/ces/ces_deployment_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_deployment_test.go
@@ -58,11 +58,19 @@ resource "google_ces_app" "my-app" {
         time_zone = "America/Los_Angeles"
     }
 }
+resource "google_ces_app_version" "my-version" {
+    location       = "us"
+    display_name   = "tf-test-version-%{random_suffix}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "tf-test-version-%{random_suffix}"
+    description    = "example-app-version"
+}
 resource "google_ces_deployment" "my-deployment" {
     location     = "us"
     display_name = "tf-test-my-deployment%{random_suffix}"
     app          = google_ces_app.my-app.name
-    app_version  = "projects/example-project/locations/us/apps/example-app/versions/example-version"
+    app_version  = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/versions/${google_ces_app_version.my-version.app_version_id}"
+    modality     = "MODALITY_TEXT"
     channel_profile {
         channel_type = "API"
         disable_barge_in_control = true
@@ -97,11 +105,19 @@ resource "google_ces_app" "my-app" {
         time_zone = "America/Los_Angeles"
     }
 }
+resource "google_ces_app_version" "my-version" {
+    location       = "us"
+    display_name   = "tf-test-version-%{random_suffix}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "tf-test-version-%{random_suffix}"
+    description    = "example-app-version"
+}
 resource "google_ces_deployment" "my-deployment" {
     location     = "us"
     display_name = "tf-test-my-deployment%{random_suffix}"
     app          = google_ces_app.my-app.name
-    app_version  = "projects/example-project/locations/us/apps/example-app/versions/example-version"
+    app_version  = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/versions/${google_ces_app_version.my-version.app_version_id}"
+    modality     = "MODALITY_VOICE"
     channel_profile {
         channel_type = "WEB_UI"
         disable_barge_in_control = true


### PR DESCRIPTION
Adds top-level `modality` field to `google_ces_deployment` resource.

Fixes https://b.corp.google.com/issues/538657713

```release-note:enhancement
ces: added `modality` field to `google_ces_deployment` resource
```
