### PR TITLE
Add IAM support for google_eventarc_channel

### DIFF
--- a/mmv1/products/eventarc/Channel.yaml
+++ b/mmv1/products/eventarc/Channel.yaml
@@ -36,7 +36,21 @@ error_retry_predicates:
 legacy_long_form_project: true
 autogen_async: true
 custom_code:
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_attribute: 'channel'
+  allowed_iam_role: 'roles/eventarc.admin'
+  import_format:
+    - 'projects/{{project}}/locations/{{location}}/channels/{{channel}}'
+    - '{{channel}}'
 samples:
+  - name: eventarc_channel
+    primary_resource_id: primary
+    exclude_basic_doc: true
+    steps:
+      - name: eventarc_channel
+        resource_id_vars:
+          channel_name: some-channel
   - name: eventarc_channel_with_cmek
     primary_resource_id: primary
     bootstrap_iam:
@@ -52,13 +66,6 @@ samples:
           project_number: PROJECT_NUMBER
         test_vars_overrides:
           key_name: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-eventarc-channel-key").CryptoKey.Name
-  - name: eventarc_channel
-    primary_resource_id: primary
-    exclude_basic_doc: true
-    steps:
-      - name: eventarc_channel
-        resource_id_vars:
-          channel_name: some-channel
 parameters:
   - name: location
     type: String


### PR DESCRIPTION
The reason for reordering the samples is that the generated IAM test is based on the first sample, which works best if it's the minimal sample. In this case, it means that the IAM test will not be creating a service account and KMS key that it doesn't need.

```release-note:new-resource
`google_eventarc_channel_iam_binding`
```
```release-note:new-resource
`google_eventarc_channel_iam_member`
```
```release-note:new-resource
`google_eventarc_channel_iam_policy` 
```
