### PR TITLE
datasource: migrate google_compute_networks compute call from Apiary …

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_networks.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_networks.go
@@ -46,15 +46,28 @@ func dataSourceGoogleComputeNetworksRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	networkList, err := NewClient(config, userAgent).Networks.List(project).Do()
+	url := fmt.Sprintf("%sprojects/%s/global/networks", transport_tpg.BaseUrl(Product, config), project)
+	networkList, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Network Not Found : %s", project))
 	}
 
-	var networks = make([]string, len(networkList.Items))
-
-	for i := 0; i < len(networkList.Items); i++ {
-		networks[i] = networkList.Items[i].Name
+	var networks []string
+	if rawItems, ok := networkList["items"].([]interface{}); ok {
+		networks = make([]string, len(rawItems))
+		for i, raw := range rawItems {
+			network, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			networks[i], _ = network["name"].(string)
+		}
 	}
 
 	if err := d.Set("networks", networks); err != nil {
@@ -65,7 +78,8 @@ func dataSourceGoogleComputeNetworksRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting the network names: %s", err)
 	}
 
-	if err := d.Set("self_link", networkList.SelfLink); err != nil {
+	selfLink, _ := networkList["selfLink"].(string)
+	if err := d.Set("self_link", selfLink); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
 


### PR DESCRIPTION
…to REST

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
datasource: migrated google_compute_networks data source to use direct HTTP rather than a client library
```
