### PR TITLE
Migrate the Compute API lookup in `resource_storage_bucket.go.tmpl` to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/registry"
-	compute_tpg "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
@@ -2484,13 +2483,22 @@ func setStorageBucket(d *schema.ResourceData, config *transport_tpg.Config, res 
 	// from the projectNumber which is included in the bucket API response
 	if d.Get("project") == "" {
 		projectName, _ := tpgresource.GetProject(d, config)
-		proj, err := compute_tpg.NewClient(config, userAgent).Projects.Get(strconv.FormatUint(res.ProjectNumber, 10)).Do()
+		// Resolve the Compute base URL through the registry so that storage does not
+		// depend on the compute service package. BaseUrl(Product, ...) would resolve
+		// the storage base URL here.
+		projectUrl := fmt.Sprintf("%sprojects/%d", transport_tpg.BaseUrl(registry.GetProduct("compute"), config), res.ProjectNumber)
+		proj, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			RawURL:    projectUrl,
+			UserAgent: userAgent,
+		})
 		if err != nil {
 			log.Printf("[ERROR] Missing Compute API permissions, fallback to provider/resource default")
 		}
 
-		if proj != nil && projectName != "" && projectName != proj.Name {
-			projectName = proj.Name
+		if projectID, ok := proj["name"].(string); ok && projectName != "" && projectName != projectID {
+			projectName = projectID
 		}
 		if err := d.Set("project", projectName); err != nil {
 			return fmt.Errorf("Error setting project: %s", err)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Part of the ongoing migration off the Apiary client library. Same shape as #18463, which moved `resourcemanager` off the compute client.

`setStorageBucket` resolves a project ID from the bucket's project number via the Compute API when `project` is not set (typically during import). That single call was the **only** reason the `storage` package imported the `compute` service package, so migrating it removes the last cross-service dependency in storage's non-test code.

Notes for review:

- **Base URL resolution.** The Compute base URL is taken from `transport_tpg.BaseUrl(registry.GetProduct("compute"), config)`. A plain `BaseUrl(Product, config)` cannot be used here: inside the `storage` package that resolves the **storage** base URL. The registry lookup keeps custom-endpoint, mTLS and universe-domain handling, and it is exactly what the Apiary client did internally, so the request URL is unchanged. A short comment marks this so the line is not "simplified" later.
- **`Project` in `SendRequestOptions` is intentionally left empty.** It only controls the per-request `X-Goog-User-Project` header, and the typed client had no way to set one — the header comes from the shared transport's billing project either way. This call looks a project up *by number* precisely because the caller does not know the project, so attaching it as a quota project would be wrong.
- **Error handling is unchanged**: the failure is still non-fatal and still logs the same message. A permission 403 is not retried by `SendRequest` (its predicates only cover 429/5xx and two body-gated 403 cases), so the fast fallback is preserved.
- **The nil guard became a comma-ok assertion.** `SendRequest` returns a nil map on failure, and reading a key from a nil map is safe, so `proj["name"].(string)` covers both the error path and a response without the field.
- Incidentally removes a latent nil dereference: `NewClient` returns `nil` when the compute service cannot be constructed, and the old line dereferenced it without a check.
- **No URL change**, so recorded VCR cassettes for the affected tests (`TestAccDataSourceGoogleStorageBucket_basic` and the `ImportState` steps of the `TestAccStorageBucket_*` tests) still match.
- Scope is deliberately one call. The `Buckets.*` / `Objects.*` calls in this file use the storage client and are left alone.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
storage: migrated the Compute API lookup in the `google_storage_bucket` resource to use direct HTTP rather than a client library
```
