### PR TITLE
Allow updating guest_accelerator gpu_sharing_config and gpu_driver_installation_config without recreate

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -325,14 +325,12 @@ func schemaNodeConfig() *schema.Schema {
 								MaxItems:     1,
 								Optional:     true,
 								Computed:     true,
-								ForceNew:     true,
 								Description:  `Configuration for auto installation of GPU driver.`,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"gpu_driver_version": {
 											Type:         schema.TypeString,
 											Required:     true,
-											ForceNew:     true,
 											Description:  `Mode for how the GPU driver is installed.`,
 											ValidateFunc: validation.StringInSlice([]string{"GPU_DRIVER_VERSION_UNSPECIFIED", "INSTALLATION_DISABLED", "DEFAULT", "LATEST"}, false),
 										},

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -4604,7 +4604,7 @@ func nodePoolNodeConfigUpdate(d *schema.ResourceData, config *transport_tpg.Conf
 			}
 
 			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
-					return err
+				return err
 			}
 
 			log.Printf("[INFO] Updated guest_accelerator for node pool %s", name)

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -304,7 +304,6 @@ func schemaNodeConfig() *schema.Schema {
 					Type:     schema.TypeList,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 					Description: `List of the type and count of accelerator cards attached to the instance.`,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -350,20 +349,17 @@ func schemaNodeConfig() *schema.Schema {
 								Type:         schema.TypeList,
 								MaxItems:     1,
 								Optional:     true,
-								ForceNew:     true,
 								Description:  `Configuration for GPU sharing.`,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"gpu_sharing_strategy": {
 											Type:        schema.TypeString,
 											Required:    true,
-											ForceNew:    true,
 											Description: `The type of GPU sharing strategy to enable on the GPU node. Possible values are described in the API package (https://pkg.go.dev/google.golang.org/api/container/v1#GPUSharingConfig)`,
 										},
 										"max_shared_clients_per_gpu": {
 											Type:        schema.TypeInt,
 											Required:    true,
-											ForceNew:    true,
 											Description: `The maximum number of containers that can share a GPU.`,
 										},
 									},
@@ -1629,6 +1625,40 @@ func expandNodeConfigDefaults(configured interface{}) *container.NodeConfigDefau
 	return nodeConfigDefaults
 }
 
