### PR TITLE
oracledatabase: randomize CIDR range in OdbSubnet acceptance test

### DIFF
--- a/mmv1/products/oracledatabase/OdbSubnet.yaml
+++ b/mmv1/products/oracledatabase/OdbSubnet.yaml
@@ -56,6 +56,7 @@ samples:
     steps:
       - name: oracledatabase_odbsubnet
         resource_id_vars:
+          cidr_range: 10.1.1.0/24
           project: my-project
           odb_network_id: my-odbnetwork
           odb_subnet_id: my-odbsubnet
@@ -67,6 +68,7 @@ samples:
           project: '"oci-terraform-testing-prod"'
           odb_network_id: '"tf-test-permanent-odbnetwork"'
           odb_subnet_id: fmt.Sprintf("tf-test-odbsubnet-%s", acctest.RandString(t, 10))
+          cidr_range: fmt.Sprintf("10.1.%d.0/24", acctest.RandInt(t) % 200 + 10)
 virtual_fields:
   - name: deletion_protection
     type: Boolean

--- a/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_odbsubnet.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_odbsubnet.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_oracle_database_odb_subnet" "{{$.PrimaryResourceId}}"{
   location = "europe-west2"
   project = "{{index $.ResourceIdVars "project"}}"
   odbnetwork = "{{index $.ResourceIdVars "odb_network_id"}}"
-  cidr_range = "10.1.1.0/24"
+  cidr_range = "{{index $.ResourceIdVars "cidr_range"}}"
   purpose = "CLIENT_SUBNET"
   labels = {
     terraform_created = "true"


### PR DESCRIPTION
Update the hardcoded cidr_range ("10.1.1.0/24") in the oracledatabase_odbsubnet template sample to use {{index $.ResourceIdVars "cidr_range"}}. This avoids CIDR range overlap errors when nightly acceptance tests run concurrently across GOOGLE and GOOGLE_BETA provider pipelines.

fixed https://github.com/hashicorp/terraform-provider-google/issues/28606
