### PR TITLE
fix: add default_from_api to cloudrunv2 service template scaling maxInstanceCount

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -403,9 +403,20 @@ properties:
         default_from_api: true
       - name: 'maxInstanceCount'
         type: Integer
-        description: |
-          Combined maximum number of instances for all revisions receiving traffic.
+        description: |-
+          Maximum number of serving instances that this resource should have. Must not be less than minimum instance count. If absent, Cloud Run will calculate
+          a default value based on the project's available container instances quota in the region and specified instance size.
         default_from_api: true
+      - name: 'cpuUtilization'
+        type: Double
+        min_version: 'beta'
+        description: |-
+          Determines a threshold for CPU utilization before scaling begins. Accepted values are between 0.1 and 0.95 (inclusive) or 0.0 to disable CPU utilization as threshold for scaling. CPU and concurrency scaling cannot both be disabled.
+      - name: 'concurrencyUtilization'
+        type: Double
+        min_version: 'beta'
+        description: |-
+          Determines a threshold for concurrency utilization before scaling begins. Accepted values are between 0.1 and 0.95 (inclusive) or 0.0 to disable concurrency utilization as threshold for scaling. CPU and concurrency scaling cannot both be disabled.
       - name: 'scalingMode'
         type: Enum
         description: |
@@ -464,6 +475,17 @@ properties:
             description: |-
               Maximum number of serving instances that this resource should have. Must not be less than minimum instance count. If absent, Cloud Run will calculate
               a default value based on the project's available container instances quota in the region and specified instance size.
+            default_from_api: true
+          - name: 'cpuUtilization'
+            type: Double
+            min_version: 'beta'
+            description: |-
+              Determines a threshold for CPU utilization before scaling begins. Accepted values are between 0.1 and 0.95 (inclusive) or 0.0 to disable CPU utilization as threshold for scaling. CPU and concurrency scaling cannot both be disabled.
+          - name: 'concurrencyUtilization'
+            type: Double
+            min_version: 'beta'
+            description: |-
+              Determines a threshold for concurrency utilization before scaling begins. Accepted values are between 0.1 and 0.95 (inclusive) or 0.0 to disable concurrency utilization as threshold for scaling. CPU and concurrency scaling cannot both be disabled.
       - name: 'vpcAccess'
         type: NestedObject
         description: |-


### PR DESCRIPTION
Adds `default_from_api: true` to `max_instance_count` inside
`template.scaling` in `google_cloud_run_v2_service`.

The field was missing `default_from_api: true`, causing a perpetual diff
when the API returns a calculated default for `max_instance_count` based
on the project's available container instance quota. Terraform treated the
absence of the field (null) as different from the API-returned value,
producing a permadiff on every plan.

Setting `default_from_api: true` tells Terraform to accept the API-returned
value as the source of truth when the field is not set in config, eliminating
the permadiff.

Note: the service-level `scaling.max_instance_count` already had
`default_from_api: true` set correctly; this fix applies the same to the
revision-level `template.scaling.max_instance_count`.

```release-note:bug
cloudrunv2: fixed permadiff on `template.scaling.max_instance_count` in `google_cloud_run_v2_service` when field is not set in config
```