### PR TITLE
Explicitly map google_biglake_iceberg_namespace

### DIFF
--- a/mmv1/products/biglakeiceberg/IcebergNamespace.yaml
+++ b/mmv1/products/biglakeiceberg/IcebergNamespace.yaml
@@ -35,6 +35,7 @@ import_format:
   - projects/{{project}}/catalogs/{{catalog}}/namespaces/{{namespace_id}}
   - '{{project}}/{{catalog}}/{{namespace_id}}'
   - '{{catalog}}/{{namespace_id}}'
+api_resource_type_kind: Namespace
 supports_indirect_user_project_override: true
 custom_code:
   update_encoder: templates/terraform/encoders/biglake_iceberg_namespace.go.tmpl


### PR DESCRIPTION
The Biglake API uses `google.api.resource_definition.type` declarations in a way that makes it difficult to infer which of biglake/biglakehive/biglakeiceberg a resource belongs to.

```release-note:none

```
