### PR TITLE
cloudbuild: Add list resources for Trigger and BitbucketServerConfig

### DIFF
--- a/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
+++ b/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
@@ -32,6 +32,7 @@ async:
   result:
     resource_inside_response: true
 autogen_async: true
+generate_list_resource: true
 include_in_tgc_next: true
 custom_code:
   encoder: templates/terraform/encoders/cloudbuild_bitbucketserver_config.go.tmpl

--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -34,6 +34,7 @@ update_verb: 'PATCH'
 import_format:
   - 'projects/{{project}}/triggers/{{trigger_id}}'
   - 'projects/{{project}}/locations/{{location}}/triggers/{{trigger_id}}'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20


### PR DESCRIPTION
Add list resources for CloudBuild Trigger and BitbucketServerConfig resources.

This enables users to query and list existing CloudBuild Triggers and BitbucketServerConfig resources using the data sources.

```release-note:enhancement
cloudbuild: Add list resource support for google_cloudbuild_trigger and google_cloudbuild_bitbucket_server_config
```
