### PR TITLE
Update IAM test imports to use Sample configuration

### DIFF
--- a/mmv1/templates/terraform/samples/base_configs/iam_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/iam_test_file.go.tmpl
@@ -19,7 +19,7 @@ import (
 	"{{ $.ImportPath }}/acctest"
 	"{{ $.ImportPath }}/envvar"
 	"{{ $.ImportPath }}/tpgresource"
-{{- range $pkg, $alias := ($.FirstTestConfig.Step.TestDependencies $.Runtime.ResourcePrefixPkgMap) }}
+{{- range $pkg, $alias := ($.FirstTestConfig.Sample.TestDependencies $.Runtime.ResourcePrefixPkgMap) }}
 	{{ $alias }} "{{ $.ImportPath  }}/{{ $pkg }}"
 {{- end }}
 )


### PR DESCRIPTION
IAM test config is based on the first test listed in the resource's .yaml config. This is usually the basic no frills example, which turns out to have worked out for every IAM test generated from the template so far. As part of my IAM skill work I happened to target a resource (Eventarc Channel) where this wasn't the case - the first test there bootstraps a KMS key, which in turn requires a `resourcemanager` import, which didn't get imported.

```release-note:none

```
