### PR TITLE
discoveryengine: remove ForceNew from json_schema in google_discovery_engine_schema

### DIFF
--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -253,6 +253,7 @@ properties:
         description: |
           Whether chunking mode is enabled.
         required: false
+        ignore_read: true
         properties:
           - name: 'layoutBasedChunkingConfig'
             type: NestedObject
@@ -281,6 +282,7 @@ properties:
           will be configured to use a default DigitalParsingConfig, and the default parsing
           config will be applied to all file types for Document parsing.
         required: false
+        ignore_read: true
         properties:
           - name: 'digitalParsingConfig'
             type: NestedObject

--- a/mmv1/products/discoveryengine/Schema.yaml
+++ b/mmv1/products/discoveryengine/Schema.yaml
@@ -24,7 +24,7 @@ references:
 docs:
 base_url: projects/{{project}}/locations/{{location}}/collections/default_collection/dataStores/{{data_store_id}}/schemas
 generate_list_resource: true
-immutable: true
+update_verb: PATCH
 self_link: projects/{{project}}/locations/{{location}}/collections/default_collection/dataStores/{{data_store_id}}/schemas/{{schema_id}}
 create_url: projects/{{project}}/locations/{{location}}/collections/default_collection/dataStores/{{data_store_id}}/schemas?schemaId={{schema_id}}
 delete_url: projects/{{project}}/locations/{{location}}/collections/default_collection/dataStores/{{data_store_id}}/schemas/{{schema_id}}
@@ -91,7 +91,6 @@ properties:
     type: String
     description: |
       The JSON representation of the schema.
-    immutable: true
     exactly_one_of:
       - json_schema
     state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_store_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_store_test.go
@@ -53,6 +53,54 @@ resource "google_discovery_engine_data_store" "basic" {
 `, context)
 }
 
+func TestAccDiscoveryEngineDataStore_documentProcessingConfigNoDiff(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiscoveryEngineDataStore_documentProcessingConfig(context),
+			},
+			{
+				Config:             testAccDiscoveryEngineDataStore_documentProcessingConfig(context),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccDiscoveryEngineDataStore_documentProcessingConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_discovery_engine_data_store" "dpc" {
+  location                    = "global"
+  data_store_id               = "tf-test-dpc-ds%{random_suffix}"
+  display_name                = "tf-test-dpc-datastore"
+  industry_vertical           = "GENERIC"
+  content_config              = "CONTENT_REQUIRED"
+  solution_types              = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search = false
+  document_processing_config {
+    default_parsing_config {
+      layout_parsing_config {}
+    }
+    chunking_config {
+      layout_based_chunking_config {
+        chunk_size                = 500
+        include_ancestor_headings = true
+      }
+    }
+  }
+}
+`, context)
+}
+
 func testAccDiscoveryEngineDataStore_discoveryengineDatastoreBasicExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_discovery_engine_data_store" "basic" {

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_schema_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_schema_test.go
@@ -1,0 +1,89 @@
+package discoveryengine_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/discoveryengine"
+)
+
+func TestAccDiscoveryEngineSchema_discoveryengineSchemaBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.AccTestPreCheck(t)
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDiscoveryEngineSchemaDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiscoveryEngineSchema_basic(context),
+			},
+			{
+				ResourceName:            "google_discovery_engine_schema.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"data_store_id", "location", "schema_id"},
+			},
+			{
+				Config: testAccDiscoveryEngineSchema_update(context),
+			},
+			{
+				ResourceName:            "google_discovery_engine_schema.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"data_store_id", "location", "schema_id"},
+			},
+		},
+	})
+}
+
+func testAccDiscoveryEngineSchema_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_discovery_engine_data_store" "basic" {
+  location                     = "global"
+  data_store_id                = "tf-test-schema-ds%{random_suffix}"
+  display_name                 = "tf-test-structured-datastore"
+  industry_vertical            = "GENERIC"
+  content_config               = "NO_CONTENT"
+  solution_types               = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search  = false
+  skip_default_schema_creation = true
+}
+
+resource "google_discovery_engine_schema" "basic" {
+  location      = google_discovery_engine_data_store.basic.location
+  data_store_id = google_discovery_engine_data_store.basic.data_store_id
+  schema_id     = "tf-test-schema%{random_suffix}"
+  json_schema   = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"type\":\"object\",\"datetime_detection\":true,\"geolocation_detection\":true}"
+}
+`, context)
+}
+
+func testAccDiscoveryEngineSchema_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_discovery_engine_data_store" "basic" {
+  location                     = "global"
+  data_store_id                = "tf-test-schema-ds%{random_suffix}"
+  display_name                 = "tf-test-structured-datastore"
+  industry_vertical            = "GENERIC"
+  content_config               = "NO_CONTENT"
+  solution_types               = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search  = false
+  skip_default_schema_creation = true
+}
+
+resource "google_discovery_engine_schema" "basic" {
+  location      = google_discovery_engine_data_store.basic.location
+  data_store_id = google_discovery_engine_data_store.basic.data_store_id
+  schema_id     = "tf-test-schema%{random_suffix}"
+  json_schema   = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"type\":\"object\",\"datetime_detection\":true,\"geolocation_detection\":true,\"properties\":{\"title\":{\"type\":\"string\",\"retrievable\":true,\"completable\":true}}}"
+}
+`, context)
+}


