### PR TITLE
change default load balancing scheme for EXTERNAL_MANAGED for global …

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -67,7 +67,7 @@ samples:
       - name: 'backend_service_basic'
         resource_id_vars:
           backend_service_name: 'backend-service'
-          http_health_check_name: 'health-check'
+          health_check_name: 'health-check'
   - name: 'backend_service_external_iap'
     primary_resource_id: 'default'
     steps:
@@ -80,7 +80,7 @@ samples:
       - name: 'backend_service_cache_simple'
         resource_id_vars:
           backend_service_name: 'backend-service'
-          http_health_check_name: 'health-check'
+          health_check_name: 'health-check'
   - name: 'backend_service_cache_include_http_headers'
     primary_resource_id: 'default'
     steps:
@@ -99,14 +99,14 @@ samples:
       - name: 'backend_service_cache'
         resource_id_vars:
           backend_service_name: 'backend-service'
-          http_health_check_name: 'health-check'
+          health_check_name: 'health-check'
   - name: 'backend_service_cache_bypass_cache_on_request_headers'
     primary_resource_id: 'default'
     steps:
       - name: 'backend_service_cache_bypass_cache_on_request_headers'
         resource_id_vars:
           backend_service_name: 'backend-service'
-          http_health_check_name: 'health-check'
+          health_check_name: 'health-check'
   - name: 'backend_service_traffic_director_round_robin'
     primary_resource_id: 'default'
     min_version: 'beta'
@@ -961,7 +961,7 @@ properties:
       external load balancing. A backend service created for one type of
       load balancing cannot be used with the other. For more information, refer to
       [Choosing a load balancer](https://cloud.google.com/load-balancing/docs/backend-service).
-    default_value: "EXTERNAL"
+    default_value: "EXTERNAL_MANAGED"
     # If you're modifying this value, it probably means Global ILB is now
     # an option. If that's the case, all of the documentation is based on
     # this resource supporting external load balancing only.

--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -353,7 +353,7 @@ properties:
 
       For more information about forwarding rules, refer to
       [Forwarding rule concepts](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts).
-    default_value: "EXTERNAL"
+    default_value: "EXTERNAL_MANAGED"
     enum_values:
       - 'EXTERNAL'
       - 'EXTERNAL_MANAGED'

--- a/mmv1/products/iap/WebBackendService.yaml
+++ b/mmv1/products/iap/WebBackendService.yaml
@@ -45,7 +45,7 @@ samples:
         config_path: templates/terraform/samples/services/compute/backend_service_basic.tf.tmpl
         resource_id_vars:
           backend_service_name: 'backend-service'
-          http_health_check_name: 'health-check'
+          health_check_name: 'health-check'
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_basic.tf.tmpl
@@ -1,11 +1,14 @@
 resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
   name          = "{{index $.ResourceIdVars "backend_service_name"}}"
-  health_checks = [google_compute_http_health_check.default.id]
+  health_checks = [google_compute_health_check.default.id]
 }
 
