### PR TITLE
ces: fix TestAccCESSecuritySettings_cesSecuritySettingsExample_update in GA

### DIFF
--- a/mmv1/third_party/terraform/services/ces/ces_security_settings_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/ces/ces_security_settings_test.go.tmpl
@@ -1,5 +1,6 @@
 package ces_test
 
+{{ if ne $.TargetVersionName "ga" }}
 import (
 	"testing"
 
@@ -129,3 +130,4 @@ resource "google_ces_security_settings" "security_settings" {
 }
 `, context)
 }
+{{ end }}


### PR DESCRIPTION
Fix TestAccCESSecuritySettings_cesSecuritySettingsExample_update in GA by adding the template version guard for a Beta-only resource.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27618

```release-note:none
```
