### PR TITLE
feat(iam3): Update iam3 AccessPolicy resources to GA

### DIFF
--- a/mmv1/products/iam3/FolderAccessPolicy.yaml
+++ b/mmv1/products/iam3/FolderAccessPolicy.yaml
@@ -18,9 +18,8 @@ description: |
   that allow or deny access to resources within the specified folder based on principals and conditions.
   See the Cloud IAM documentation for more details on Access Policies.
 references:
-  api: https://cloud.google.com/iam/docs/reference/rest/v3beta/folders.locations.accessPolicies
+  api: https://cloud.google.com/iam/docs/reference/rest/v3/folders.locations.accessPolicies
 base_url: folders/{{folder}}/locations/{{location}}/accessPolicies
-min_version: beta
 self_link: folders/{{folder}}/locations/{{location}}/accessPolicies/{{access_policy_id}}
 create_url: folders/{{folder}}/locations/{{location}}/accessPolicies?accessPolicyId={{access_policy_id}}
 update_verb: PATCH

--- a/mmv1/products/iam3/OrganizationAccessPolicy.yaml
+++ b/mmv1/products/iam3/OrganizationAccessPolicy.yaml
@@ -18,9 +18,8 @@ description: |-
   defines rules that allow or deny access to resources within the specified organization based on principals and conditions.
   See the Cloud IAM documentation for more details on Access Policies.
 references:
-  api: https://cloud.google.com/iam/docs/reference/rest/v3beta/organizations.locations.accessPolicies
+  api: https://cloud.google.com/iam/docs/reference/rest/v3/organizations.locations.accessPolicies
 base_url: organizations/{{organization}}/locations/{{location}}/accessPolicies
-min_version: beta
 self_link: organizations/{{organization}}/locations/{{location}}/accessPolicies/{{access_policy_id}}
 create_url: organizations/{{organization}}/locations/{{location}}/accessPolicies?accessPolicyId={{access_policy_id}}
 update_verb: PATCH

--- a/mmv1/products/iam3/ProjectAccessPolicy.yaml
+++ b/mmv1/products/iam3/ProjectAccessPolicy.yaml
@@ -18,9 +18,8 @@ description: |
   that allow or deny access to resources within the specified project based on principals and conditions.
   See the Cloud IAM documentation for more details on Access Policies.
 references:
-  api: https://cloud.google.com/iam/docs/reference/rest/v3beta/projects.locations.accessPolicies
+  api: https://cloud.google.com/iam/docs/reference/rest/v3/projects.locations.accessPolicies
 base_url: projects/{{project}}/locations/{{location}}/accessPolicies
-min_version: beta
 self_link: projects/{{project}}/locations/{{location}}/accessPolicies/{{access_policy_id}}
 create_url: projects/{{project}}/locations/{{location}}/accessPolicies?accessPolicyId={{access_policy_id}}
 update_verb: PATCH