-resource "google_compute_http_health_check" "default" {
-  name               = "{{index $.ResourceIdVars "http_health_check_name"}}"
-  request_path       = "/"
+resource "google_compute_health_check" "default" {
+  name               = "{{index $.ResourceIdVars "health_check_name"}}"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_cache.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_cache.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
   name          = "{{index $.ResourceIdVars "backend_service_name"}}"
-  health_checks = [google_compute_http_health_check.default.id]
+  health_checks = [google_compute_health_check.default.id]
   enable_cdn  = true
   cdn_policy {
     cache_mode = "CACHE_ALL_STATIC"
@@ -12,9 +12,12 @@ resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
   }
 }
 
-resource "google_compute_http_health_check" "default" {
-  name               = "{{index $.ResourceIdVars "http_health_check_name"}}"
-  request_path       = "/"
+resource "google_compute_health_check" "default" {
+  name               = "{{index $.ResourceIdVars "health_check_name"}}"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_cache_bypass_cache_on_request_headers.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_cache_bypass_cache_on_request_headers.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
   name          = "{{index $.ResourceIdVars "backend_service_name"}}"
-  health_checks = [google_compute_http_health_check.default.id]
+  health_checks = [google_compute_health_check.default.id]
   enable_cdn  = true
   cdn_policy {
     cache_mode = "CACHE_ALL_STATIC"
@@ -20,9 +20,12 @@ resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
   }
 }
 
-resource "google_compute_http_health_check" "default" {
-  name               = "{{index $.ResourceIdVars "http_health_check_name"}}"
-  request_path       = "/"
+resource "google_compute_health_check" "default" {
+  name               = "{{index $.ResourceIdVars "health_check_name"}}"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_cache_simple.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_cache_simple.tf.tmpl
@@ -1,15 +1,18 @@
 resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
   name          = "{{index $.ResourceIdVars "backend_service_name"}}"
-  health_checks = [google_compute_http_health_check.default.id]
+  health_checks = [google_compute_health_check.default.id]
   enable_cdn  = true
   cdn_policy {
     signed_url_cache_max_age_sec = 7200
   }
 }
 
-resource "google_compute_http_health_check" "default" {
-  name               = "{{index $.ResourceIdVars "http_health_check_name"}}"
-  request_path       = "/"
+resource "google_compute_health_check" "default" {
+  name               = "{{index $.ResourceIdVars "health_check_name"}}"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_dynamic_backends.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_dynamic_backends.tf.tmpl
@@ -69,16 +69,19 @@ resource "google_compute_backend_service" "default" {
     group = google_compute_instance_group.default[each.key].self_link
   }
 
-  health_checks = [google_compute_http_health_check.default[each.key].self_link]
+  health_checks = [google_compute_health_check.default[each.key].self_link]
   port_name     = "http"
 }
 
-resource "google_compute_http_health_check" "default" {
+resource "google_compute_health_check" "default" {
   for_each           = local.instances
   name               = "${each.key}-hc"
-  request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }
 
 

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_signed_url_key.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_signed_url_key.tf.tmpl
@@ -20,7 +20,7 @@ resource "google_compute_backend_service" "example_backend" {
     group = google_compute_instance_group_manager.webservers.instance_group
   }
 
-  health_checks = [google_compute_http_health_check.default.id]
+  health_checks = [google_compute_health_check.default.id]
 }
 
 resource "google_compute_instance_group_manager" "webservers" {
@@ -51,9 +51,12 @@ resource "google_compute_instance_template" "webserver" {
   }
 }
 
-resource "google_compute_http_health_check" "default" {
+resource "google_compute_health_check" "default" {
   name               = "test"
-  request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }

--- a/mmv1/templates/terraform/samples/services/compute/global_forwarding_rule_http.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/global_forwarding_rule_http.tf.tmpl
@@ -37,12 +37,15 @@ resource "google_compute_backend_service" "default" {
   protocol    = "HTTP"
   timeout_sec = 10
 
-  health_checks = [google_compute_http_health_check.default.id]
+  health_checks = [google_compute_health_check.default.id]
 }
 
-resource "google_compute_http_health_check" "default" {
+resource "google_compute_health_check" "default" {
   name               = "check-{{index $.ResourceIdVars "backend_service_name"}}"
-  request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }

--- a/mmv1/templates/terraform/samples/services/compute/managed_ssl_certificate_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/managed_ssl_certificate_basic.tf.tmpl
@@ -35,10 +35,11 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name        = "{{index $.ResourceIdVars "backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }
@@ -51,7 +52,8 @@ resource "google_compute_http_health_check" "default" {
 }
 
 resource "google_compute_global_forwarding_rule" "default" {
-  name       = "{{index $.ResourceIdVars "forwarding_rule_name"}}"
-  target     = google_compute_target_https_proxy.default.id
-  port_range = 443
+  name                  = "{{index $.ResourceIdVars "forwarding_rule_name"}}"
+  target                = google_compute_target_https_proxy.default.id
+  port_range            = 443
+  load_balancing_scheme = "EXTERNAL"
 }

--- a/mmv1/templates/terraform/samples/services/compute/managed_ssl_certificate_recreation.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/managed_ssl_certificate_recreation.tf.tmpl
@@ -51,11 +51,12 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name          = "backend-service"
-  port_name     = "http"
-  protocol      = "HTTP"
-  timeout_sec   = 10
-  health_checks = [google_compute_http_health_check.default.id]
+  name                  = "backend-service"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_http_health_check.default.id]
 }
 
 resource "google_compute_http_health_check" "default" {

--- a/mmv1/templates/terraform/samples/services/compute/ssl_certificate_target_https_proxies.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/ssl_certificate_target_https_proxies.tf.tmpl
@@ -47,10 +47,11 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name        = "{{index $.ResourceIdVars "backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }

--- a/mmv1/templates/terraform/samples/services/compute/target_http_proxy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/target_http_proxy_basic.tf.tmpl
@@ -24,10 +24,11 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name        = "{{index $.ResourceIdVars "backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }

--- a/mmv1/templates/terraform/samples/services/compute/target_http_proxy_fingerprint.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/target_http_proxy_fingerprint.tf.tmpl
@@ -24,10 +24,11 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name        = "{{index $.ResourceIdVars "backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }

--- a/mmv1/templates/terraform/samples/services/compute/target_https_proxy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/target_https_proxy_basic.tf.tmpl
@@ -33,10 +33,11 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name        = "{{index $.ResourceIdVars "backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }

