### PR TITLE
discoveryengine: fix permadiff on features in google_discovery_engine_search_engine

### DIFF
--- a/mmv1/products/discoveryengine/SearchEngine.yaml
+++ b/mmv1/products/discoveryengine/SearchEngine.yaml
@@ -53,6 +53,7 @@ async:
     resource_inside_response: true
 autogen_async: false
 custom_code:
+  constants: templates/terraform/constants/discovery_engine_search_engine.go.tmpl
   encoder: templates/terraform/encoders/discovery_engine_search_engine_hardcode_solution_type.go.tmpl
 samples:
   - name: discoveryengine_searchengine_basic
@@ -204,6 +205,7 @@ properties:
   - name: features
     type: KeyValuePairs
     default_from_api: true
+    diff_suppress_func: 'DiscoveryEngineSearchEngineFeaturesDiffSuppress'
     description: |
       A map of the feature config for the engine to opt in or opt out of features.
   - name: kmsKeyName

--- a/mmv1/templates/terraform/constants/discovery_engine_search_engine.go.tmpl
+++ b/mmv1/templates/terraform/constants/discovery_engine_search_engine.go.tmpl
@@ -1,0 +1,30 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+
+var DiscoveryEngineSearchEngineServerProvidedFeatures = []string{
+	"enable-end-user-sharing-with-groups",
+}
+
+func DiscoveryEngineSearchEngineFeaturesDiffSuppress(k, old, new string, _ *schema.ResourceData) bool {
+	for _, feature := range DiscoveryEngineSearchEngineServerProvidedFeatures {
+		if strings.Contains(k, feature) && new == "" {
+			return true
+		}
+	}
+
+	if strings.Contains(k, "features.%") {
+		return true
+	}
+
+	return false
+}

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_search_engine_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_search_engine_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/discoveryengine"
+	"github.com/hashicorp/terraform-provider-google/google/services/discoveryengine"
 )
 
 func TestAccDiscoveryEngineSearchEngine_discoveryengineSearchengineBasicExample_update(t *testing.T) {
@@ -147,4 +147,48 @@ resource "google_discovery_engine_search_engine" "basic" {
   }
 }
 `, context)
+}
+
+func TestDiscoveryEngineSearchEngineFeaturesDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Key, Old, New      string
+		ExpectDiffSuppress bool
+	}{
+		"server provided feature in state when config is empty": {
+			Key:                "features.enable-end-user-sharing-with-groups",
+			Old:                "FEATURE_STATE_OFF",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"server provided feature in config": {
+			Key:                "features.enable-end-user-sharing-with-groups",
+			Old:                "FEATURE_STATE_OFF",
+			New:                "FEATURE_STATE_ON",
+			ExpectDiffSuppress: false,
+		},
+		"other feature in state when config is empty": {
+			Key:                "features.agent-sharing-without-admin-approval",
+			Old:                "FEATURE_STATE_OFF",
+			New:                "",
+			ExpectDiffSuppress: false,
+		},
+		"features map item count delta": {
+			Key:                "features.%",
+			Old:                "3",
+			New:                "2",
+			ExpectDiffSuppress: true,
+		},
+		"other map item count delta": {
+			Key:                "other_map.%",
+			Old:                "3",
+			New:                "2",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if discoveryengine.DiscoveryEngineSearchEngineFeaturesDiffSuppress(tc.Key, tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Errorf("bad: %s, key=%q %q => %q expect DiffSuppress to return %t", tn, tc.Key, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27402

Adds a custom `diff_suppress_func` (`DiscoveryEngineSearchEngineFeaturesDiffSuppress`) to `google_discovery_engine_search_engine` to suppress diffs on server-injected feature flags in the `features` map (e.g., `"enable-end-user-sharing-with-groups" = "FEATURE_STATE_OFF"`) when unset in user configuration, as well as map item count deltas (`features.%`). Explicit user modifications continue to be detected.

```release-note:bug
discoveryengine: fixed permadiff on `features` in `google_discovery_engine_search_engine`
```