--- a/mmv1/templates/terraform/samples/services/iam3/access_policy_folder_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/iam3/access_policy_folder_full.tf.tmpl
@@ -1,11 +1,9 @@
 resource "google_folder" "folder" {
-  provider     = google-beta
   display_name = "{{index $.ResourceIdVars "folder_name"}}"
   parent       = "organizations/{{index $.TestEnvVars "org_id"}}"
   deletion_protection = false
 }
 resource "google_project" "project" {
-  provider        = google-beta
   project_id      = "{{index $.ResourceIdVars "project_name"}}"
   name            = "{{index $.ResourceIdVars "project_name"}}"
   folder_id       = google_folder.folder.folder_id
@@ -14,7 +12,6 @@ resource "google_project" "project" {
   depends_on = [google_folder.folder]
 }
 resource "google_project_service" "iam_api" {
-  provider = google-beta
   project  = google_project.project.project_id
   service  = "iam.googleapis.com"
   disable_on_destroy = false
@@ -28,7 +25,6 @@ resource "time_sleep" "wait_for_propagation" {
   ]
 }
 resource "google_service_account" "test_sa" {
-  provider        = google-beta
   account_id   = "{{index $.ResourceIdVars "account_id"}}"
   display_name = "Test Service Account for Access Policy"
   project      = google_project.project.project_id
@@ -37,7 +33,6 @@ resource "google_service_account" "test_sa" {
   ]
 }
 resource "google_service_account" "excluded_sa" {
-  provider        = google-beta
   account_id   = "{{index $.ResourceIdVars "excluded_account_id"}}"
   display_name = "Excluded Service Account for Access Policy"
   project      = google_project.project.project_id
@@ -46,7 +41,6 @@ resource "google_service_account" "excluded_sa" {
   ]
 }
 resource "google_iam_folder_access_policy" "{{$.PrimaryResourceId}}" {
-  provider          = google-beta
   folder            = google_folder.folder.folder_id
   location          = "global"
   access_policy_id  = "{{index $.ResourceIdVars "access_policy_id"}}"

--- a/mmv1/templates/terraform/samples/services/iam3/access_policy_folder_minimal.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/iam3/access_policy_folder_minimal.tf.tmpl
@@ -1,11 +1,9 @@
 resource "google_folder" "folder" {
-  provider     = google-beta
   display_name = "{{index $.ResourceIdVars "folder_name"}}"
   parent       = "organizations/{{index $.TestEnvVars "org_id"}}"
   deletion_protection = false
 }
 resource "google_project" "project" {
-  provider        = google-beta
   project_id      = "{{index $.ResourceIdVars "project_name"}}"
   name            = "{{index $.ResourceIdVars "project_name"}}"
   folder_id       = google_folder.folder.folder_id
@@ -14,7 +12,6 @@ resource "google_project" "project" {
   depends_on = [google_folder.folder]
 }
 resource "google_project_service" "iam_api" {
-  provider = google-beta
   project  = google_project.project.project_id
   service  = "iam.googleapis.com"
   disable_on_destroy = false
@@ -28,7 +25,6 @@ resource "time_sleep" "wait_for_propagation" {
   ]
 }
 resource "google_service_account" "test_sa" {
-  provider        = google-beta
   account_id   = "{{index $.ResourceIdVars "account_id"}}"
   display_name = "Test Service Account for Access Policy"
   project      = google_project.project.project_id
@@ -37,7 +33,6 @@ resource "google_service_account" "test_sa" {
   ]
 }
 resource "google_iam_folder_access_policy" "{{$.PrimaryResourceId}}" {
-  provider          = google-beta
   folder            = google_folder.folder.folder_id
   location          = "global"
   access_policy_id  = "{{index $.ResourceIdVars "access_policy_id"}}"

--- a/mmv1/templates/terraform/samples/services/iam3/access_policy_organization_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/iam3/access_policy_organization_full.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_project" "project" {
-  provider        = google-beta
   project_id      = "{{index $.ResourceIdVars "project_name"}}"
   name            = "{{index $.ResourceIdVars "project_name"}}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
@@ -7,7 +6,6 @@ resource "google_project" "project" {
   deletion_policy = "DELETE"
 }
 resource "google_project_service" "iam_api" {
-  provider = google-beta
   project  = google_project.project.project_id
   service  = "iam.googleapis.com"
   disable_on_destroy = false
@@ -20,7 +18,6 @@ resource "time_sleep" "wait_for_propagation" {
   ]
 }
 resource "google_service_account" "test_sa" {
-  provider        = google-beta
   account_id   = "{{index $.ResourceIdVars "account_id"}}"
   display_name = "Org Access Policy Test SA"
   project      = google_project.project.project_id
@@ -29,7 +26,6 @@ resource "google_service_account" "test_sa" {
   ]
 }
 resource "google_service_account" "excluded_sa" {
-  provider        = google-beta
   account_id   = "{{index $.ResourceIdVars "excluded_account_id"}}"
   display_name = "Excluded Service Account for Access Policy"
   project      = google_project.project.project_id
@@ -38,7 +34,6 @@ resource "google_service_account" "excluded_sa" {
   ]
 }
 resource "google_iam_organization_access_policy" "{{$.PrimaryResourceId}}" {
-  provider          = google-beta
   organization      = "{{index $.TestEnvVars "org_id"}}"
   location          = "global"
   access_policy_id  = "{{index $.ResourceIdVars "access_policy_id"}}"

--- a/mmv1/templates/terraform/samples/services/iam3/access_policy_organization_minimal.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/iam3/access_policy_organization_minimal.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_project" "project" {
-  provider        = google-beta
   project_id      = "{{index $.ResourceIdVars "project_name"}}"
   name            = "{{index $.ResourceIdVars "project_name"}}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
@@ -7,7 +6,6 @@ resource "google_project" "project" {
   deletion_policy = "DELETE"
 }
 resource "google_project_service" "iam_api" {
-  provider = google-beta
   project  = google_project.project.project_id
   service  = "iam.googleapis.com"
   disable_on_destroy = false
@@ -20,7 +18,6 @@ resource "time_sleep" "wait_for_propagation" {
   ]
 }
 resource "google_service_account" "test_sa" {
-  provider        = google-beta
   account_id   = "{{index $.ResourceIdVars "account_id"}}"
   display_name = "Org Access Policy Test SA"
   project      = google_project.project.project_id
@@ -29,7 +26,6 @@ resource "google_service_account" "test_sa" {
   ]
 }
 resource "google_iam_organization_access_policy" "{{$.PrimaryResourceId}}" {
-  provider          = google-beta
   organization      = "{{index $.TestEnvVars "org_id"}}"
   location          = "global"
   access_policy_id  = "{{index $.ResourceIdVars "access_policy_id"}}"

--- a/mmv1/templates/terraform/samples/services/iam3/access_policy_project_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/iam3/access_policy_project_full.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_project" "project" {
-  provider        = google-beta
   project_id      = "{{index $.ResourceIdVars "project_name"}}"
   name            = "{{index $.ResourceIdVars "project_name"}}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
@@ -7,7 +6,6 @@ resource "google_project" "project" {
   deletion_policy = "DELETE"
 }
 resource "google_project_service" "iam_api" {
-  provider = google-beta
   project  = google_project.project.project_id
   service  = "iam.googleapis.com"
   disable_on_destroy = false
@@ -19,7 +17,6 @@ resource "time_sleep" "wait_for_project_propagation" {
   ]
 }
 resource "google_service_account" "test_sa" {
-  provider        = google-beta
   account_id   = "{{index $.ResourceIdVars "account_id"}}"
   display_name = "Test Service Account for Access Policy"
   project      = google_project.project.project_id
@@ -28,7 +25,6 @@ resource "google_service_account" "test_sa" {
   ]
 }
 resource "google_service_account" "excluded_sa" {
-  provider        = google-beta
   account_id   = "{{index $.ResourceIdVars "excluded_account_id"}}"
   display_name = "Excluded Service Account for Access Policy"
   project      = google_project.project.project_id
@@ -37,7 +33,6 @@ resource "google_service_account" "excluded_sa" {
   ]
 }
 resource "google_iam_project_access_policy" "{{$.PrimaryResourceId}}" {
-  provider          = google-beta
   project           = google_project.project.project_id
   location          = "global"
   access_policy_id  = "{{index $.ResourceIdVars "access_policy_id"}}"

--- a/mmv1/templates/terraform/samples/services/iam3/access_policy_project_minimal.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/iam3/access_policy_project_minimal.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_project" "project" {
-  provider        = google-beta
   project_id      = "{{index $.ResourceIdVars "project_name"}}"
   name            = "{{index $.ResourceIdVars "project_name"}}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
@@ -7,7 +6,6 @@ resource "google_project" "project" {
   deletion_policy = "DELETE"
 }
 resource "google_project_service" "iam_api" {
-  provider = google-beta
   project  = google_project.project.project_id
   service  = "iam.googleapis.com"
   disable_on_destroy = false
@@ -19,7 +17,6 @@ resource "time_sleep" "wait_for_project_propagation" {
   ]
 }
 resource "google_service_account" "test_sa" {
-  provider        = google-beta
   account_id   = "{{index $.ResourceIdVars "account_id"}}"
   display_name = "Test Service Account for Access Policy"
   project      = google_project.project.project_id
@@ -28,7 +25,6 @@ resource "google_service_account" "test_sa" {
   ]
 }
 resource "google_iam_project_access_policy" "{{$.PrimaryResourceId}}" {
-  provider          = google-beta
   project           = google_project.project.project_id
   location          = "global"
   access_policy_id  = "{{index $.ResourceIdVars "access_policy_id"}}"


### PR DESCRIPTION
- Remove `min_version: beta` from the resource configuration [ProjectAccessPolicy.yaml](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/products/iam3/ProjectAccessPolicy.yaml), [FolderAccessPolicy.yaml](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/products/iam3/FolderAccessPolicy.yaml), [OrganizationAccessPolicy.yaml](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/products/iam3/OrganizationAccessPolicy.yaml)
- Remove `provider = google-beta` from all the `tf.tmpl`examples.


```release-note:new-resource
google_iam_access_policy (ga)
```
