### PR TITLE
ces: fix app_version dependency in ces_deployment acceptance tests

### DIFF
--- a/mmv1/products/ces/Deployment.yaml
+++ b/mmv1/products/ces/Deployment.yaml
@@ -30,6 +30,8 @@ samples:
         resource_id_vars:
           app_display_name: my-app
           app_id: app-id
+          app_version_display_name: my-app-version
+          app_version_id: app-version-id
           deployment_display_name: my-deployment
   - name: ces_deployment_full
     primary_resource_id: my-deployment
@@ -38,6 +40,8 @@ samples:
         resource_id_vars:
           app_display_name: my-app
           app_id: app-id
+          app_version_display_name: my-app-version
+          app_version_id: app-version-id
           deployment_display_name: my-deployment
 parameters:
   - name: location

--- a/mmv1/templates/terraform/samples/services/ces/ces_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_deployment_basic.tf.tmpl
@@ -6,11 +6,18 @@ resource "google_ces_app" "my-app" {
         time_zone = "America/Los_Angeles"
     }
 }
+resource "google_ces_app_version" "my-app-version" {
+    location       = "us"
+    display_name   = "{{index $.ResourceIdVars "app_version_display_name"}}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "{{index $.ResourceIdVars "app_version_id"}}"
+    description    = "example-app-version"
+}
 resource "google_ces_deployment" "{{$.PrimaryResourceId}}" {
     location     = "us"
     display_name = "{{index $.ResourceIdVars "deployment_display_name"}}"
     app          = google_ces_app.my-app.name
-    app_version  = "projects/example-project/locations/us/apps/example-app/versions/example-version"
+    app_version  = google_ces_app_version.my-app-version.id
     channel_profile {
         channel_type = "API"
         disable_barge_in_control = true

--- a/mmv1/templates/terraform/samples/services/ces/ces_deployment_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_deployment_full.tf.tmpl
@@ -6,11 +6,18 @@ resource "google_ces_app" "my-app" {
         time_zone = "America/Los_Angeles"
     }
 }
+resource "google_ces_app_version" "my-app-version" {
+    location       = "us"
+    display_name   = "{{index $.ResourceIdVars "app_version_display_name"}}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "{{index $.ResourceIdVars "app_version_id"}}"
+    description    = "example-app-version"
+}
 resource "google_ces_deployment" "{{$.PrimaryResourceId}}" {
     location     = "us"
     display_name = "{{index $.ResourceIdVars "deployment_display_name"}}"
     app          = google_ces_app.my-app.name
-    app_version  = "projects/example-project/locations/us/apps/example-app/versions/example-version"
+    app_version  = google_ces_app_version.my-app-version.id
     channel_profile {
         channel_type = "API"
         disable_barge_in_control = true

--- a/mmv1/third_party/terraform/services/ces/ces_deployment_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_deployment_test.go
@@ -58,11 +58,18 @@ resource "google_ces_app" "my-app" {
         time_zone = "America/Los_Angeles"
     }
 }
+resource "google_ces_app_version" "my-app-version" {
+    location       = "us"
+    display_name   = "tf-test-my-app-version%{random_suffix}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "tf-test-app-version-id%{random_suffix}"
+    description    = "example-app-version"
+}
 resource "google_ces_deployment" "my-deployment" {
     location     = "us"
     display_name = "tf-test-my-deployment%{random_suffix}"
     app          = google_ces_app.my-app.name
-    app_version  = "projects/example-project/locations/us/apps/example-app/versions/example-version"
+    app_version  = google_ces_app_version.my-app-version.id
     channel_profile {
         channel_type = "API"
         disable_barge_in_control = true
@@ -97,11 +104,18 @@ resource "google_ces_app" "my-app" {
         time_zone = "America/Los_Angeles"
     }
 }
+resource "google_ces_app_version" "my-app-version" {
+    location       = "us"
+    display_name   = "tf-test-my-app-version%{random_suffix}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "tf-test-app-version-id%{random_suffix}"
+    description    = "example-app-version"
+}
 resource "google_ces_deployment" "my-deployment" {
     location     = "us"
     display_name = "tf-test-my-deployment%{random_suffix}"
     app          = google_ces_app.my-app.name
-    app_version  = "projects/example-project/locations/us/apps/example-app/versions/example-version"
+    app_version  = google_ces_app_version.my-app-version.id
     channel_profile {
         channel_type = "WEB_UI"
         disable_barge_in_control = true


### PR DESCRIPTION
Fixes hardcoded `app_version` dependency in `ces_deployment` acceptance test sample templates (`ces_deployment_basic.tf.tmpl`, `ces_deployment_full.tf.tmpl`) and handwritten test (`ces_deployment_test.go`).
Previously, the tests used a static string placeholder that did not belong to the dynamically created `google_ces_app.my-app` resource, causing HTTP 400 errors. This change adds a `google_ces_app_version` resource to the test configurations and sets `app_version` to `google_ces_app_version.my-app-version.id` so that the full resource name is correctly referenced.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28082
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28074
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28101

```release-note:none
```
