### PR TITLE
feat: add support for regex rewrite api in url map (beta)

### DIFF
--- a/mmv1/products/compute/RegionUrlMap.yaml
+++ b/mmv1/products/compute/RegionUrlMap.yaml
@@ -1025,6 +1025,34 @@ properties:
                           Prior to forwarding the request to the selected service, the request's host
                           header is replaced with contents of hostRewrite. The value must be between 1 and
                           255 characters.
+                      - name: 'regexRewrite'
+                        type: NestedObject
+                        min_version: beta
+                        description: |
+                          The regex rewrite to be applied to the URL. Only one of pathPrefixRewrite, pathTemplateRewrite, or regexRewrite may be specified.
+                        properties:
+                          - name: 'pathPattern'
+                            type: String
+                            description: |
+                              The regular expression used to match against the URL path.
+                              It uses RE2 syntax with the following constraints:
+                               - Any single character operators
+                               - Groups are allowed to have only submatch operator inside
+                               - Groups are allowed only without any char repetition, e.g. .*
+                               - Any char repetition, e.g. .*, is only allowed to be used in a single regex together with:
+                                   - Empty string operators
+                                   - Other repetitions
+                                   - Ranges
+                                   - Repetitions of ranges
+                               - Ranges are only allowed to have:
+                                   - Character range
+                                   - Digits range
+                                   - Symbols listed in characters allowed for ranges
+                          - name: 'pathSubstitution'
+                            type: String
+                            description: |
+                              Required when path pattern is specified. Used to rewrite matching parts of
+                              the path.
                       - name: 'pathPrefixRewrite'
                         type: String
                         description: |
@@ -1494,6 +1522,34 @@ properties:
                           Prior to forwarding the request to the selected service, the request's host
                           header is replaced with contents of hostRewrite. The value must be between 1 and
                           255 characters.
+                      - name: 'regexRewrite'
+                        type: NestedObject
+                        min_version: beta
+                        description: |
+                          The regex rewrite to be applied to the URL. Only one of pathPrefixRewrite, pathTemplateRewrite, or regexRewrite may be specified.
+                        properties:
+                          - name: 'pathPattern'
+                            type: String
+                            description: |
+                              The regular expression used to match against the URL path.
+                              It uses RE2 syntax with the following constraints:
+                               - Any single character operators
+                               - Groups are allowed to have only submatch operator inside
+                               - Groups are allowed only without any char repetition, e.g. .*
+                               - Any char repetition, e.g. .*, is only allowed to be used in a single regex together with:
+                                   - Empty string operators
+                                   - Other repetitions
+                                   - Ranges
+                                   - Repetitions of ranges
+                               - Ranges are only allowed to have:
+                                   - Character range
+                                   - Digits range
+                                   - Symbols listed in characters allowed for ranges
+                          - name: 'pathSubstitution'
+                            type: String
+                            description: |
+                              Required when path pattern is specified. Used to rewrite matching parts of
+                              the path.
                       - name: 'pathPrefixRewrite'
                         type: String
                         description: |
@@ -1873,6 +1929,34 @@ properties:
               description: |
                 The spec to modify the URL of the request, prior to forwarding the request to the matched service.
               properties:
+                - name: 'regexRewrite'
+                  type: NestedObject
+                  min_version: beta
+                  description: |
+                    The regex rewrite to be applied to the URL. Only one of pathPrefixRewrite, pathTemplateRewrite, or regexRewrite may be specified.
+                  properties:
+                    - name: 'pathPattern'
+                      type: String
+                      description: |
+                        The regular expression used to match against the URL path.
+                        It uses RE2 syntax with the following constraints:
+                         - Any single character operators
+                         - Groups are allowed to have only submatch operator inside
+                         - Groups are allowed only without any char repetition, e.g. .*
+                         - Any char repetition, e.g. .*, is only allowed to be used in a single regex together with:
+                             - Empty string operators
+                             - Other repetitions
+                             - Ranges
+                             - Repetitions of ranges
+                         - Ranges are only allowed to have:
+                             - Character range
+                             - Digits range
+                             - Symbols listed in characters allowed for ranges
+                    - name: 'pathSubstitution'
+                      type: String
+                      description: |
+                        Required when path pattern is specified. Used to rewrite matching parts of
+                        the path.
                 - name: 'pathPrefixRewrite'
                   type: String
                   description: |
@@ -2353,6 +2437,34 @@ properties:
           - 'default_route_action.0.cors_policy'
           - 'default_route_action.0.fault_injection_policy'
         properties:
