### PR TITLE
Pr 18277 Fork 

### DIFF
--- a/mmv1/products/appengine/StandardAppVersion.yaml
+++ b/mmv1/products/appengine/StandardAppVersion.yaml
@@ -374,6 +374,7 @@ properties:
       - manual_scaling
     # This flattener is entirely handwritten and must be updated with **any** new field or subfield
     custom_flatten: templates/terraform/custom_flatten/appengine_standardappversion_automatic_scaling_handlenil.go.tmpl
+    default_from_api: true
     properties:
       - name: maxConcurrentRequests
         type: Integer

--- a/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version.tf.tmpl
@@ -72,8 +72,18 @@ resource "google_app_engine_standard_app_version" "myapp_v2" {
     port = "8080"
   }
 
-  basic_scaling {
-    max_instances = 5
+automatic_scaling {
+    max_concurrent_requests = 10
+    min_idle_instances = 1
+    max_idle_instances = 3
+    min_pending_latency = "1s"
+    max_pending_latency = "5s"
+    standard_scheduler_settings {
+      target_cpu_utilization = 0.5
+      target_throughput_utilization = 0.75
+      min_instances = 2
+      max_instances = 10
+    }
   }
 
   noop_on_destroy = true

--- a/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version.tf.tmpl
@@ -72,18 +72,8 @@ resource "google_app_engine_standard_app_version" "myapp_v2" {
     port = "8080"
   }
 
-automatic_scaling {
-    max_concurrent_requests = 10
-    min_idle_instances = 1
-    max_idle_instances = 3
-    min_pending_latency = "1s"
-    max_pending_latency = "5s"
-    standard_scheduler_settings {
-      target_cpu_utilization = 0.5
-      target_throughput_utilization = 0.75
-      min_instances = 2
-      max_instances = 10
-    }
+  basic_scaling {
+    max_instances = 5
   }
 
   noop_on_destroy = true

--- a/mmv1/templates/terraform/samples/services/iap/iap_app_engine_service.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/iap/iap_app_engine_service.tf.tmpl
@@ -40,10 +40,6 @@ resource "google_app_engine_standard_app_version" "version" {
   runtime         = "nodejs22"
   noop_on_destroy = true
 
-  // TODO: Removed basic scaling once automatic_scaling refresh behavior is fixed.
-  basic_scaling { 
-    max_instances = 5 
-  }
   entrypoint {
     shell = "node ./app.js"
   }


### PR DESCRIPTION
Replaced basic scaling with explicit automatic scaling in App Engine sample to fix diff issue.
 
Per b/325645138, this rolls back https://github.com/GoogleCloudPlatform/magic-modules/pull/10000, which was intended to be a temporary fix.
  
```release-note:bug
appengine: fixed permadiff in `google_app_engine_standard_app_version` 
```  