### PR TITLE
fix(monitoring): suppress dashboard JSON normalization drift

### DIFF
--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"time"
 
@@ -15,35 +16,102 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-// This recursive function takes an old map and a new map and is intended to remove the computed keys
-// from the old json string (stored in state) so that it doesn't show a diff if it's not defined in the
-// new map's json string (defined in config)
-func removeComputedKeys(old map[string]interface{}, new map[string]interface{}) map[string]interface{} {
-	for k, v := range old {
-		if _, ok := old[k]; ok && new[k] == nil {
-			delete(old, k)
-			continue
-		}
-
-		if reflect.ValueOf(v).Kind() == reflect.Map {
-			old[k] = removeComputedKeys(v.(map[string]interface{}), new[k].(map[string]interface{}))
-			continue
-		}
-
-		if reflect.ValueOf(v).Kind() == reflect.Slice {
-			for i, j := range v.([]interface{}) {
-				if reflect.ValueOf(j).Kind() == reflect.Map && len(new[k].([]interface{})) > i {
-					old[k].([]interface{})[i] = removeComputedKeys(j.(map[string]interface{}), new[k].([]interface{})[i].(map[string]interface{}))
-				}
-			}
-			continue
-		}
-	}
-
-	return old
+func stripMonitoringDashboardComputedFields(m map[string]interface{}) map[string]interface{} {
+	result := maps.Clone(m)
+	delete(result, "etag")
+	delete(result, "name")
+	return result
 }
 
-func monitoringDashboardDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+func removeKeysAbsentFromConfig(state, config map[string]interface{}) map[string]interface{} {
+	if state == nil {
+		return nil
+	}
+	if config == nil {
+		config = map[string]interface{}{}
+	}
+
+	result := make(map[string]interface{}, len(state))
+	for k, stateValue := range state {
+		configValue, exists := config[k]
+		if !exists {
+			continue
+		}
+
+		switch stateValue := stateValue.(type) {
+		case map[string]interface{}:
+			if configValue, ok := configValue.(map[string]interface{}); ok {
+				result[k] = removeKeysAbsentFromConfig(stateValue, configValue)
+			} else {
+				result[k] = stateValue
+			}
+		case []interface{}:
+			if configValue, ok := configValue.([]interface{}); ok {
+				result[k] = removeKeysAbsentFromConfigSlice(stateValue, configValue)
+			} else {
+				result[k] = stateValue
+			}
+		default:
+			result[k] = stateValue
+		}
+	}
+	return result
+}
+
+func removeKeysAbsentFromConfigSlice(state, config []interface{}) []interface{} {
+	result := make([]interface{}, len(state))
+	for i, stateValue := range state {
+		if i >= len(config) {
+			result[i] = stateValue
+			continue
+		}
+		stateMap, stateIsMap := stateValue.(map[string]interface{})
+		configMap, configIsMap := config[i].(map[string]interface{})
+		if stateIsMap && configIsMap {
+			result[i] = removeKeysAbsentFromConfig(stateMap, configMap)
+		} else {
+			result[i] = stateValue
+		}
+	}
+	return result
+}
+
+// The API omits zero-valued tile positions, while Terraform's jsonencode preserves them.
+func stripMonitoringDashboardZeroTilePositions(dashboard map[string]interface{}) map[string]interface{} {
+	result := maps.Clone(dashboard)
+	mosaicLayout, ok := result["mosaicLayout"].(map[string]interface{})
+	if !ok {
+		return result
+	}
+	tiles, ok := mosaicLayout["tiles"].([]interface{})
+	if !ok {
+		return result
+	}
+
+	normalizedTiles := make([]interface{}, len(tiles))
+	copy(normalizedTiles, tiles)
+	for i, tile := range tiles {
+		tile, ok := tile.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		tile = maps.Clone(tile)
+		if xPos, ok := tile["xPos"].(float64); ok && xPos == 0 {
+			delete(tile, "xPos")
+		}
+		if yPos, ok := tile["yPos"].(float64); ok && yPos == 0 {
+			delete(tile, "yPos")
+		}
+		normalizedTiles[i] = tile
+	}
+
+	mosaicLayout = maps.Clone(mosaicLayout)
+	mosaicLayout["tiles"] = normalizedTiles
+	result["mosaicLayout"] = mosaicLayout
+	return result
+}
+
+func monitoringDashboardDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	oldMap, err := structure.ExpandJsonFromString(old)
 	if err != nil {
 		return false
@@ -53,7 +121,12 @@ func monitoringDashboardDiffSuppress(k, old, new string, d *schema.ResourceData)
 		return false
 	}
 
-	oldMap = removeComputedKeys(oldMap, newMap)
+	oldMap = stripMonitoringDashboardComputedFields(oldMap)
+	newMap = stripMonitoringDashboardComputedFields(newMap)
+	oldMap = removeKeysAbsentFromConfig(oldMap, newMap)
+	oldMap = stripMonitoringDashboardZeroTilePositions(oldMap)
+	newMap = stripMonitoringDashboardZeroTilePositions(newMap)
+
 	return reflect.DeepEqual(oldMap, newMap)
 }
 

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard_internal_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard_internal_test.go
@@ -1,0 +1,178 @@
+package monitoring
+
+import "testing"
+
+func TestMonitoringDashboardDiffSuppress(t *testing.T) {
+	tests := []struct {
+		name string
+		old  string
+		new  string
+		want bool
+	}{
+		{
+			name: "identical dashboard",
+			old:  `{"displayName":"Dashboard","gridLayout":{"widgets":[{"blank":{}}]}}`,
+			new:  `{"displayName":"Dashboard","gridLayout":{"widgets":[{"blank":{}}]}}`,
+			want: true,
+		},
+		{
+			name: "API fields and defaults",
+			old: `{
+				"name": "projects/my-project/dashboards/abc",
+				"etag": "1234",
+				"displayName": "Dashboard",
+				"mosaicLayout": {
+					"tiles": [
+						{"height": 4, "width": 4},
+						{"widget": {"xyChart": {
+							"dataSets": [{"targetAxis": "Y1"}],
+							"yAxis": {"scale": "LINEAR"}
+						}}},
+						{"widget": {"timeSeriesTable": {"metricVisualization": "NUMBER"}}}
+					]
+				}
+			}`,
+			new: `{
+				"displayName": "Dashboard",
+				"mosaicLayout": {
+					"tiles": [
+						{"height": 4, "width": 4, "xPos": 0, "yPos": 0},
+						{"widget": {"xyChart": {"dataSets": [{}], "yAxis": {}}}},
+						{"widget": {"timeSeriesTable": {}}}
+					]
+				}
+			}`,
+			want: true,
+		},
+		{
+			name: "exported computed fields",
+			old:  `{"name":"projects/my-project/dashboards/abc","etag":"old","displayName":"Dashboard"}`,
+			new:  `{"name":"projects/my-project/dashboards/abc","etag":"new","displayName":"Dashboard"}`,
+			want: true,
+		},
+		{
+			name: "scalar array preserved",
+			old:  `{"mosaicLayout":{"tiles":[{"widget":{"xyChart":{"dataSets":[{"timeSeriesQuery":{"timeSeriesFilter":{"aggregation":{"groupByFields":["metric.label.status"]}}}}]}}}]}}`,
+			new:  `{"mosaicLayout":{"tiles":[{"widget":{"xyChart":{"dataSets":[{"timeSeriesQuery":{"timeSeriesFilter":{"aggregation":{"groupByFields":["metric.label.status"]}}}}]}}}]}}`,
+			want: true,
+		},
+		{
+			name: "display name changed",
+			old:  `{"name":"projects/my-project/dashboards/abc","etag":"1234","displayName":"Old"}`,
+			new:  `{"displayName":"New"}`,
+			want: false,
+		},
+		{
+			name: "unsupported config field added",
+			old:  `{"displayName":"Dashboard"}`,
+			new:  `{"displayName":"Dashboard","description":"Not supported by the API"}`,
+			want: false,
+		},
+		{
+			name: "nonzero tile position added",
+			old:  `{"mosaicLayout":{"tiles":[{"width":4,"height":4}]}}`,
+			new:  `{"mosaicLayout":{"tiles":[{"width":4,"height":4,"xPos":1}]}}`,
+			want: false,
+		},
+		{
+			name: "nonzero tile position changed to zero",
+			old:  `{"mosaicLayout":{"tiles":[{"width":4,"height":4,"xPos":4}]}}`,
+			new:  `{"mosaicLayout":{"tiles":[{"width":4,"height":4,"xPos":0}]}}`,
+			want: false,
+		},
+		{
+			name: "widget removed",
+			old:  `{"gridLayout":{"widgets":[{"blank":{}},{"text":{"content":"remove","format":"MARKDOWN"}}]}}`,
+			new:  `{"gridLayout":{"widgets":[{"blank":{}}]}}`,
+			want: false,
+		},
+		{
+			name: "widget added",
+			old:  `{"gridLayout":{"widgets":[{"blank":{}}]}}`,
+			new:  `{"gridLayout":{"widgets":[{"blank":{}},{"text":{"content":"add","format":"MARKDOWN"}}]}}`,
+			want: false,
+		},
+		{
+			name: "nested type changed",
+			old:  `{"gridLayout":{"widgets":[{"blank":{"nested":{"value":1}}}]}}`,
+			new:  `{"gridLayout":{"widgets":[{"blank":{"nested":"value"}}]}}`,
+			want: false,
+		},
+		{
+			name: "invalid state JSON",
+			old:  `{not-json`,
+			new:  `{"displayName":"Dashboard"}`,
+			want: false,
+		},
+		{
+			name: "invalid config JSON",
+			old:  `{"displayName":"Dashboard"}`,
+			new:  `{not-json`,
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := monitoringDashboardDiffSuppress("dashboard_json", test.old, test.new, nil)
+			if got != test.want {
+				t.Errorf("monitoringDashboardDiffSuppress() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRemoveKeysAbsentFromConfigDoesNotMutateState(t *testing.T) {
+	state := map[string]interface{}{
+		"mosaicLayout": map[string]interface{}{
+			"tiles": []interface{}{
+				map[string]interface{}{
+					"widget": map[string]interface{}{
+						"xyChart": map[string]interface{}{
+							"dataSets": []interface{}{
+								map[string]interface{}{"targetAxis": "Y1"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	config := map[string]interface{}{
+		"mosaicLayout": map[string]interface{}{
+			"tiles": []interface{}{
+				map[string]interface{}{
+					"widget": map[string]interface{}{
+						"xyChart": map[string]interface{}{
+							"dataSets": []interface{}{map[string]interface{}{}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	removeKeysAbsentFromConfig(state, config)
+
+	tiles := state["mosaicLayout"].(map[string]interface{})["tiles"].([]interface{})
+	widget := tiles[0].(map[string]interface{})["widget"].(map[string]interface{})
+	dataSets := widget["xyChart"].(map[string]interface{})["dataSets"].([]interface{})
+	if _, ok := dataSets[0].(map[string]interface{})["targetAxis"]; !ok {
+		t.Fatal("removeKeysAbsentFromConfig() mutated state")
+	}
+}
+
+func TestStripMonitoringDashboardZeroTilePositionsDoesNotMutateInput(t *testing.T) {
+	dashboard := map[string]interface{}{
+		"mosaicLayout": map[string]interface{}{
+			"tiles": []interface{}{map[string]interface{}{"xPos": float64(0)}},
+		},
+	}
+
+	stripMonitoringDashboardZeroTilePositions(dashboard)
+
+	tiles := dashboard["mosaicLayout"].(map[string]interface{})["tiles"].([]interface{})
+	if _, ok := tiles[0].(map[string]interface{})["xPos"]; !ok {
+		t.Fatal("stripMonitoringDashboardZeroTilePositions() mutated input")
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/24650

## Description

The Monitoring API normalizes dashboard JSON by adding API-managed fields and defaults while omitting zero-valued mosaic tile positions. This updates the diff suppressor to compare those equivalent representations safely without hiding explicit dashboard changes.

Regression tests cover API-managed fields, nested defaults, scalar arrays, zero-valued tile positions, invalid JSON, and changes that must continue to produce a diff.

## Test plan

- Generated the GA provider
- Ran the Monitoring dashboard unit tests
- Ran `gofmt`, `go vet`, and the provider build
- Verified a captured two-dashboard plan produces no changes

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
monitoring: fixed perma-diffs in `google_monitoring_dashboard` caused by API JSON normalization
```