+          - name: 'regexRewrite'
+            type: NestedObject
+            min_version: beta
+            description: |
+              The regex rewrite to be applied to the URL. Only one of pathPrefixRewrite, pathTemplateRewrite, or regexRewrite may be specified.
+            properties:
+              - name: 'pathPattern'
+                type: String
+                description: |
+                  The regular expression used to match against the URL path.
+                  It uses RE2 syntax with the following constraints:
+                   - Any single character operators
+                   - Groups are allowed to have only submatch operator inside
+                   - Groups are allowed only without any char repetition, e.g. .*
+                   - Any char repetition, e.g. .*, is only allowed to be used in a single regex together with:
+                       - Empty string operators
+                       - Other repetitions
+                       - Ranges
+                       - Repetitions of ranges
+                   - Ranges are only allowed to have:
+                       - Character range
+                       - Digits range
+                       - Symbols listed in characters allowed for ranges
+              - name: 'pathSubstitution'
+                type: String
+                description: |
+                  Required when path pattern is specified. Used to rewrite matching parts of
+                  the path.
           - name: 'pathPrefixRewrite'
             type: String
             description: |

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -1031,6 +1031,34 @@ properties:
                           Prior to forwarding the request to the selected service, the request's host
                           header is replaced with contents of hostRewrite. The value must be between 1 and
                           255 characters.
+                      - name: 'regexRewrite'
+                        type: NestedObject
+                        min_version: beta
+                        description: |
+                          The regex rewrite to be applied to the URL. Only one of pathPrefixRewrite, pathTemplateRewrite, or regexRewrite may be specified.
+                        properties:
+                          - name: 'pathPattern'
+                            type: String
+                            description: |
+                              The regular expression used to match against the URL path.
+                              It uses RE2 syntax with the following constraints:
+                               - Any single character operators
+                               - Groups are allowed to have only submatch operator inside
+                               - Groups are allowed only without any char repetition, e.g. .*
+                               - Any char repetition, e.g. .*, is only allowed to be used in a single regex together with:
+                                   - Empty string operators
+                                   - Other repetitions
+                                   - Ranges
+                                   - Repetitions of ranges
+                               - Ranges are only allowed to have:
+                                   - Character range
+                                   - Digits range
+                                   - Symbols listed in characters allowed for ranges
+                          - name: 'pathSubstitution'
+                            type: String
+                            description: |
+                              Required when path pattern is specified. Used to rewrite matching parts of
+                              the path.
                       - name: 'pathPrefixRewrite'
                         type: String
                         description: |
@@ -2093,6 +2121,34 @@ properties:
                           Prior to forwarding the request to the selected service, the request's host
                           header is replaced with contents of hostRewrite. The value must be between 1 and
                           255 characters.
+                      - name: 'regexRewrite'
+                        type: NestedObject
+                        min_version: beta
+                        description: |
+                          The regex rewrite to be applied to the URL. Only one of pathPrefixRewrite, pathTemplateRewrite, or regexRewrite may be specified.
+                        properties:
+                          - name: 'pathPattern'
+                            type: String
+                            description: |
+                              The regular expression used to match against the URL path.
+                              It uses RE2 syntax with the following constraints:
+                               - Any single character operators
+                               - Groups are allowed to have only submatch operator inside
+                               - Groups are allowed only without any char repetition, e.g. .*
+                               - Any char repetition, e.g. .*, is only allowed to be used in a single regex together with:
+                                   - Empty string operators
+                                   - Other repetitions
+                                   - Ranges
+                                   - Repetitions of ranges
+                               - Ranges are only allowed to have:
+                                   - Character range
+                                   - Digits range
+                                   - Symbols listed in characters allowed for ranges
+                          - name: 'pathSubstitution'
+                            type: String
+                            description: |
+                              Required when path pattern is specified. Used to rewrite matching parts of
+                              the path.
                       - name: 'pathPrefixRewrite'
                         type: String
                         description: |
@@ -2885,6 +2941,34 @@ properties:
               description: |
                 The spec to modify the URL of the request, prior to forwarding the request to the matched service.
               properties:
