### PR TITLE
datasource: migrate data_source_compute_network_endpoint_groups call …

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_groups.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_groups.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"fmt"
+	neturl "net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/registry"
@@ -65,30 +66,73 @@ func dataSourceComputeNetworkEndpointGroupsRead(d *schema.ResourceData, meta int
 
 	networkEndpointGroups := make([]map[string]interface{}, 0)
 
-	networkEndpointGroupsList, err := NewClient(config, userAgent).NetworkEndpointGroups.List(project, zone).Filter(filter).Do()
-	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("NetworkEndpointGroups : %s %s", project, zone))
-	}
+	baseURL := fmt.Sprintf("%sprojects/%s/zones/%s/networkEndpointGroups", transport_tpg.BaseUrl(Product, config), project, zone)
+	pageToken := ""
 
-	for _, neg := range networkEndpointGroupsList.Items {
-		network, err := tpgresource.GetRelativePath(neg.Network)
-		if err != nil {
-			return err
+	for {
+		params := neturl.Values{}
+		if filter != "" {
+			params.Set("filter", filter)
 		}
-		subnetwork, err := tpgresource.GetRelativePath(neg.Subnetwork)
-		if err != nil {
-			return err
+		if pageToken != "" {
+			params.Set("pageToken", pageToken)
 		}
-		networkEndpointGroups = append(networkEndpointGroups, map[string]interface{}{
-			"self_link":             neg.SelfLink,
-			"name":                  neg.Name,
-			"description":           neg.Description,
-			"network_endpoint_type": neg.NetworkEndpointType,
-			"network":               network,
-			"subnetwork":            subnetwork,
-			"default_port":          neg.DefaultPort,
-			"size":                  neg.Size,
+		url := baseURL
+		if len(params) > 0 {
+			url = fmt.Sprintf("%s?%s", url, params.Encode())
+		}
+		networkEndpointGroupsList, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
 		})
+		if err != nil {
+			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("NetworkEndpointGroups : %s %s", project, zone))
+		}
+
+		if rawItems, ok := networkEndpointGroupsList["items"].([]interface{}); ok {
+			for _, raw := range rawItems {
+				neg, ok := raw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				negNetwork, _ := neg["network"].(string)
+				network, err := tpgresource.GetRelativePath(negNetwork)
+				if err != nil {
+					return err
+				}
+				negSubnetwork, _ := neg["subnetwork"].(string)
+				subnetwork, err := tpgresource.GetRelativePath(negSubnetwork)
+				if err != nil {
+					return err
+				}
+				defaultPort := 0
+				if v, ok := neg["defaultPort"].(float64); ok {
+					defaultPort = int(v)
+				}
+				size := 0
+				if v, ok := neg["size"].(float64); ok {
+					size = int(v)
+				}
+				networkEndpointGroups = append(networkEndpointGroups, map[string]interface{}{
+					"self_link":             neg["selfLink"],
+					"name":                  neg["name"],
+					"description":           neg["description"],
+					"network_endpoint_type": neg["networkEndpointType"],
+					"network":               network,
+					"subnetwork":            subnetwork,
+					"default_port":          defaultPort,
+					"size":                  size,
+				})
+			}
+		}
+
+		pageToken, _ = networkEndpointGroupsList["nextPageToken"].(string)
+		if pageToken == "" {
+			break
+		}
 	}
 
 	if err := d.Set("network_endpoint_groups", networkEndpointGroups); err != nil {

--- a/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_groups.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_groups.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"fmt"
+	neturl "net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/registry"
@@ -65,30 +66,60 @@ func dataSourceComputeNetworkEndpointGroupsRead(d *schema.ResourceData, meta int
 
 	networkEndpointGroups := make([]map[string]interface{}, 0)
 
-	networkEndpointGroupsList, err := NewClient(config, userAgent).NetworkEndpointGroups.List(project, zone).Filter(filter).Do()
+	params := neturl.Values{}
+	if filter != "" {
+		params.Set("filter", filter)
+	}
+	url := fmt.Sprintf("%sprojects/%s/zones/%s/networkEndpointGroups", transport_tpg.BaseUrl(Product, config), project, zone)
+	if len(params) > 0 {
+		url = fmt.Sprintf("%s?%s", url, params.Encode())
+	}
+	networkEndpointGroupsList, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("NetworkEndpointGroups : %s %s", project, zone))
 	}
 
-	for _, neg := range networkEndpointGroupsList.Items {
-		network, err := tpgresource.GetRelativePath(neg.Network)
-		if err != nil {
-			return err
+	if rawItems, ok := networkEndpointGroupsList["items"].([]interface{}); ok {
+		for _, raw := range rawItems {
+			neg, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			negNetwork, _ := neg["network"].(string)
+			network, err := tpgresource.GetRelativePath(negNetwork)
+			if err != nil {
+				return err
+			}
+			negSubnetwork, _ := neg["subnetwork"].(string)
+			subnetwork, err := tpgresource.GetRelativePath(negSubnetwork)
+			if err != nil {
+				return err
+			}
+			defaultPort := 0
+			if v, ok := neg["defaultPort"].(float64); ok {
+				defaultPort = int(v)
+			}
+			size := 0
+			if v, ok := neg["size"].(float64); ok {
+				size = int(v)
+			}
+			networkEndpointGroups = append(networkEndpointGroups, map[string]interface{}{
+				"self_link":             neg["selfLink"],
+				"name":                  neg["name"],
+				"description":           neg["description"],
+				"network_endpoint_type": neg["networkEndpointType"],
+				"network":               network,
+				"subnetwork":            subnetwork,
+				"default_port":          defaultPort,
+				"size":                  size,
+			})
 		}
-		subnetwork, err := tpgresource.GetRelativePath(neg.Subnetwork)
-		if err != nil {
-			return err
-		}
-		networkEndpointGroups = append(networkEndpointGroups, map[string]interface{}{
-			"self_link":             neg.SelfLink,
-			"name":                  neg.Name,
-			"description":           neg.Description,
-			"network_endpoint_type": neg.NetworkEndpointType,
-			"network":               network,
-			"subnetwork":            subnetwork,
-			"default_port":          neg.DefaultPort,
-			"size":                  neg.Size,
-		})
 	}
 
 	if err := d.Set("network_endpoint_groups", networkEndpointGroups); err != nil {


### PR DESCRIPTION
…from Apiary to REST

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
datasource: Migrate data_source_compute_network_endpoint_groups.go to use direct HTTP rather than a client library
```
