### PR TITLE
ces: add enable_snippets field under data_store_tool in google_ces_tool

### DIFF
--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -2161,6 +2161,15 @@ properties:
                             type: String
                             description: The prompt definition. If not set, default prompt will be used.
                             output: true
+                      - name: snippetsConfig
+                        type: NestedObject
+                        description: Snippets configuration.
+                        output: true
+                        properties:
+                          - name: enableSnippets
+                            type: Boolean
+                            description: Whether snippets are enabled.
+                            output: true
                       - name: summarizationConfig
                         type: NestedObject
                         description: Summarization configuration.

--- a/mmv1/products/ces/Tool.yaml
+++ b/mmv1/products/ces/Tool.yaml
@@ -844,6 +844,13 @@ properties:
                 - name: prompt
                   type: String
                   description: The prompt definition. If not set, default prompt will be used.
+            - name: snippetsConfig
+              type: NestedObject
+              description: Snippets configuration.
+              properties:
+                - name: enableSnippets
+                  type: Boolean
+                  description: Whether snippets are enabled.
             - name: summarizationConfig
               type: NestedObject
               description: Summarization configuration.

--- a/mmv1/templates/terraform/samples/services/ces/ces_tool_data_store_tool_engine_source_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_tool_data_store_tool_engine_source_basic.tf.tmpl
@@ -74,6 +74,9 @@ resource "google_ces_tool" "{{$.PrimaryResourceId}}" {
                 grounding_level = 3
                 disabled = false
             }
+            snippets_config {
+                enable_snippets = true
+            }
         }
 
         engine_source {

--- a/mmv1/third_party/terraform/services/ces/ces_tool_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_tool_test.go
@@ -483,6 +483,9 @@ resource "google_ces_tool" "ces_tool_data_store_tool_engine_source_basic" {
                 grounding_level = 3
                 disabled = false
             }
+            snippets_config {
+                enable_snippets = true
+            }
         }
 
         engine_source {


### PR DESCRIPTION
Add support for the `enable_snippets` field under `data_store_tool.modality_configs.snippets_config` in `google_ces_tool`.

Reference: b/543478643

```release-note:enhancement
ces: added `data_store_tool.modality_configs.snippets_config.enable_snippets` field to `google_ces_tool` resource
```