+func expandGuestAccelerator(v interface{}) []*container.AcceleratorConfig {
+	accels := v.([]interface{})
+	guestAccelerators := make([]*container.AcceleratorConfig, 0, len(accels))
+	for _, raw := range accels {
+		data := raw.(map[string]interface{})
+		if data["count"].(int) == 0 {
+			continue
+		}
+		guestAcceleratorConfig := &container.AcceleratorConfig{
+			AcceleratorCount: int64(data["count"].(int)),
+			AcceleratorType:  data["type"].(string),
+			GpuPartitionSize: data["gpu_partition_size"].(string),
+		}
+
+		if v, ok := data["gpu_driver_installation_config"]; ok && len(v.([]interface{})) > 0 {
+			gpuDriverInstallationConfig := data["gpu_driver_installation_config"].([]interface{})[0].(map[string]interface{})
+			guestAcceleratorConfig.GpuDriverInstallationConfig = &container.GPUDriverInstallationConfig{
+				GpuDriverVersion: gpuDriverInstallationConfig["gpu_driver_version"].(string),
+			}
+		}
+
+		if v, ok := data["gpu_sharing_config"]; ok && len(v.([]interface{})) > 0 {
+			gpuSharingConfig := data["gpu_sharing_config"].([]interface{})[0].(map[string]interface{})
+			guestAcceleratorConfig.GpuSharingConfig = &container.GPUSharingConfig{
+				GpuSharingStrategy:     gpuSharingConfig["gpu_sharing_strategy"].(string),
+				MaxSharedClientsPerGpu: int64(gpuSharingConfig["max_shared_clients_per_gpu"].(int)),
+			}
+		}
+
+		guestAccelerators = append(guestAccelerators, guestAcceleratorConfig)
+	}
+	return guestAccelerators
+}
+
 func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *container.NodeConfig {
 	nodeConfigs := v.([]interface{})
 	nc := &container.NodeConfig{
@@ -1658,37 +1688,7 @@ func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *con
 	}
 
 	if v, ok := nodeConfig["guest_accelerator"]; ok {
-		accels := v.([]interface{})
-		guestAccelerators := make([]*container.AcceleratorConfig, 0, len(accels))
-		for _, raw := range accels {
-			data := raw.(map[string]interface{})
-			if data["count"].(int) == 0 {
-				continue
-			}
-			guestAcceleratorConfig := &container.AcceleratorConfig{
-				AcceleratorCount: int64(data["count"].(int)),
-				AcceleratorType:  data["type"].(string),
-				GpuPartitionSize: data["gpu_partition_size"].(string),
-			}
-
-			if v, ok := data["gpu_driver_installation_config"]; ok && len(v.([]interface{})) > 0 {
-				gpuDriverInstallationConfig := data["gpu_driver_installation_config"].([]interface{})[0].(map[string]interface{})
-				guestAcceleratorConfig.GpuDriverInstallationConfig = &container.GPUDriverInstallationConfig{
-					GpuDriverVersion: gpuDriverInstallationConfig["gpu_driver_version"].(string),
-				}
-			}
-
-			if v, ok := data["gpu_sharing_config"]; ok && len(v.([]interface{})) > 0 {
-				gpuSharingConfig := data["gpu_sharing_config"].([]interface{})[0].(map[string]interface{})
-				guestAcceleratorConfig.GpuSharingConfig = &container.GPUSharingConfig{
-					GpuSharingStrategy: gpuSharingConfig["gpu_sharing_strategy"].(string),
-					MaxSharedClientsPerGpu: int64(gpuSharingConfig["max_shared_clients_per_gpu"].(int)),
-				}
-			}
-
-			guestAccelerators = append(guestAccelerators, guestAcceleratorConfig)
-		}
-		nc.Accelerators = guestAccelerators
+		nc.Accelerators = expandGuestAccelerator(v)
 	}
 
 	if v, ok := nodeConfig["disk_size_gb"]; ok {
@@ -4580,6 +4580,36 @@ func nodePoolNodeConfigUpdate(d *schema.ResourceData, config *transport_tpg.Conf
 			}
 
 			log.Printf("[INFO] Updated gvnic for node pool %s", name)
+		}
+
+		if d.HasChange(prefix + "node_config.0.guest_accelerator") {
+			req := &container.UpdateNodePoolRequest{
+				NodePoolId:   name,
+				Accelerators: expandGuestAccelerator(d.Get(prefix + "node_config.0.guest_accelerator")),
+			}
+			updateF := func() error {
+				clusterNodePoolsUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
+				if config.UserProjectOverride {
+					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
+				}
+				op, err := clusterNodePoolsUpdateCall.Do()
+				if err != nil {
+					return err
+				}
+
+				// Wait until it's updated
+				return ContainerOperationWait(config, op,
+					nodePoolInfo.project,
+					nodePoolInfo.location,
+					"updating GKE node pool guest_accelerator", userAgent,
+					timeout)
+			}
+
+			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+					return err
+			}
+
+			log.Printf("[INFO] Updated guest_accelerator for node pool %s", name)
 		}
 
 		if d.HasChange(prefix + "node_config.0.kubelet_config") {

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -304,7 +304,6 @@ func schemaNodeConfig() *schema.Schema {
 					Type:     schema.TypeList,
 					Optional: true,
 					Computed: true,
-					ForceNew: true,
 					Description: `List of the type and count of accelerator cards attached to the instance.`,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -350,20 +349,17 @@ func schemaNodeConfig() *schema.Schema {
 								Type:         schema.TypeList,
 								MaxItems:     1,
 								Optional:     true,
-								ForceNew:     true,
 								Description:  `Configuration for GPU sharing.`,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"gpu_sharing_strategy": {
 											Type:        schema.TypeString,
 											Required:    true,
-											ForceNew:    true,
 											Description: `The type of GPU sharing strategy to enable on the GPU node. Possible values are described in the API package (https://pkg.go.dev/google.golang.org/api/container/v1#GPUSharingConfig)`,
 										},
 										"max_shared_clients_per_gpu": {
 											Type:        schema.TypeInt,
 											Required:    true,
-											ForceNew:    true,
 											Description: `The maximum number of containers that can share a GPU.`,
 										},
 									},
@@ -1598,6 +1594,40 @@ func expandNodeConfigDefaults(configured interface{}) *container.NodeConfigDefau
 	return nodeConfigDefaults
 }
 
+func expandGuestAccelerator(v interface{}) []*container.AcceleratorConfig {
+	accels := v.([]interface{})
+	guestAccelerators := make([]*container.AcceleratorConfig, 0, len(accels))
+	for _, raw := range accels {
+		data := raw.(map[string]interface{})
+		if data["count"].(int) == 0 {
+			continue
+		}
+		guestAcceleratorConfig := &container.AcceleratorConfig{
+			AcceleratorCount: int64(data["count"].(int)),
+			AcceleratorType:  data["type"].(string),
+			GpuPartitionSize: data["gpu_partition_size"].(string),
+		}
+
+		if v, ok := data["gpu_driver_installation_config"]; ok && len(v.([]interface{})) > 0 {
+			gpuDriverInstallationConfig := data["gpu_driver_installation_config"].([]interface{})[0].(map[string]interface{})
+			guestAcceleratorConfig.GpuDriverInstallationConfig = &container.GPUDriverInstallationConfig{
+				GpuDriverVersion: gpuDriverInstallationConfig["gpu_driver_version"].(string),
+			}
+		}
+
+		if v, ok := data["gpu_sharing_config"]; ok && len(v.([]interface{})) > 0 {
+			gpuSharingConfig := data["gpu_sharing_config"].([]interface{})[0].(map[string]interface{})
+			guestAcceleratorConfig.GpuSharingConfig = &container.GPUSharingConfig{
+				GpuSharingStrategy:     gpuSharingConfig["gpu_sharing_strategy"].(string),
+				MaxSharedClientsPerGpu: int64(gpuSharingConfig["max_shared_clients_per_gpu"].(int)),
+			}
+		}
+
+		guestAccelerators = append(guestAccelerators, guestAcceleratorConfig)
+	}
+	return guestAccelerators
+}
+
 func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *container.NodeConfig {
 	nodeConfigs := v.([]interface{})
 	nc := &container.NodeConfig{
@@ -1627,37 +1657,7 @@ func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *con
 	}
 
 	if v, ok := nodeConfig["guest_accelerator"]; ok {
-		accels := v.([]interface{})
-		guestAccelerators := make([]*container.AcceleratorConfig, 0, len(accels))
-		for _, raw := range accels {
-			data := raw.(map[string]interface{})
-			if data["count"].(int) == 0 {
-				continue
-			}
-			guestAcceleratorConfig := &container.AcceleratorConfig{
-				AcceleratorCount: int64(data["count"].(int)),
-				AcceleratorType:  data["type"].(string),
-				GpuPartitionSize: data["gpu_partition_size"].(string),
-			}
-
-			if v, ok := data["gpu_driver_installation_config"]; ok && len(v.([]interface{})) > 0 {
-				gpuDriverInstallationConfig := data["gpu_driver_installation_config"].([]interface{})[0].(map[string]interface{})
-				guestAcceleratorConfig.GpuDriverInstallationConfig = &container.GPUDriverInstallationConfig{
-					GpuDriverVersion: gpuDriverInstallationConfig["gpu_driver_version"].(string),
-				}
-			}
-
-			if v, ok := data["gpu_sharing_config"]; ok && len(v.([]interface{})) > 0 {
-				gpuSharingConfig := data["gpu_sharing_config"].([]interface{})[0].(map[string]interface{})
-				guestAcceleratorConfig.GpuSharingConfig = &container.GPUSharingConfig{
-					GpuSharingStrategy: gpuSharingConfig["gpu_sharing_strategy"].(string),
-					MaxSharedClientsPerGpu: int64(gpuSharingConfig["max_shared_clients_per_gpu"].(int)),
-				}
-			}
-
-			guestAccelerators = append(guestAccelerators, guestAcceleratorConfig)
-		}
-		nc.Accelerators = guestAccelerators
+		nc.Accelerators = expandGuestAccelerator(v)
 	}
 
 	if v, ok := nodeConfig["disk_size_gb"]; ok {
@@ -4507,6 +4507,36 @@ func nodePoolNodeConfigUpdate(d *schema.ResourceData, config *transport_tpg.Conf
 			}
 
 			log.Printf("[INFO] Updated gvnic for node pool %s", name)
+		}
+
+		if d.HasChange(prefix + "node_config.0.guest_accelerator") {
+			req := &container.UpdateNodePoolRequest{
+				NodePoolId:   name,
+				Accelerators: expandGuestAccelerator(d.Get(prefix + "node_config.0.guest_accelerator")),
+			}
+			updateF := func() error {
+				clusterNodePoolsUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
+				if config.UserProjectOverride {
+					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
+				}
+				op, err := clusterNodePoolsUpdateCall.Do()
+				if err != nil {
+					return err
+				}
+
+				// Wait until it's updated
+				return ContainerOperationWait(config, op,
+					nodePoolInfo.project,
+					nodePoolInfo.location,
+					"updating GKE node pool guest_accelerator", userAgent,
+					timeout)
+			}
+
+			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+					return err
+			}
+
+			log.Printf("[INFO] Updated guest_accelerator for node pool %s", name)
 		}
 
 		if d.HasChange(prefix + "node_config.0.kubelet_config") {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -17893,6 +17893,156 @@ resource "google_container_cluster" "with_kubelet_config" {
 `, clusterName, networkName, subnetworkName, npName, npName)
 }
 
+func TestAccContainerCluster_guestAcceleratorSubconfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_guestAcceleratorSubconfig(clusterName, networkName, subnetworkName, "DEFAULT", 2),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			// The default node pool goes through the cluster's own node_config update path, which must
+			// apply the sub-config changes in place rather than recreating the cluster.
+			{
+				Config: testAccContainerCluster_guestAcceleratorSubconfig(clusterName, networkName, subnetworkName, "LATEST", 4),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_cluster.primary", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_config.0.guest_accelerator.0.gpu_driver_installation_config.0.gpu_driver_version", "LATEST"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_config.0.guest_accelerator.0.gpu_sharing_config.0.max_shared_clients_per_gpu", "4"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_guestAcceleratorSubconfig(clusterName, networkName, subnetworkName, driverVersion string, maxSharedClientsPerGpu int) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+
+  node_config {
+    machine_type = "n1-standard-2"
+
+    guest_accelerator {
+      type  = "nvidia-tesla-t4"
+      count = 1
+      gpu_driver_installation_config {
+        gpu_driver_version = "%s"
+      }
+      gpu_sharing_config {
+        gpu_sharing_strategy       = "TIME_SHARING"
+        max_shared_clients_per_gpu = %d
+      }
+    }
+  }
+}
+`, clusterName, networkName, subnetworkName, driverVersion, maxSharedClientsPerGpu)
+}
+
+func TestAccContainerCluster_nodePoolGuestAcceleratorSubconfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_nodePoolGuestAcceleratorSubconfig(clusterName, networkName, subnetworkName, 2),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			// Same for a node_pool block, which updates through nodePoolUpdate instead.
+			{
+				Config: testAccContainerCluster_nodePoolGuestAcceleratorSubconfig(clusterName, networkName, subnetworkName, 4),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_cluster.primary", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_pool.0.node_config.0.guest_accelerator.0.gpu_sharing_config.0.max_shared_clients_per_gpu", "4"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_nodePoolGuestAcceleratorSubconfig(clusterName, networkName, subnetworkName string, maxSharedClientsPerGpu int) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+
+  node_pool {
+    name               = "gpu-pool"
+    initial_node_count = 1
+
+    node_config {
+      machine_type = "n1-standard-2"
+
+      guest_accelerator {
+        type  = "nvidia-tesla-t4"
+        count = 1
+        gpu_driver_installation_config {
+          gpu_driver_version = "DEFAULT"
+        }
+        gpu_sharing_config {
+          gpu_sharing_strategy       = "TIME_SHARING"
+          max_shared_clients_per_gpu = %d
+        }
+      }
+    }
+  }
+}
+`, clusterName, networkName, subnetworkName, maxSharedClientsPerGpu)
+}
+
 func testAccContainerCluster_nodePool_acceleratorNetworkProfile(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -1650,6 +1650,84 @@ func TestAccContainerNodePool_withGPU(t *testing.T) {
 	})
 }
 
+func TestAccContainerNodePool_gpuSharingConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_gpuSharingConfig(cluster, np, networkName, subnetworkName, 2),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Updating max_shared_clients_per_gpu must happen in place, not by recreating the node pool.
+			{
+				Config: testAccContainerNodePool_gpuSharingConfig(cluster, np, networkName, subnetworkName, 4),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_node_pool.np", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_config.0.guest_accelerator.0.gpu_sharing_config.0.max_shared_clients_per_gpu", "4"),
+				),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_gpuSharingConfig(cluster, np, networkName, subnetworkName string, maxSharedClientsPerGpu int) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+
+  node_config {
+    machine_type = "n1-standard-2"
+
+    guest_accelerator {
+      type  = "nvidia-tesla-t4"
+      count = 1
+      gpu_driver_installation_config {
+        gpu_driver_version = "DEFAULT"
+      }
+      gpu_sharing_config {
+        gpu_sharing_strategy       = "TIME_SHARING"
+        max_shared_clients_per_gpu = %d
+      }
+    }
+  }
+}
+`, cluster, networkName, subnetworkName, np, maxSharedClientsPerGpu)
+}
+
 func TestAccContainerNodePool_withRDMA(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -1677,6 +1677,84 @@ func TestAccContainerNodePool_withGPU(t *testing.T) {
 	})
 }
 
