### PR TITLE
compute: update instance scheduling test locations to avoid us-central1 stockouts

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -2128,7 +2128,7 @@ func TestAccComputeInstance_scheduling(t *testing.T) {
 						t, "google_compute_instance.foobar", &instance),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 			{
 				Config: testAccComputeInstance_schedulingUpdated(instanceName),
 				Check: resource.ComposeTestCheckFunc(
@@ -2136,7 +2136,7 @@ func TestAccComputeInstance_scheduling(t *testing.T) {
 						t, "google_compute_instance.foobar", &instance),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 		},
 	})
 }
@@ -4134,7 +4134,7 @@ func TestAccComputeInstance_standardVM_maxRunDuration_stopTerminationAction(t *t
 					testAccCheckComputeInstanceMaxRunDuration(&instance, expectedMaxRunDuration),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 		},
 	})
 }
@@ -4196,7 +4196,7 @@ func TestAccComputeInstance_spotVM_maxRunDuration_deleteTerminationAction(t *tes
 					testAccCheckComputeInstanceMaxRunDuration(&instance, expectedMaxRunDuration),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 		},
 	})
 }
@@ -4227,7 +4227,7 @@ func TestAccComputeInstance_standardVM_maxRunDuration_deleteTerminationAction(t 
 					testAccCheckComputeInstanceMaxRunDuration(&instance, expectedMaxRunDuration),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 		},
 	})
 }
@@ -4254,7 +4254,7 @@ func TestAccComputeInstance_spotVM_maxRunDuration_update(t *testing.T) {
 						t, "google_compute_instance.foobar", &instance),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 			{
 				Config: testAccComputeInstance_spotVM_maxRunDuration(instanceName, "DELETE"),
 				Check: resource.ComposeTestCheckFunc(
@@ -4263,7 +4263,7 @@ func TestAccComputeInstance_spotVM_maxRunDuration_update(t *testing.T) {
 					testAccCheckComputeInstanceMaxRunDuration(&instance, expectedMaxRunDuration),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 		},
 	})
 }
@@ -9462,7 +9462,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "e2-medium"
-  zone         = "us-central1-a"
+  zone         = "us-east1-d"
 
   boot_disk {
     initialize_params {
@@ -9491,7 +9491,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "e2-medium"
-  zone         = "us-central1-a"
+  zone         = "us-east1-d"
 
   boot_disk {
     initialize_params {
@@ -12269,7 +12269,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "e2-medium"
-  zone         = "us-central1-a"
+  zone         = "us-east1-d"
 
   boot_disk {
     initialize_params {
@@ -12304,7 +12304,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "e2-medium"
-  zone         = "us-central1-a"
+  zone         = "us-east1-d"
 
   boot_disk {
     initialize_params {
@@ -12380,7 +12380,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "e2-medium"
-  zone         = "us-central1-a"
+  zone         = "us-east1-d"
 
   boot_disk {
     initialize_params {


### PR DESCRIPTION
<!-- Reference: PLX script_cb._a691b3_d496_4857_b7ca_c6cc596a8c86 -->
Update Compute Instance scheduling and spotVM test configurations and import steps to use `us-east1-d` instead of `us-central1-a` to prevent nightly test stockout failures.

Fixed tests:
- `TestAccComputeInstance_spotVM_maxRunDuration_deleteTerminationAction`
- `TestAccComputeInstance_spotVM_maxRunDuration_update`
- `TestAccComputeInstance_standardVM_maxRunDuration_deleteTerminationAction`
- `TestAccComputeInstance_standardVM_maxRunDuration_update`
- `TestAccComputeInstance_scheduling`

```release-note:none

```