### PR TITLE
vertexai: add port field to ReasoningEngine container_spec

### DIFF
--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -81,7 +81,6 @@ samples:
         ignore_read_extra:
           - 'deletion_policy'
   - name: 'vertex_ai_reasoning_engine_byoc'
-    skip_func: acctest.SkipTestUntil(t, "2026-05-15") # requires valid image in Artifact Registry, give time for things to settle
     skip_vcr: true # multiple IAM members
     primary_resource_id: 'reasoning_engine'
     steps:
@@ -771,6 +770,11 @@ properties:
               The Artifact Registry Docker image URI (e.g.,
               `us-central1-docker.pkg.dev/my-project/my-repo/my-image:tag`) of the
               container image that is to be run on each worker replica.
+          - name: 'port'
+            type: Integer
+            default_from_api: true
+            description: |-
+              Optional. The port that the container listens on for incoming requests. If not specified, defaults to 8080.
       - name: 'sourceCodeSpec'
         type: NestedObject
         conflicts:

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_byoc.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_byoc.tf.tmpl
@@ -6,6 +6,7 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
   spec {
     container_spec {
       image_uri = "us-central1-docker.pkg.dev/${data.google_project.project.project_id}/vertex-byoc/byoc-agent:latest" # image path
+      port      = 8080
     }
   }
 

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -621,6 +621,10 @@ resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
 
   spec {
     identity_type = "SERVICE_ACCOUNT"
+    container_spec {
+      image_uri = "us-docker.pkg.dev/cloudrun/container/hello"
+      port      = 8000
+    }
   }
 }
 `, context)
@@ -635,6 +639,10 @@ resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
 
   spec {
     identity_type = "AGENT_IDENTITY"
+    container_spec {
+      image_uri = "us-docker.pkg.dev/cloudrun/container/hello"
+      port      = 9000
+    }
   }
 }
 `, context)


### PR DESCRIPTION
Add `port` field to `google_vertex_ai_reasoning_engine.spec.container_spec`.

Issue: b/543478707

```release-note:enhancement
vertexai: added `spec.container_spec.port` field to `google_vertex_ai_reasoning_engine` resource
```