+func TestAccContainerNodePool_gpuSharingConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_gpuSharingConfig(cluster, np, networkName, subnetworkName, 2),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Updating max_shared_clients_per_gpu must happen in place, not by recreating the node pool.
+			{
+				Config: testAccContainerNodePool_gpuSharingConfig(cluster, np, networkName, subnetworkName, 4),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_node_pool.np", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_config.0.guest_accelerator.0.gpu_sharing_config.0.max_shared_clients_per_gpu", "4"),
+				),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_gpuSharingConfig(cluster, np, networkName, subnetworkName string, maxSharedClientsPerGpu int) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+
+  node_config {
+    machine_type = "n1-standard-2"
+
+    guest_accelerator {
+      type  = "nvidia-tesla-t4"
+      count = 1
+      gpu_driver_installation_config {
+        gpu_driver_version = "DEFAULT"
+      }
+      gpu_sharing_config {
+        gpu_sharing_strategy       = "TIME_SHARING"
+        max_shared_clients_per_gpu = %d
+      }
+    }
+  }
+}
+`, cluster, networkName, subnetworkName, np, maxSharedClientsPerGpu)
+}
+
 func TestAccContainerNodePool_withRDMA(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -1715,44 +1715,37 @@ func TestAccContainerNodePool_gpuSharingConfigUpdate(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Dropping the block is also an in-place update; the post-apply plan is only empty if the
+			// API actually cleared the sharing config.
+			{
+				Config: testAccContainerNodePool_guestAcceleratorNoSharing(cluster, np, networkName, subnetworkName, 1),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_node_pool.np", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_config.0.guest_accelerator.0.gpu_sharing_config.#", "0"),
+				),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// count and type stay ForceNew: the GKE API rejects updating them in place.
+			{
+				Config:             testAccContainerNodePool_guestAcceleratorNoSharing(cluster, np, networkName, subnetworkName, 2),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_node_pool.np", plancheck.ResourceActionReplace),
+					},
+				},
+			},
 		},
 	})
-}
-
-func testAccContainerNodePool_gpuSharingConfig(cluster, np, networkName, subnetworkName string, maxSharedClientsPerGpu int) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "cluster" {
-  name                = "%s"
-  location            = "us-central1-a"
-  initial_node_count  = 1
-  deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
-}
-
-resource "google_container_node_pool" "np" {
-  name               = "%s"
-  location           = "us-central1-a"
-  cluster            = google_container_cluster.cluster.name
-  initial_node_count = 1
-
-  node_config {
-    machine_type = "n1-standard-2"
-
-    guest_accelerator {
-      type  = "nvidia-tesla-t4"
-      count = 1
-      gpu_driver_installation_config {
-        gpu_driver_version = "DEFAULT"
-      }
-      gpu_sharing_config {
-        gpu_sharing_strategy       = "TIME_SHARING"
-        max_shared_clients_per_gpu = %d
-      }
-    }
-  }
-}
-`, cluster, networkName, subnetworkName, np, maxSharedClientsPerGpu)
 }
 
 func TestAccContainerNodePool_gpuDriverInstallationConfigUpdate(t *testing.T) {
@@ -1797,7 +1790,7 @@ func TestAccContainerNodePool_gpuDriverInstallationConfigUpdate(t *testing.T) {
 	})
 }
 
