### PR TITLE
Migrate `data_source_google_compute_network.go` data source to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go
@@ -123,38 +123,58 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 
 	id := fmt.Sprintf("projects/%s/global/networks/%s", project, name)
 
-	network, err := NewClient(config, userAgent).Networks.Get(project, name).Do()
+	url := fmt.Sprintf("%sprojects/%s/global/networks/%s", transport_tpg.BaseUrl(Product, config), project, name)
+	network, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Network Not Found : %s", name), id)
 	}
-	if err := d.Set("name", network.Name); err != nil {
+	if err := d.Set("name", network["name"]); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-	if err := d.Set("gateway_ipv4", network.GatewayIPv4); err != nil {
+	// Note the API casing: gatewayIPv4 but internalIpv6Range.
+	if err := d.Set("gateway_ipv4", network["gatewayIPv4"]); err != nil {
 		return fmt.Errorf("Error setting gateway_ipv4: %s", err)
 	}
-	if err := d.Set("internal_ipv6_range", network.InternalIpv6Range); err != nil {
+	if err := d.Set("internal_ipv6_range", network["internalIpv6Range"]); err != nil {
 		return fmt.Errorf("Error setting internal_ipv6_range: %s", err)
 	}
-	if err := d.Set("network_profile", network.NetworkProfile); err != nil {
+	if err := d.Set("network_profile", network["networkProfile"]); err != nil {
 		return fmt.Errorf("Error setting network_profile: %s", err)
 	}
-	if err := d.Set("self_link", network.SelfLink); err != nil {
+	if err := d.Set("self_link", network["selfLink"]); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
-	if err := d.Set("description", network.Description); err != nil {
+	if err := d.Set("description", network["description"]); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
-	if err := d.Set("network_id", network.Id); err != nil {
+	// REST API returns uint64 id as a JSON string to avoid float64 precision loss.
+	idStr, _ := network["id"].(string)
+	var networkId uint64
+	if idStr != "" {
+		networkId, err = strconv.ParseUint(idStr, 10, 64)
+		if err != nil {
+			return fmt.Errorf("Error parsing network_id %q: %s", idStr, err)
+		}
+	} else {
+		idStr = "0"
+	}
+	if err := d.Set("network_id", int64(networkId)); err != nil {
 		return fmt.Errorf("Error setting network_id: %s", err)
 	}
-	if err := d.Set("numeric_id", strconv.Itoa(int(network.Id))); err != nil {
+	// numeric_id keeps the raw API value, matching the google_compute_network resource.
+	if err := d.Set("numeric_id", idStr); err != nil {
 		return fmt.Errorf("Error setting numeric_id: %s", err)
 	}
-	if err := d.Set("subnetworks_self_links", network.Subnetworks); err != nil {
+	if err := d.Set("subnetworks_self_links", network["subnetworks"]); err != nil {
 		return fmt.Errorf("Error setting subnetworks_self_links: %s", err)
 	}
 	d.SetId(id)

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go
@@ -2,7 +2,6 @@ package compute
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -156,18 +155,16 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 	if err := d.Set("description", network["description"]); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
-	// REST API returns uint64 id as a JSON string to avoid float64 precision loss.
+	// The API returns the uint64 id as a JSON string.
 	idStr, _ := network["id"].(string)
-	var networkId uint64
-	if idStr != "" {
-		networkId, err = strconv.ParseUint(idStr, 10, 64)
-		if err != nil {
-			return fmt.Errorf("Error parsing network_id %q: %s", idStr, err)
-		}
-	} else {
+	if idStr == "" {
 		idStr = "0"
 	}
-	if err := d.Set("network_id", int64(networkId)); err != nil {
+	networkId, err := tpgresource.StringToFixed64(idStr)
+	if err != nil {
+		return fmt.Errorf("Error parsing network_id %q: %s", idStr, err)
+	}
+	if err := d.Set("network_id", networkId); err != nil {
 		return fmt.Errorf("Error setting network_id: %s", err)
 	}
 	// numeric_id keeps the raw API value, matching the google_compute_network resource.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Part of the ongoing migration of handwritten compute files from the Apiary client library to direct HTTP calls (`transport_tpg.SendRequest`). Same pattern as the merged data source migrations #17090 / #17117 and as #18511.

Replaces `NewClient(...).Networks.Get(project, name).Do()` with `GET projects/{project}/global/networks/{network}`. The `self_link` input parsing, the resource ID format and the order of the `d.Set` calls are unchanged, so the diff stays mechanical.

Notes for review:

- **`id` arrives as a JSON string.** The Compute API encodes the uint64 `id` as a string, so `network_id` (`schema.TypeInt`) is parsed with `tpgresource.StringToFixed64` - the shared helper MMv1 emits for `type: Integer` properties in this format (see the `Integer` branch of `flatten_property_method.go.tmpl`). This matches the already-migrated `data_source_google_compute_subnetwork.go`, and it lets the file drop its `strconv` import.
- **`numeric_id` now uses the raw API value.** It previously went through `strconv.Itoa(int(network.Id))`, which wraps for ids above `MaxInt64` and truncates on 32-bit builds. The raw string is exactly what the `google_compute_network` resource stores (`res["numericId"] = res["id"]` plus an identity flattener), so this makes the data source and the resource agree. For real network ids the value is unchanged. Both `network_id` and `numeric_id` are still always set, including when `id` is absent, so the state shape does not change.
- **API field casing differs between two neighbouring fields**: `gatewayIPv4` (capital `IPv4`) but `internalIpv6Range` (lowercase `pv6`). Both spellings were verified against the generated client and against the generated `resource_compute_network.go`, which reads the same keys.
- **`X-Goog-User-Project`**: with `user_project_override = true`, `SendRequest` attaches the header while the typed client did not. This matches every compute data source already migrated.
- The `self_link` input path has no acceptance coverage; that is unchanged by this PR.
- This data source is consumed by roughly 180 HCL blocks in other services' tests, which CI does not replay because VCR packages are selected by changed-file path. Those configs only ever read `id`, `self_link` and `name`, all of which come from unchanged code paths.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_network` data source to use direct HTTP rather than a client library
```
