### PR TITLE
compute: migrate google_compute_default_service_account to REST API

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_default_service_account.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_default_service_account.go
@@ -55,12 +55,28 @@ func dataSourceGoogleComputeDefaultServiceAccountRead(d *schema.ResourceData, me
 		return err
 	}
 
-	projectCompResource, err := NewClient(config, userAgent).Projects.Get(project).Do()
+	url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}")
+	if err != nil {
+		return err
+	}
+
+	projectCompResource, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleDataSourceNotFoundError(err, d, "GCE default service account", fmt.Sprintf("%q GCE default service account", project))
 	}
 
-	serviceAccountName, err := tpgresource.ServiceAccountFQN(projectCompResource.DefaultServiceAccount, d, config)
+	defaultServiceAccount, ok := projectCompResource["defaultServiceAccount"].(string)
+	if !ok {
+		return fmt.Errorf("Error reading GCE default service account for project %s: expected string, got %T(%v)", project, projectCompResource["defaultServiceAccount"], projectCompResource["defaultServiceAccount"])
+	}
+
+	serviceAccountName, err := tpgresource.ServiceAccountFQN(defaultServiceAccount, d, config)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: migrated google_compute_default_service_account to use direct HTTP rather than a client library
```