### PR DESCRIPTION
```release-note:bug
discoveryengine: fixed `json_schema` forcing resource replacement on every change in `google_discovery_engine_schema`
```

```release-note:bug
discoveryengine: fixed permadiff on `document_processing_config.chunking_config` and `document_processing_config.default_parsing_config` in `google_discovery_engine_data_store`
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28660

## Summary

Two bugs in the `discoveryengine` service:

### 1. `google_discovery_engine_schema`: `json_schema` forces replacement

`json_schema` was marked `immutable` (`ForceNew`), so any change forced destroy+recreate. The GCP API supports [in-place schema updates](https://cloud.google.com/generative-ai-app-builder/docs/update-schemas) for additive changes. The destroy path fails when documents exist in the data store because the [`DeleteSchema` API](https://cloud.google.com/generative-ai-app-builder/docs/delete-schemas) refuses to delete schemas with existing documents.

**Fix**: Replaced resource-level `immutable: true` with `update_verb: PATCH` in `Schema.yaml`, removed `immutable: true` from `jsonSchema`. Identity parameters keep their own `immutable: true`.

### 2. `google_discovery_engine_data_store`: `document_processing_config` permadiff

The API returns incorrect values for two sub-fields of `document_processing_config`:
- `chunkingConfig`: API returns null, dropping it from state
- `defaultParsingConfig`: API returns the wrong protobuf oneof variant (`digitalParsingConfig: {}` instead of the configured `layoutParsingConfig`)

Since `documentProcessingConfig` is marked `immutable`, the diff plans a destroy+recreate of the entire data store on every apply.

**Fix**: Added `ignore_read: true` to `chunkingConfig` and `defaultParsingConfig` in `DataStore.yaml`. This is safe because the parent field is immutable, so there is no drift to detect.

**Note on API-side bugs**: The root cause is server-side. The `dataStores.get` response doesn't preserve the protobuf oneof variant for `defaultParsingConfig` and omits `chunkingConfig` entirely. If the API is fixed to return these fields correctly, the `ignore_read` workaround can be removed.

## Test plan

- [ ] `TestAccDiscoveryEngineSchema_discoveryengineSchemaBasicExample_update` verifies in-place schema update
- [ ] `TestAccDiscoveryEngineDataStore_documentProcessingConfigNoDiff` verifies no permadiff with layout_parsing_config + chunking_config
- [ ] Existing tests continue to pass