### PR TITLE
canonicalize extension headers in signed url SigningString

### DIFF
--- a/mmv1/third_party/terraform/services/storage/data_source_storage_object_signed_url.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_object_signed_url.go
@@ -300,21 +300,53 @@ func (u *UrlData) SigningString() []byte {
 	buf.WriteString("\n")
 
 	// Extra HTTP headers (optional)
-	// Must be sorted in lexigraphical order
-	var keys []string
-	for k := range u.HttpHeaders {
-		keys = append(keys, strings.ToLower(k))
-	}
-	sort.Strings(keys)
-	// Write sorted headers to signing string buffer
-	for _, k := range keys {
-		buf.WriteString(fmt.Sprintf("%s:%s\n", k, u.HttpHeaders[k]))
+	for _, h := range canonicalExtensionHeaders(u.HttpHeaders) {
+		buf.WriteString(h)
 	}
 
 	// Storage Object path (includes bucketname)
 	buf.WriteString(u.SignPath)
 
 	return buf.Bytes()
+}
+
+// canonicalExtensionHeaders builds the CANONICALIZED_EXTENSION_HEADERS block of
+// the v2 signing string, as documented at
+// https://cloud.google.com/storage/docs/access-control/signed-urls-v2:
+// header names are lowercased, values with the same name are merged into one
+// comma-separated value, folded values are flattened onto a single line,
+// whitespace around the colon is dropped, and the result is sorted by name.
+func canonicalExtensionHeaders(headers map[string]string) []string {
+	merged := map[string][]string{}
+	for k, v := range headers {
+		name := strings.ToLower(strings.TrimSpace(k))
+		merged[name] = append(merged[name], foldHeaderValue(v))
+	}
+
+	names := make([]string, 0, len(merged))
+	for name := range merged {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	canonical := make([]string, 0, len(names))
+	for _, name := range names {
+		values := merged[name]
+		// Terraform hands us a map, so there is no request order to preserve;
+		// sort the values instead to keep the signature stable across runs.
+		sort.Strings(values)
+		canonical = append(canonical, fmt.Sprintf("%s:%s\n", name, strings.Join(values, ",")))
+	}
+	return canonical
+}
+
+// foldHeaderValue flattens a header value onto a single line so that it cannot
+// contribute extra lines to the signing string.
+func foldHeaderValue(v string) string {
+	for _, nl := range []string{"\r\n", "\r", "\n"} {
+		v = strings.ReplaceAll(v, nl, " ")
+	}
+	return strings.TrimSpace(v)
 }
 
 func (u *UrlData) Signature() ([]byte, error) {

--- a/mmv1/third_party/terraform/services/storage/data_source_storage_object_signed_url_internal_test.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_object_signed_url_internal_test.go
@@ -74,6 +74,53 @@ func TestUrlData_Signing(t *testing.T) {
 
 }
 
+func TestUrlData_SigningString_ExtensionHeaders(t *testing.T) {
+	cases := map[string]struct {
+		headers  map[string]string
+		expected string
+	}{
+		"lowercase name": {
+			headers:  map[string]string{"x-goog-acl": "private"},
+			expected: "PUT\n\n\n1470967410\nx-goog-acl:private\n" + testSignUrlPath,
+		},
+		"mixed case name keeps its value": {
+			headers:  map[string]string{"X-Goog-Acl": "private"},
+			expected: "PUT\n\n\n1470967410\nx-goog-acl:private\n" + testSignUrlPath,
+		},
+		"sorted by lowercased name": {
+			headers:  map[string]string{"X-Goog-Meta-Two": "2", "x-goog-acl": "private"},
+			expected: "PUT\n\n\n1470967410\nx-goog-acl:private\nx-goog-meta-two:2\n" + testSignUrlPath,
+		},
+		"names differing only in case are merged": {
+			headers:  map[string]string{"x-goog-acl": "private", "X-Goog-Acl": "public-read"},
+			expected: "PUT\n\n\n1470967410\nx-goog-acl:private,public-read\n" + testSignUrlPath,
+		},
+		"newline in value does not add a header line": {
+			headers:  map[string]string{"x-goog-meta-a": "v\nx-goog-acl:public-read"},
+			expected: "PUT\n\n\n1470967410\nx-goog-meta-a:v x-goog-acl:public-read\n" + testSignUrlPath,
+		},
+		"whitespace around the value is dropped": {
+			headers:  map[string]string{"x-goog-meta-a": "  v  "},
+			expected: "PUT\n\n\n1470967410\nx-goog-meta-a:v\n" + testSignUrlPath,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			urlData := &UrlData{
+				HttpMethod:  "PUT",
+				Expires:     testUrlExpires,
+				Path:        testUrlPath,
+				SignPath:    testSignUrlPath,
+				HttpHeaders: tc.headers,
+			}
+			if got := string(urlData.SigningString()); got != tc.expected {
+				t.Errorf("signing string does not match expected value:\n%q\n%q", tc.expected, got)
+			}
+		})
+	}
+}
+
 func TestUrlData_SignedUrl(t *testing.T) {
 	// load fake service account credentials
 	cfg, err := google.JWTConfigFromJSON([]byte(fakeCredentials), "")


### PR DESCRIPTION
Repro: sign a URL with `extension_headers = { "X-Goog-Acl" = "private" }`; the value never reaches the signing string, which gets `x-goog-acl:` instead.
Cause: `SigningString` lowercases the header names into a separate slice, then looks their values back up in `HttpHeaders` with the lowercased key, and writes values verbatim so a newline in one adds a whole extra signed header line.
Fix: build the canonicalized-extension-headers block from the original map per the [v2 rules](https://cloud.google.com/storage/docs/access-control/signed-urls-v2), merging same-name values and folding CR/LF to a space.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: fixed a bug in `data.google_storage_object_signed_url` where an `extension_headers` name that was not all lowercase had its value dropped from the signature
```
