### PR TITLE
vertexai: add spec.containerSpec.port to ReasoningEngine

### DIFF
--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -771,6 +771,10 @@ properties:
               The Artifact Registry Docker image URI (e.g.,
               `us-central1-docker.pkg.dev/my-project/my-repo/my-image:tag`) of the
               container image that is to be run on each worker replica.
+          - name: 'port'
+            type: Integer
+            description: |-
+              Optional. Port for HTTP requests to be sent to.
       - name: 'sourceCodeSpec'
         type: NestedObject
         conflicts:

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_byoc.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_byoc.tf.tmpl
@@ -6,6 +6,7 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
   spec {
     container_spec {
       image_uri = "us-central1-docker.pkg.dev/${data.google_project.project.project_id}/vertex-byoc/byoc-agent:latest" # image path
+      port      = 8080
     }
   }
 

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -1091,3 +1091,41 @@ resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
 }
 `, context)
 }
+
+func TestAccVertexAIReasoningEngine_containerSpecPort(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccVertexAIReasoningEngine_containerSpecPort(context),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccVertexAIReasoningEngine_containerSpecPort(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
+  provider     = google-beta
+  display_name = "tf-test-reasoning-engine-%{random_suffix}"
+  description  = "Reasoning engine testing container_spec.port field"
+  region       = "us-central1"
+
+  spec {
+    container_spec {
+      image_uri = "us-central1-docker.pkg.dev/my-project/my-repo/my-image:latest"
+      port      = 8080
+    }
+  }
+}
+`, context)
+}


### PR DESCRIPTION
Add support for missing field `spec.containerSpec.port` in `google_vertex_ai_reasoning_engine`.

Issue: http://b/538658926

```release-note:enhancement
vertexai: added `spec.container_spec.port` field to `google_vertex_ai_reasoning_engine`
```
