### PR TITLE
feat: add fields to configure GE Notebook datastore

### DIFF
--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -108,6 +108,13 @@ samples:
       - name: 'discoveryengine_datastore_acl_config'
         resource_id_vars:
           data_store_id: 'data-store-id'
+  - name: 'discoveryengine_datastore_federated_search_config'
+    primary_resource_id: 'federated_search_config'
+    exclude_basic_doc: true
+    steps:
+      - name: 'discoveryengine_datastore_federated_search_config'
+        resource_id_vars:
+          data_store_id: 'data-store-id'
 parameters:
   - name: 'location'
     type: String
@@ -463,6 +470,23 @@ properties:
                   required: false
                   item_type:
                     type: String
+  - name: 'federatedSearchConfig'
+    type: NestedObject
+    description: |
+      Configuration for federated search.
+    required: false
+    properties:
+      - name: 'notebooklmConfig'
+        type: NestedObject
+        description: |
+          Configuration for NotebookLM.
+        required: false
+        properties:
+          - name: 'searchConfig'
+            type: String
+            description: |
+              The search config resource name for NotebookLM.
+            required: false
   - name: 'createTime'
     type: Time
     description: |

--- a/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_federated_search_config.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_federated_search_config.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_discovery_engine_data_store" "federated_search_config" {
+  location                     = "global"
+  data_store_id                = "{{index $.ResourceIdVars "data_store_id"}}"
+  display_name                 = "tf-test-structured-datastore"
+  industry_vertical            = "GENERIC"
+  content_config               = "NO_CONTENT"
+  solution_types               = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search  = false
+  skip_default_schema_creation = false
+  federated_search_config {
+    notebooklm_config {
+      search_config = "projects/${data.google_project.project.number}/locations/global/notebooklmSearchConfigs/default_search_config"
+    }
+  }
+}
+
+data "google_project" "project" {
+}


### PR DESCRIPTION
This PR add fields allowing to configure Gemini Notebook datastore through `google_discovery_engine_data_store` resource.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28490

```release-note:enhancement
discoveryengine: add `federated_search_config` field in `google_discovery_engine_data_store`
```
