### PR TITLE
Migrate `data_source_google_compute_interconnect_locations.go` data source to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_interconnect_locations.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_interconnect_locations.go
@@ -102,28 +102,62 @@ func dataSourceGoogleComputeInterconnectLocationsRead(d *schema.ResourceData, me
 		return err
 	}
 	d.SetId(fmt.Sprintf("projects/%s", project))
-	list, err := NewClient(config, userAgent).InterconnectLocations.List(project).Do()
-	if err != nil {
-		return fmt.Errorf("Error retrieving list of interconnect locations: %s", err)
-	}
+	baseURL := fmt.Sprintf("%sprojects/%s/global/interconnectLocations", transport_tpg.BaseUrl(Product, config), project)
+
 	var locations []map[string]interface{}
-	for _, location := range list.Items {
-		locations = append(locations, map[string]interface{}{
-			"name":                          location.Name,
-			"description":                   location.Description,
-			"self_link":                     location.SelfLink,
-			"peeringdb_facility_id":         location.PeeringdbFacilityId,
-			"address":                       location.Address,
-			"facility_provider":             location.FacilityProvider,
-			"facility_provider_facility_id": location.FacilityProviderFacilityId,
-			"status":                        location.Status,
-			"continent":                     location.Continent,
-			"city":                          location.City,
-			"availability_zone":             location.AvailabilityZone,
-			"supports_pzs":                  location.SupportsPzs,
-			"available_features":            location.AvailableFeatures,
-			"available_link_types":          location.AvailableLinkTypes,
+	pageToken := ""
+	for {
+		// The previous typed-client call sent no query parameters, so the first
+		// request stays parameter-free. pageToken is only added for later pages.
+		params := map[string]string{}
+		if pageToken != "" {
+			params["pageToken"] = pageToken
+		}
+		url, err := transport_tpg.AddQueryParams(baseURL, params)
+		if err != nil {
+			return err
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
 		})
+		if err != nil {
+			return fmt.Errorf("Error retrieving list of interconnect locations: %s", err)
+		}
+
+		if items, ok := res["items"].([]interface{}); ok {
+			for _, raw := range items {
+				location, ok := raw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				locations = append(locations, map[string]interface{}{
+					"name":                          location["name"],
+					"description":                   location["description"],
+					"self_link":                     location["selfLink"],
+					"peeringdb_facility_id":         location["peeringdbFacilityId"],
+					"address":                       location["address"],
+					"facility_provider":             location["facilityProvider"],
+					"facility_provider_facility_id": location["facilityProviderFacilityId"],
+					"status":                        location["status"],
+					"continent":                     location["continent"],
+					"city":                          location["city"],
+					"availability_zone":             location["availabilityZone"],
+					"supports_pzs":                  location["supportsPzs"],
+					"available_features":            location["availableFeatures"],
+					"available_link_types":          location["availableLinkTypes"],
+				})
+			}
+		}
+
+		pageToken, _ = res["nextPageToken"].(string)
+		if pageToken == "" {
+			break
+		}
 	}
 	if err := d.Set("locations", locations); err != nil {
 		return fmt.Errorf("Error setting locations: %s", err)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Part of the ongoing migration of handwritten compute files from the Apiary client library to direct HTTP calls (`transport_tpg.SendRequest`). Same pattern as #18444 and the merged data source migrations #17090 / #17117.

- Replaces `NewClient(...).InterconnectLocations.List(project).Do()` with `GET projects/{project}/global/interconnectLocations` via `transport_tpg.SendRequest`. Note the REST path uses camelCase `interconnectLocations`, the same path the typed client used.
- Adds `pageToken` pagination. The previous `.Do()` returned a single page (server default 500 items) and silently dropped the rest. There are currently far fewer than 500 interconnect locations, so this is defensive rather than a user-visible fix, and no release note claims a bug fix.
- The first request deliberately carries no query parameters, exactly like the typed client did, so the recorded VCR cassette still matches; `pageToken` is only added for follow-up pages.
- All fields consumed by the data source are read straight from the decoded JSON. Only `supportsPzs` (bool) and `availableFeatures` / `availableLinkTypes` (arrays of strings) are non-string; none of them need conversion.
- No schema, test, or documentation changes.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_interconnect_locations` data source to use direct HTTP rather than a client library
```