--- a/mmv1/templates/terraform/samples/services/compute/target_https_proxy_fingerprint.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/target_https_proxy_fingerprint.tf.tmpl
@@ -33,10 +33,11 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name        = "{{index $.ResourceIdVars "backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }

--- a/mmv1/templates/terraform/samples/services/compute/target_https_proxy_mtls.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/target_https_proxy_mtls.tf.tmpl
@@ -73,11 +73,12 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  provider    = google-beta
-  name        = "{{index $.ResourceIdVars "backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  provider              = google-beta
+  name                  = "{{index $.ResourceIdVars "backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }

--- a/mmv1/templates/terraform/samples/services/compute/target_ssl_proxy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/target_ssl_proxy_basic.tf.tmpl
@@ -12,9 +12,10 @@ resource "google_compute_ssl_certificate" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name          = "{{index $.ResourceIdVars "backend_service_name"}}"
-  protocol      = "SSL"
-  health_checks = [google_compute_health_check.default.id]
+  name                  = "{{index $.ResourceIdVars "backend_service_name"}}"
+  protocol              = "SSL"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_health_check.default.id]
 }
 
 resource "google_compute_health_check" "default" {

--- a/mmv1/templates/terraform/samples/services/compute/url_map_bucket_and_service.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/url_map_bucket_and_service.tf.tmpl
@@ -47,10 +47,11 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "login" {
-  name        = "{{index $.ResourceIdVars "login_backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "login_backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }

--- a/mmv1/templates/terraform/samples/services/compute/url_map_header_based_routing.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/url_map_header_based_routing.tf.tmpl
@@ -40,28 +40,31 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name        = "{{index $.ResourceIdVars "default_backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "default_backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }
 
 resource "google_compute_backend_service" "service-a" {
-  name        = "{{index $.ResourceIdVars "service_a_backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "service_a_backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }
 
 resource "google_compute_backend_service" "service-b" {
-  name        = "{{index $.ResourceIdVars "service_b_backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "service_b_backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }

--- a/mmv1/templates/terraform/samples/services/compute/url_map_parameter_based_routing.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/url_map_parameter_based_routing.tf.tmpl
@@ -40,28 +40,31 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "default" {
-  name        = "{{index $.ResourceIdVars "default_backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "default_backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }
 
 resource "google_compute_backend_service" "service-a" {
-  name        = "{{index $.ResourceIdVars "service_a_backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "service_a_backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }
 
 resource "google_compute_backend_service" "service-b" {
-  name        = "{{index $.ResourceIdVars "service_b_backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "service_b_backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_http_health_check.default.id]
 }

--- a/mmv1/templates/terraform/samples/services/compute/url_map_test_expected_output_url.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/url_map_test_expected_output_url.tf.tmpl
@@ -9,10 +9,11 @@ resource "google_compute_health_check" "{{$.ResourceIdVars.health_check_name}}" 
 }
 
 resource "google_compute_backend_service" "{{$.ResourceIdVars.backend_service_name}}" {
-  name        = "{{index $.ResourceIdVars "backend_service_name"}}"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
+  name                  = "{{index $.ResourceIdVars "backend_service_name"}}"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "EXTERNAL"
 
   health_checks = [google_compute_health_check.{{$.ResourceIdVars.health_check_name}}.id]
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -3031,7 +3031,7 @@ func TestAccComputeBackendService_updateCanaryMigration(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeBackendService_basic(serviceName, checkName),
+				Config: testAccComputeBackendService_withCanaryMigrationInitial(serviceName, checkName),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",
@@ -3084,12 +3084,30 @@ func TestAccComputeBackendService_updateCanaryMigration(t *testing.T) {
 	})
 }
 
+func testAccComputeBackendService_withCanaryMigrationInitial(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name                  = "%s"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_http_health_check.zero.self_link]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, checkName)
+}
+
 func testAccComputeBackendService_withCanaryMigration(serviceName, checkName, description, migrationState string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
-  name             = "%s"
-  description      = "%s"
-  health_checks    = [google_compute_http_health_check.zero.self_link]
+  name                             = "%s"
+  description                      = "%s"
+  load_balancing_scheme            = "EXTERNAL"
+  health_checks                    = [google_compute_http_health_check.zero.self_link]
   external_managed_migration_state = "%s"
 }
 
@@ -3109,9 +3127,10 @@ resource "time_sleep" "six_minutes_delay" {
 }
 
 resource "google_compute_backend_service" "foobar" {
-  name             = "%s"
-  description      = "%s"
-  health_checks    = [google_compute_http_health_check.zero.self_link]
+  name                             = "%s"
+  description                      = "%s"
+  load_balancing_scheme            = "EXTERNAL"
+  health_checks                    = [google_compute_http_health_check.zero.self_link]
   external_managed_migration_state = "%s"
 	depends_on = [
 		time_sleep.six_minutes_delay
@@ -3134,9 +3153,10 @@ resource "time_sleep" "six_minutes_delay" {
 }
 
 resource "google_compute_backend_service" "foobar" {
-  name             = "%s"
-  description      = "%s"
-  health_checks    = [google_compute_http_health_check.zero.self_link]
+  name                             = "%s"
+  description                      = "%s"
+  load_balancing_scheme            = "EXTERNAL"
+  health_checks                    = [google_compute_http_health_check.zero.self_link]
   external_managed_migration_state = "TEST_BY_PERCENTAGE"
 	external_managed_migration_testing_percentage = %d
 	depends_on = [

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
@@ -460,14 +460,17 @@ resource "google_compute_target_http_proxy" "proxy2" {
 
 resource "google_compute_backend_service" "backend" {
   name          = "%s"
-  health_checks = [google_compute_http_health_check.zero.self_link]
+  health_checks = [google_compute_health_check.zero.self_link]
 }
 
-resource "google_compute_http_health_check" "zero" {
+resource "google_compute_health_check" "zero" {
   name               = "%s"
-  request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }
 
 resource "google_compute_url_map" "url_map" {
@@ -515,14 +518,17 @@ resource "google_compute_target_http_proxy" "proxy" {
 
 resource "google_compute_backend_service" "backend" {
   name          = "%s"
-  health_checks = [google_compute_http_health_check.zero.self_link]
+  health_checks = [google_compute_health_check.zero.self_link]
 }
 
-resource "google_compute_http_health_check" "zero" {
+resource "google_compute_health_check" "zero" {
   name               = "%s"
-  request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }
 
 resource "google_compute_url_map" "urlmap" {
@@ -570,14 +576,17 @@ resource "google_compute_target_http_proxy" "proxy" {
 
 resource "google_compute_backend_service" "backend" {
   name          = "%s"
-  health_checks = [google_compute_http_health_check.zero.self_link]
+  health_checks = [google_compute_health_check.zero.self_link]
 }
 
-resource "google_compute_http_health_check" "zero" {
+resource "google_compute_health_check" "zero" {
   name               = "%s"
-  request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }
 
 resource "google_compute_url_map" "urlmap" {
@@ -723,14 +732,17 @@ resource "google_compute_target_http_proxy" "proxy" {
 
 resource "google_compute_backend_service" "backend" {
   name          = "%s"
-  health_checks = [google_compute_http_health_check.zero.self_link]
+  health_checks = [google_compute_health_check.zero.self_link]
 }
 
-resource "google_compute_http_health_check" "zero" {
+resource "google_compute_health_check" "zero" {
   name               = "%s"
-  request_path       = "/"
   check_interval_sec = 1
   timeout_sec        = 1
+  http_health_check {
+    port         = 80
+    request_path = "/"
+  }
 }
 
 resource "google_compute_url_map" "urlmap" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_https_proxy_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_https_proxy_test.go
@@ -250,8 +250,9 @@ resource "google_compute_target_https_proxy" "foobar" {
 }
 
 resource "google_compute_backend_service" "foobar" {
-  name          = "tf-test-httpsproxy-backend-%s"
-  health_checks = [google_compute_http_health_check.zero.self_link]
+  name                  = "tf-test-httpsproxy-backend-%s"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_http_health_check.zero.self_link]
 }
 
 resource "google_compute_http_health_check" "zero" {
@@ -341,8 +342,9 @@ resource "google_compute_target_https_proxy" "foobar" {
 }
 
 resource "google_compute_backend_service" "foobar" {
-  name          = "tf-test-httpsproxy-backend-%s"
-  health_checks = [google_compute_http_health_check.zero.self_link]
+  name                  = "tf-test-httpsproxy-backend-%s"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_http_health_check.zero.self_link]
 }
 
 resource "google_compute_http_health_check" "zero" {
@@ -408,8 +410,9 @@ resource "google_compute_target_https_proxy" "foobar" {
 }
 
 resource "google_compute_backend_service" "foobar" {
-  name          = "tf-test-httpsproxy-backend-%s"
-  health_checks = [google_compute_http_health_check.zero.self_link]
+  name                  = "tf-test-httpsproxy-backend-%s"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_http_health_check.zero.self_link]
 }
 
 resource "google_compute_http_health_check" "zero" {
@@ -467,8 +470,9 @@ resource "google_compute_target_https_proxy" "foobar" {
 }
 
 resource "google_compute_backend_service" "foobar" {
-  name          = "tf-test-httpsproxy-backend-%s"
-  health_checks = [google_compute_http_health_check.zero.self_link]
+  name                  = "tf-test-httpsproxy-backend-%s"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_http_health_check.zero.self_link]
 }
 
 resource "google_compute_http_health_check" "zero" {
@@ -505,8 +509,9 @@ resource "google_compute_target_https_proxy" "foobar" {
 }
 
 resource "google_compute_backend_service" "foobar" {
-  name          = "tf-test-httpsproxy-backend-%s"
-  health_checks = [google_compute_http_health_check.zero.self_link]
+  name                  = "tf-test-httpsproxy-backend-%s"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_http_health_check.zero.self_link]
 }
 
 resource "google_compute_http_health_check" "zero" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_ssl_proxy_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_ssl_proxy_test.go
@@ -179,9 +179,10 @@ resource "google_compute_ssl_certificate" "foo" {
 }
 
 resource "google_compute_backend_service" "foo" {
-  name          = "%s"
-  protocol      = "SSL"
-  health_checks = [google_compute_health_check.zero.self_link]
+  name                  = "%s"
+  protocol              = "SSL"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_health_check.zero.self_link]
 }
 
 resource "google_compute_health_check" "zero" {
@@ -225,15 +226,17 @@ resource "google_compute_ssl_certificate" "bar" {
 }
 
 resource "google_compute_backend_service" "foo" {
-  name          = "%s"
-  protocol      = "SSL"
-  health_checks = [google_compute_health_check.zero.self_link]
+  name                  = "%s"
+  protocol              = "SSL"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_health_check.zero.self_link]
 }
 
 resource "google_compute_backend_service" "bar" {
-  name          = "%s"
-  protocol      = "SSL"
-  health_checks = [google_compute_health_check.zero.self_link]
+  name                  = "%s"
+  protocol              = "SSL"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_health_check.zero.self_link]
 }
 
 resource "google_compute_health_check" "zero" {
@@ -257,9 +260,10 @@ resource "google_compute_target_ssl_proxy" "with_certificate_map" {
 }
 
 resource "google_compute_backend_service" "foo" {
-  name          = "tf-test-backend-%s"
-  protocol      = "SSL"
-  health_checks = [google_compute_health_check.zero.self_link]
+  name                  = "tf-test-backend-%s"
+  protocol              = "SSL"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_health_check.zero.self_link]
 }
 
 resource "google_compute_health_check" "zero" {
@@ -311,9 +315,10 @@ resource "google_compute_target_ssl_proxy" "with_certificate_map" {
 }
 
 resource "google_compute_backend_service" "foo" {
-  name          = "tf-test-backend-%s"
-  protocol      = "SSL"
-  health_checks = [google_compute_health_check.zero.self_link]
+  name                  = "tf-test-backend-%s"
+  protocol              = "SSL"
+  load_balancing_scheme = "EXTERNAL"
+  health_checks         = [google_compute_health_check.zero.self_link]
 }
 
 resource "google_compute_health_check" "zero" {

--- a/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
@@ -107,6 +107,22 @@ The `http_get.http_headers.port` field of container startup probe and liveness p
 The `http_get.http_headers.name` field of container startup probe and liveness probe are now required in this resource. If `http_get.http_headers` field is used, add the sub field `http_get.http_headers.name` to your configuration after
 upgrading.
 
+## Resource: `google_compute_backend_service`
+
+### `load_balancing_scheme` default value changed to `EXTERNAL_MANAGED`
+
+The default value of `load_balancing_scheme` for `google_compute_backend_service` has been changed from `EXTERNAL` to `EXTERNAL_MANAGED`.
+Configurations that do not set `load_balancing_scheme` will now default to `EXTERNAL_MANAGED` instead of `EXTERNAL`.
+To maintain the previous behavior (Classic Application Load Balancer), set `load_balancing_scheme = "EXTERNAL"` explicitly.
+
+## Resource: `google_compute_global_forwarding_rule`
+
+### `load_balancing_scheme` default value changed to `EXTERNAL_MANAGED`
+
+The default value of `load_balancing_scheme` for `google_compute_global_forwarding_rule` has been changed from `EXTERNAL` to `EXTERNAL_MANAGED`.
+Configurations that do not set `load_balancing_scheme` will now default to `EXTERNAL_MANAGED` instead of `EXTERNAL`.
+To maintain the previous behavior (Classic Application Load Balancer), set `load_balancing_scheme = "EXTERNAL"` explicitly.
+
 ## Resource: `google_netapp_storage_pool`
 
 ### `scale_tier` has been removed


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Define default value for load_balancing_scheme as EXTERNAL_MANAGED instead of EXTERNAL 
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/23950


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: updated 'load-balancing-scheme' default value to 'EXTERNAL_MANAGED' for `google_compute_backend_service` and `google_compute_global_forwarding_rule`
```
