### PR TITLE
Fixed bug in nested exactly-one-of breaking change detection

### DIFF
--- a/tools/diff-processor/breaking_changes/resource_diff.go
+++ b/tools/diff-processor/breaking_changes/resource_diff.go
@@ -141,14 +141,18 @@ func isContainedInNewOptionalAncestor(field string, diff diff.ResourceDiff) bool
 	if len(parts) < 2 {
 		return false
 	}
-	ancestorName := strings.Join(parts[:len(parts)-1], ".")
-	ancestorDiff, ok := diff.Fields[ancestorName]
-	if !ok {
-		return false
+	for i := len(parts) - 1; i >= 1; i-- {
+		ancestorName := strings.Join(parts[:i], ".")
+		ancestorDiff, ok := diff.Fields[ancestorName]
+		if !ok {
+			continue
+		}
+
+		isAncestorNew := ancestorDiff.Old == nil && ancestorDiff.New != nil
+		isAncestorOptional := ancestorDiff.New != nil && ancestorDiff.New.Optional
+		if isAncestorNew && isAncestorOptional {
+			return true
+		}
 	}
-
-	isAncestorNew := ancestorDiff.Old == nil && ancestorDiff.New != nil
-	isAncestorOptional := ancestorDiff.New != nil && ancestorDiff.New.Optional
-
-	return isAncestorNew && isAncestorOptional
+	return false
 }

--- a/tools/diff-processor/breaking_changes/resource_diff_test.go
+++ b/tools/diff-processor/breaking_changes/resource_diff_test.go
@@ -368,6 +368,37 @@ var resourceSchemaRule_AddingExactlyOneOf_TestCases = []resourceSchemaTestCase{
 		},
 	},
 	{
+		name: "adding ExactlyOneOf to new fields within a new required block nested inside a newly-added, optional ancestor",
+		resourceDiff: diff.ResourceDiff{
+			FieldSets: diff.ResourceFieldSetsDiff{
+				Old: diff.ResourceFieldSets{},
+				New: diff.ResourceFieldSets{
+					ExactlyOneOf: map[string]diff.FieldSet{
+						"parent.child.field-a,parent.child.field-b": {"parent.child.field-a": {}, "parent.child.field-b": {}},
+					},
+				},
+			},
+			Fields: map[string]diff.FieldDiff{
+				"parent": {
+					Old: nil,
+					New: &schema.Schema{Description: "parent", Optional: true, Type: schema.TypeList},
+				},
+				"parent.child": {
+					Old: nil,
+					New: &schema.Schema{Description: "child", Required: true, Type: schema.TypeList},
+				},
+				"parent.child.field-a": {
+					Old: nil,
+					New: &schema.Schema{Description: "beep", Optional: true},
+				},
+				"parent.child.field-b": {
+					Old: nil,
+					New: &schema.Schema{Description: "boop", Optional: true},
+				},
+			},
+		},
+	},
+	{
 		name: "adding ExactlyOneOf to existing fields that are all within an existing, optional ancestor",
 		resourceDiff: diff.ResourceDiff{
 			FieldSets: diff.ResourceFieldSetsDiff{


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

Ran into this on https://github.com/GoogleCloudPlatform/magic-modules/pull/18473. When a new exactlyoneof constraint is deeply nested - the immediate parent is required, but has a new parent that's optional - it was incorrectly detected as a breaking change.

```release-note:none

```
