### PR TITLE
feat(compute): add `no_graceful_shutdown_on_destroy` to instance group managers

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.tmpl
@@ -635,9 +635,16 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 					},
 				},
 			},
-//UDP schema start
-            "deletion_policy": tpgresource.DeletionPolicySchemaEntry("DELETE"),
-//UDP schema end
+
+			"no_graceful_shutdown_on_destroy": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `When set to true, graceful shutdown is skipped for instance deletion even if it's configured for the instances. Otherwise, if graceful shutdown is configured, the MIG deletion waits for all instances to shut down gracefully before deletion.`,
+			},
+
+			//UDP schema start
+			"deletion_policy": tpgresource.DeletionPolicySchemaEntry("DELETE"),
+			//UDP schema end
 		},
 		UseJSONNumber: true,
 	}
@@ -1363,6 +1370,13 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instanceGroupManagers/{{"{{"}}name{{"}}"}}")
 	if err != nil {
 		return err
+	}
+
+	if v, ok := d.GetOk("no_graceful_shutdown_on_destroy"); ok && v.(bool) {
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"noGracefulShutdown": "true"})
+		if err != nil {
+			return err
+		}
 	}
 
 	op, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_meta.yaml.tmpl
@@ -93,6 +93,8 @@ fields:
     provider_only: true
   - field: 'wait_for_instances_status'
     provider_only: true
+  - field: 'no_graceful_shutdown_on_destroy'
+    provider_only: true
   - api_field: 'zone'
   - field: 'deletion_policy'
     provider_only: true

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
@@ -86,13 +86,13 @@ func TestAccInstanceGroupManager_basic(t *testing.T) {
 				ResourceName:            "google_compute_instance_group_manager.igm-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"status"},
+				ImportStateVerifyIgnore: []string{"status", "no_graceful_shutdown_on_destroy"},
 			},
 			{
 				ResourceName:            "google_compute_instance_group_manager.igm-no-tp",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"status"},
+				ImportStateVerifyIgnore: []string{"status", "no_graceful_shutdown_on_destroy"},
 			},
 		},
 	})
@@ -692,6 +692,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
   base_instance_name             = "tf-test-igm-basic"
   zone                           = "us-central1-c"
   target_size                    = 2
+  no_graceful_shutdown_on_destroy = true
   list_managed_instances_results = "PAGINATED"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
@@ -971,9 +971,16 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 				},
 			},
 			{{- end }}
+
+			"no_graceful_shutdown_on_destroy": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `When set to true, graceful shutdown is skipped for instance deletion even if it's configured for the instances. Otherwise, if graceful shutdown is configured, the MIG deletion waits for all instances to shut down gracefully before deletion.`,
+			},
+
 			//UDP schema start
-            "deletion_policy": tpgresource.DeletionPolicySchemaEntry("DELETE"),
-//UDP schema end
+			"deletion_policy": tpgresource.DeletionPolicySchemaEntry("DELETE"),
+			//UDP schema end
 		},
 		UseJSONNumber: true,
 	}
@@ -1558,6 +1565,13 @@ func resourceComputeRegionInstanceGroupManagerDelete(d *schema.ResourceData, met
 	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/regions/{{"{{"}}region{{"}}"}}/instanceGroupManagers/{{"{{"}}name{{"}}"}}")
 	if err != nil {
 		return err
+	}
+
+	if v, ok := d.GetOk("no_graceful_shutdown_on_destroy"); ok && v.(bool) {
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"noGracefulShutdown": "true"})
+		if err != nil {
+			return err
+		}
 	}
 
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_meta.yaml.tmpl
@@ -177,5 +177,7 @@ fields:
     provider_only: true
   - field: 'wait_for_instances_status'
     provider_only: true
+  - field: 'no_graceful_shutdown_on_destroy'
+    provider_only: true
   - field: 'deletion_policy'
     provider_only: true

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
@@ -39,13 +39,13 @@ func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 				ResourceName:            "google_compute_region_instance_group_manager.igm-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"status"},
+				ImportStateVerifyIgnore: []string{"status", "no_graceful_shutdown_on_destroy"},
 			},
 			{
 				ResourceName:            "google_compute_region_instance_group_manager.igm-no-tp",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"status"},
+				ImportStateVerifyIgnore: []string{"status", "no_graceful_shutdown_on_destroy"},
 			},
 		},
 	})
@@ -670,6 +670,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
   target_pools                   = [google_compute_target_pool.igm-basic.self_link]
   base_instance_name             = "tf-test-igm-basic"
   target_size                    = 2
+  no_graceful_shutdown_on_destroy = true
   list_managed_instances_results = "PAGINATED"
 }
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -228,6 +228,8 @@ The following arguments are supported:
     set, it will wait for the version target to be reached and any per instance configs to be effective as well as all
     instances to be stable before returning. The possible values are `STABLE` and `UPDATED`
 
+* `no_graceful_shutdown_on_destroy` - (Optional) When set to true, graceful shutdown is skipped for instance deletion even if it's configured for the instances. Otherwise, if graceful shutdown is configured, the MIG waits for all instances to shut down gracefully before deletion.
+
 ---
 
 * `auto_healing_policies` - (Optional) The autohealing policies for this managed instance
@@ -505,7 +507,7 @@ This resource provides the following
 
 - `create` - Default is 15 minutes.
 - `update` - Default is 15 minutes.
-- `delete` - Default is 15 minutes.
+- `delete` - Default is 15 minutes. It can take up to 6 more hours if graceful shutdown configured in the instance template.
 
 
 ## Import

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -180,6 +180,8 @@ The following arguments are supported:
     set, it will wait for the version target to be reached and any per instance configs to be effective as well as all
     instances to be stable before returning. The possible values are `STABLE` and `UPDATED`
 
+* `no_graceful_shutdown_on_destroy` - (Optional) When set to true, graceful shutdown is skipped for instance deletion even if it's configured for the instances. Otherwise, if graceful shutdown is configured, the MIG waits for all instances to shut down gracefully before deletion.
+
 ---
 
 * `auto_healing_policies` - (Optional) The autohealing policies for this managed instance
@@ -667,7 +669,7 @@ This resource provides the following
 
 - `create` - Default is 15 minutes.
 - `update` - Default is 15 minutes.
-- `delete` - Default is 15 minutes.
+- `delete` - Default is 15 minutes. It can take up to 6 more hours if graceful shutdown configured in the instance template.
 
 
 ## Import


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `no_graceful_shutdown_on_destroy` to `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager`
```