-func testAccContainerNodePool_gpuDriverInstallationConfig(cluster, np, networkName, subnetworkName, driverVersion string) string {
+func testAccContainerNodePool_guestAccelerator(cluster, np, networkName, subnetworkName string, count int, driverVersion, gpuSharingConfig string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
   name                = "%s"
@@ -1819,14 +1812,31 @@ resource "google_container_node_pool" "np" {
 
     guest_accelerator {
       type  = "nvidia-tesla-t4"
-      count = 1
+      count = %d
       gpu_driver_installation_config {
         gpu_driver_version = "%s"
       }
+%s
     }
   }
 }
-`, cluster, networkName, subnetworkName, np, driverVersion)
+`, cluster, networkName, subnetworkName, np, count, driverVersion, gpuSharingConfig)
+}
+
+func testAccContainerNodePool_gpuSharingConfig(cluster, np, networkName, subnetworkName string, maxSharedClientsPerGpu int) string {
+	return testAccContainerNodePool_guestAccelerator(cluster, np, networkName, subnetworkName, 1, "DEFAULT", fmt.Sprintf(`
+      gpu_sharing_config {
+        gpu_sharing_strategy       = "TIME_SHARING"
+        max_shared_clients_per_gpu = %d
+      }`, maxSharedClientsPerGpu))
+}
+
+func testAccContainerNodePool_guestAcceleratorNoSharing(cluster, np, networkName, subnetworkName string, count int) string {
+	return testAccContainerNodePool_guestAccelerator(cluster, np, networkName, subnetworkName, count, "DEFAULT", "")
+}
+
+func testAccContainerNodePool_gpuDriverInstallationConfig(cluster, np, networkName, subnetworkName, driverVersion string) string {
+	return testAccContainerNodePool_guestAccelerator(cluster, np, networkName, subnetworkName, 1, driverVersion, "")
 }
 
 func TestAccContainerNodePool_withRDMA(t *testing.T) {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -1755,6 +1755,80 @@ resource "google_container_node_pool" "np" {
 `, cluster, networkName, subnetworkName, np, maxSharedClientsPerGpu)
 }
 
+func TestAccContainerNodePool_gpuDriverInstallationConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_gpuDriverInstallationConfig(cluster, np, networkName, subnetworkName, "DEFAULT"),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Updating gpu_driver_version must happen in place, not by recreating the node pool.
+			{
+				Config: testAccContainerNodePool_gpuDriverInstallationConfig(cluster, np, networkName, subnetworkName, "LATEST"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_node_pool.np", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_config.0.guest_accelerator.0.gpu_driver_installation_config.0.gpu_driver_version", "LATEST"),
+				),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_gpuDriverInstallationConfig(cluster, np, networkName, subnetworkName, driverVersion string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+
+  node_config {
+    machine_type = "n1-standard-2"
+
+    guest_accelerator {
+      type  = "nvidia-tesla-t4"
+      count = 1
+      gpu_driver_installation_config {
+        gpu_driver_version = "%s"
+      }
+    }
+  }
+}
+`, cluster, networkName, subnetworkName, np, driverVersion)
+}
+
 func TestAccContainerNodePool_withRDMA(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -1728,6 +1728,80 @@ resource "google_container_node_pool" "np" {
 `, cluster, networkName, subnetworkName, np, maxSharedClientsPerGpu)
 }
 
+func TestAccContainerNodePool_gpuDriverInstallationConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_gpuDriverInstallationConfig(cluster, np, networkName, subnetworkName, "DEFAULT"),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Updating gpu_driver_version must happen in place, not by recreating the node pool.
+			{
+				Config: testAccContainerNodePool_gpuDriverInstallationConfig(cluster, np, networkName, subnetworkName, "LATEST"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_node_pool.np", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_config.0.guest_accelerator.0.gpu_driver_installation_config.0.gpu_driver_version", "LATEST"),
+				),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_gpuDriverInstallationConfig(cluster, np, networkName, subnetworkName, driverVersion string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+
+  node_config {
+    machine_type = "n1-standard-2"
+
+    guest_accelerator {
+      type  = "nvidia-tesla-t4"
+      count = 1
+      gpu_driver_installation_config {
+        gpu_driver_version = "%s"
+      }
+    }
+  }
+}
+`, cluster, networkName, subnetworkName, np, driverVersion)
+}
+
 func TestAccContainerNodePool_withRDMA(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1397,6 +1397,10 @@ sole_tenant_config {
 
 <a name="nested_guest_accelerator"></a>The `guest_accelerator` block supports:
 
+~> **Note:** `gpu_driver_installation_config` and `gpu_sharing_config` are updated in place. Changing
+`type`, `count` or `gpu_partition_size` recreates the node pool, because the GKE API does not support
+updating them on an existing node pool.
+
 * `type` (Required) - The accelerator type resource to expose to this instance. E.g. `nvidia-tesla-k80`.
 
 * `count` (Required) - The number of the guest accelerator cards exposed to this instance.


### PR DESCRIPTION
Allows the updatable sub-configs of `node_config.guest_accelerator` to be changed in place, instead of forcing the node pool to be recreated:

- `gpu_sharing_config` (e.g. `max_shared_clients_per_gpu`)
- `gpu_driver_installation_config` (`gpu_driver_version`)

`ForceNew` is removed from the `guest_accelerator` block and those two sub-blocks, and an `UpdateNodePool` handler is added so changes to them apply in place.

### Scope / why this is narrow

The GKE API does **not** allow updating accelerator `count` or `type` in place (`PUT nodePools.update` returns `Accelerator count: 1 should not be updated.`), and an empty `accelerators` list is a no-op (not a removal). So `count`, `type`, and `gpu_partition_size` intentionally keep `ForceNew` — changing them still recreates the node pool. Only `gpu_sharing_config` and `gpu_driver_installation_config` are updatable, verified directly against a real cluster.

`Computed` is retained on `guest_accelerator`, so this is **not** a breaking change (no `optional+computed -> optional` transition).

### Testing

All tests assert via `plancheck.ExpectResourceAction(..., ResourceActionUpdate)` that the change lands in place rather than recreating, and are followed by import verification. The framework's post-apply empty-plan check confirms each update converges.

`google_container_node_pool`:

- `TestAccContainerNodePool_gpuSharingConfigUpdate` — `max_shared_clients_per_gpu` 2 -> 4, then dropping the `gpu_sharing_config` block entirely, then a `PlanOnly` step asserting a `count` change still plans a `Replace`
- `TestAccContainerNodePool_gpuDriverInstallationConfigUpdate` — `gpu_driver_version` DEFAULT -> LATEST

`google_container_cluster` — `ForceNew` is removed from the shared `schemaNodeConfig()`, so both of the cluster's node config paths are covered too:

- `TestAccContainerCluster_guestAcceleratorSubconfigUpdate` — cluster-level `node_config`, which updates the default node pool through the cluster's own update path
- `TestAccContainerCluster_nodePoolGuestAcceleratorSubconfigUpdate` — a `node_pool` block, which updates through `nodePoolUpdate`

```release-note:enhancement
container: made `node_config.guest_accelerator.gpu_sharing_config` and `node_config.guest_accelerator.gpu_driver_installation_config` updatable in place (without recreating the node pool) in `google_container_cluster` and `google_container_node_pool`
```

