### PR TITLE
Replaced basic scaling with explicit automatic scaling in App Engine sample to fix diff issue.

### DIFF
--- a/mmv1/products/appengine/StandardAppVersion.yaml
+++ b/mmv1/products/appengine/StandardAppVersion.yaml
@@ -374,6 +374,7 @@ properties:
       - manual_scaling
     # This flattener is entirely handwritten and must be updated with **any** new field or subfield
     custom_flatten: templates/terraform/custom_flatten/appengine_standardappversion_automatic_scaling_handlenil.go.tmpl
+    default_from_api: true
     properties:
       - name: maxConcurrentRequests
         type: Integer

--- a/mmv1/templates/terraform/samples/services/iap/iap_app_engine_service.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/iap/iap_app_engine_service.tf.tmpl
@@ -40,10 +40,6 @@ resource "google_app_engine_standard_app_version" "version" {
   runtime         = "nodejs22"
   noop_on_destroy = true
 
-  // TODO: Removed basic scaling once automatic_scaling refresh behavior is fixed.
-  basic_scaling { 
-    max_instances = 5 
-  }
   entrypoint {
     shell = "node ./app.js"
   }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

Replaced basic scaling with explicit automatic scaling in App Engine sample to fix diff issue.
 
Per b/325645138, this rolls back https://github.com/GoogleCloudPlatform/magic-modules/pull/10000, which was intended to be a temporary fix.
  
```release-note:bug
appengine: fixed permadiff in `google_app_engine_standard_app_version` 
```  