+                - name: 'regexRewrite'
+                  type: NestedObject
+                  min_version: beta
+                  description: |
+                    The regex rewrite to be applied to the URL. Only one of pathPrefixRewrite, pathTemplateRewrite, or regexRewrite may be specified.
+                  properties:
+                    - name: 'pathPattern'
+                      type: String
+                      description: |
+                        The regular expression used to match against the URL path.
+                        It uses RE2 syntax with the following constraints:
+                         - Any single character operators
+                         - Groups are allowed to have only submatch operator inside
+                         - Groups are allowed only without any char repetition, e.g. .*
+                         - Any char repetition, e.g. .*, is only allowed to be used in a single regex together with:
+                             - Empty string operators
+                             - Other repetitions
+                             - Ranges
+                             - Repetitions of ranges
+                         - Ranges are only allowed to have:
+                             - Character range
+                             - Digits range
+                             - Symbols listed in characters allowed for ranges
+                    - name: 'pathSubstitution'
+                      type: String
+                      description: |
+                        Required when path pattern is specified. Used to rewrite matching parts of
+                        the path.
                 - name: 'pathPrefixRewrite'
                   type: String
                   description: |
@@ -3764,6 +3848,34 @@ properties:
           - 'default_route_action.0.fault_injection_policy'
           - 'default_route_action.0.cache_policy'
         properties:
+          - name: 'regexRewrite'
+            type: NestedObject
+            min_version: beta
+            description: |
+              The regex rewrite to be applied to the URL. Only one of pathPrefixRewrite, pathTemplateRewrite, or regexRewrite may be specified.
+            properties:
+              - name: 'pathPattern'
+                type: String
+                description: |
+                  The regular expression used to match against the URL path.
+                  It uses RE2 syntax with the following constraints:
+                   - Any single character operators
+                   - Groups are allowed to have only submatch operator inside
+                   - Groups are allowed only without any char repetition, e.g. .*
+                   - Any char repetition, e.g. .*, is only allowed to be used in a single regex together with:
+                       - Empty string operators
+                       - Other repetitions
+                       - Ranges
+                       - Repetitions of ranges
+                   - Ranges are only allowed to have:
+                       - Character range
+                       - Digits range
+                       - Symbols listed in characters allowed for ranges
+              - name: 'pathSubstitution'
+                type: String
+                description: |
+                  Required when path pattern is specified. Used to rewrite matching parts of
+                  the path.
           - name: 'pathPrefixRewrite'
             type: String
             description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.tmpl
@@ -2572,3 +2572,94 @@ resource "google_compute_health_check" "default" {
 }
 `, suffix, suffix, suffix)
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func TestAccComputeUrlMap_defaultRouteActionRegexUrlRewrite(t *testing.T) {
+  t.Parallel()
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy:             testAccCheckComputeUrlMapDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeUrlMap_defaultRouteActionRegexUrlRewrite(acctest.RandString(t, 10)),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckComputeUrlMapExists(
+            t, "google_compute_url_map.foobar"),
+        ),
+      },
+      {
+        Config: testAccComputeUrlMap_defaultRouteActionRegexUrlRewrite_update(acctest.RandString(t, 10)),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckComputeUrlMapExists(
+            t, "google_compute_url_map.foobar"),
+        ),
+      },
+    },
+  })
+}
+
+func testAccComputeUrlMap_defaultRouteActionRegexUrlRewrite(suffix string) string {
+  return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "urlmap-test-%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "urlmap-test-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_url_map" "foobar" {
+  name            = "urlmap-test-%s"
+  default_service = google_compute_backend_service.foobar.self_link
+
+  default_route_action {
+    url_rewrite {
+      host_rewrite = "dev.example.com"
+      regex_rewrite {
+        path_pattern = "/v1/api/.*"
+        path_substitution = "/v2/api/"
+      }
+    }
+  }
+}
+`, suffix, suffix, suffix)
+}
+
+func testAccComputeUrlMap_defaultRouteActionRegexUrlRewrite_update(suffix string) string {
+  return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "urlmap-test-%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "urlmap-test-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_url_map" "foobar" {
+  name            = "urlmap-test-%s"
+  default_service = google_compute_backend_service.foobar.self_link
+
+  default_route_action {
+    url_rewrite {
+      host_rewrite = "stage.example.com" # updated
+      regex_rewrite {
+        path_pattern = "/v2/api/.*"
+        path_substitution = "/v3/api/"
+      }
+    }
+  }
+}
+`, suffix, suffix, suffix)
+}
+{{- end }}
+


### PR DESCRIPTION
Adds support for the `regexRewrite` API field in the `url_rewrite` block for `google_compute_url_map` and `google_compute_region_url_map` resources in the `google-beta` provider.

Resolves b/493449768

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `regex_rewrite` field to `url_rewrite` block in `google_compute_url_map` and `google_compute_region_url_map` (beta)
```