### PR TITLE
compute: add Computed: true to layer_7_ddos_defense_config.enable to suppress permadiff

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -560,6 +560,7 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 									"enable": {
 										Type: schema.TypeBool,
 										Optional: true,
+										Computed: true,
 										Description: `If set to true, enables CAAP for L7 DDoS detection.`,
 									},
 									"rule_visibility": {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/12743

Adds `Computed: true` to the `enable` field inside `adaptive_protection_config.layer_7_ddos_defense_config` in `google_compute_security_policy`.

The field was missing `Computed: true`, causing a perpetual diff when the API returns `enable: false` for a policy created without explicitly setting this field. Terraform treated the absence of the field (null) as different from `false`, producing a permadiff on every plan.

Setting `Computed: true` tells Terraform to accept the API-returned value as the source of truth when the field is not set in config, eliminating the permadiff.

```release-note:bug
compute: fixed permadiff on `adaptive_protection_config.layer_7_ddos_defense_config.enable` in `google_compute_security_policy` when field is not set in config
```