### PR TITLE
discoveryengine: suppress diffs for server-provided feature flags in google_discovery_engine_search_engine

### DIFF
--- a/mmv1/products/discoveryengine/SearchEngine.yaml
+++ b/mmv1/products/discoveryengine/SearchEngine.yaml
@@ -53,6 +53,7 @@ async:
     resource_inside_response: true
 autogen_async: false
 custom_code:
+  constants: 'templates/terraform/constants/discoveryengine_search_engine.go.tmpl'
   encoder: templates/terraform/encoders/discovery_engine_search_engine_hardcode_solution_type.go.tmpl
 samples:
   - name: discoveryengine_searchengine_basic
@@ -204,6 +205,7 @@ properties:
   - name: features
     type: KeyValuePairs
     default_from_api: true
+    diff_suppress_func: 'DiscoveryEngineSearchEngineFeaturesDiffSuppress'
     description: |
       A map of the feature config for the engine to opt in or opt out of features.
   - name: kmsKeyName

--- a/mmv1/templates/terraform/constants/discoveryengine_search_engine.go.tmpl
+++ b/mmv1/templates/terraform/constants/discoveryengine_search_engine.go.tmpl
@@ -1,0 +1,20 @@
+var discoveryEngineSearchEngineGoogleProvidedFeatures = []string{
+	"enable-end-user-sharing-with-groups",
+}
+
+func DiscoveryEngineSearchEngineFeaturesDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// Suppress diffs for the features provided by API when not set in config
+	for _, feature := range discoveryEngineSearchEngineGoogleProvidedFeatures {
+		if strings.Contains(k, feature) && new == "" {
+			return true
+		}
+	}
+
+	// Let diff be determined by features (above)
+	if strings.Contains(k, "features.%") {
+		return true
+	}
+
+	// For other keys, don't suppress diff.
+	return false
+}

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_search_engine_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_search_engine_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/discoveryengine"
+	"github.com/hashicorp/terraform-provider-google/google/services/discoveryengine"
 )
 
 func TestAccDiscoveryEngineSearchEngine_discoveryengineSearchengineBasicExample_update(t *testing.T) {
@@ -147,4 +147,42 @@ resource "google_discovery_engine_search_engine" "basic" {
   }
 }
 `, context)
+}
+
+func TestDiscoveryEngineSearchEngineFeaturesDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Key, Old, New      string
+		ExpectDiffSuppress bool
+	}{
+		"suppress server-provided feature when unset in config": {
+			Key:                "features.enable-end-user-sharing-with-groups",
+			Old:                "FEATURE_STATE_OFF",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"suppress features map length diff": {
+			Key:                "features.%",
+			Old:                "3",
+			New:                "2",
+			ExpectDiffSuppress: true,
+		},
+		"do not suppress when server-provided feature is set in config": {
+			Key:                "features.enable-end-user-sharing-with-groups",
+			Old:                "FEATURE_STATE_OFF",
+			New:                "FEATURE_STATE_ON",
+			ExpectDiffSuppress: false,
+		},
+		"do not suppress user feature diff": {
+			Key:                "features.agent-sharing-without-admin-approval",
+			Old:                "FEATURE_STATE_ON",
+			New:                "FEATURE_STATE_OFF",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if discoveryengine.DiscoveryEngineSearchEngineFeaturesDiffSuppress(tc.Key, tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Errorf("bad: %s, %q => %q expect DiffSuppress to return %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27402

This PR fixes non-empty plan permadiffs on the `features` map attribute in `google_discovery_engine_search_engine`. The backend automatically populates default feature flags in `features` (such as `"enable-end-user-sharing-with-groups"`). Because SDKv2 diffs map attributes key-by-key against configuration, any API-returned keys not specified in user HCL were planned for removal (`-> null`).

We introduce `DiscoveryEngineSearchEngineFeaturesDiffSuppress` to suppress diffs for server-provided feature keys when unset in user configuration, eliminating the permadiff while preserving diff detection for user-configured features.

```release-note:bug
discoveryengine: fixed permadiffs on `features` in `google_discovery_engine_search_engine` caused by server-provided feature flags
```
