### PR TITLE
colab: add workbench_runtime support to google_colab_notebook_execution

### DIFF
--- a/mmv1/products/colab/NotebookExecution.yaml
+++ b/mmv1/products/colab/NotebookExecution.yaml
@@ -24,6 +24,8 @@ base_url: 'projects/{{project}}/locations/{{location}}/notebookExecutionJobs'
 self_link: 'projects/{{project}}/locations/{{location}}/notebookExecutionJobs/{{notebook_execution_job_id}}'
 immutable: true
 create_url: 'projects/{{project}}/locations/{{location}}/notebookExecutionJobs?notebook_execution_job_id={{notebook_execution_job_id}}'
+timeouts:
+  insert_minutes: 60
 async:
   type: 'OpAsync'
   operation:
@@ -70,6 +72,29 @@ samples:
         test_env_vars:
           project_id: 'PROJECT_NAME'
           service_account: 'SERVICE_ACCT'
+        # Vertex AI GetNotebookExecutionJob API does not return workbenchRuntime in read responses.
+        ignore_read_extra:
+          - workbench_runtime.0.vm_image.0.project
+          - workbench_runtime.0.vm_image.0.family
+          - workbench_runtime.0.vm_image.0.name
+  - name: 'colab_notebook_execution_vm_image_name'
+    min_version: beta
+    primary_resource_id: 'notebook-execution'
+    steps:
+      - name: 'colab_notebook_execution_vm_image_name'
+        min_version: beta
+        resource_id_vars:
+          notebook_execution_job_id: 'colab-notebook-execution'
+          runtime_template_name: 'runtime-template-name'
+          bucket: 'my_bucket'
+        test_env_vars:
+          project_id: 'PROJECT_NAME'
+          service_account: 'SERVICE_ACCT'
+        # Vertex AI GetNotebookExecutionJob API does not return workbenchRuntime in read responses.
+        ignore_read_extra:
+          - workbench_runtime.0.vm_image.0.project
+          - workbench_runtime.0.vm_image.0.family
+          - workbench_runtime.0.vm_image.0.name
   - name: 'colab_notebook_execution_dataform'
     min_version: beta
     primary_resource_id: 'notebook-execution'
@@ -229,3 +254,33 @@ properties:
       - execution_user
       - service_account
     description: 'The service account to run the execution as.'
+  - name: 'workbenchRuntime'
+    type: NestedObject
+    # Vertex AI GetNotebookExecutionJob API does not return workbenchRuntime in read responses.
+    ignore_read: true
+    description: 'Configuration for a Workbench Instances-based environment.'
+    properties:
+      - name: 'vmImage'
+        type: NestedObject
+        description: |
+          Definition of a custom Compute Engine virtual machine image for starting
+          a notebook execution with the environment installed directly on the VM.
+        properties:
+          - name: 'project'
+            type: String
+            required: true
+            description: |
+              The name of the Google Cloud project that this VM image belongs to.
+              Format: `{project_id}`
+          - name: 'name'
+            type: String
+            description: 'Use this VM image name to find the image.'
+            exactly_one_of:
+              - workbench_runtime.0.vm_image.0.name
+              - workbench_runtime.0.vm_image.0.family
+          - name: 'family'
+            type: String
+            description: 'Use this VM image family to find the image; the newest image in this family will be used.'
+            exactly_one_of:
+              - workbench_runtime.0.vm_image.0.name
+              - workbench_runtime.0.vm_image.0.family

--- a/mmv1/templates/terraform/samples/services/colab/colab_notebook_execution_vm_image_name.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/colab/colab_notebook_execution_vm_image_name.tf.tmpl
@@ -66,13 +66,13 @@ resource "google_storage_bucket_object" "notebook" {
 resource "google_colab_notebook_execution" "{{$.PrimaryResourceId}}" {
   provider = google-beta
   notebook_execution_job_id = "{{index $.ResourceIdVars "notebook_execution_job_id"}}"
-  display_name = "Notebook execution full"
+  display_name = "Notebook execution vm image name"
   location = "us-central1"
 
   execution_timeout = "86400s"
   gcs_notebook_source {
-  uri = "gs://${google_storage_bucket_object.notebook.bucket}/${google_storage_bucket_object.notebook.name}"
-  generation = google_storage_bucket_object.notebook.generation
+    uri = "gs://${google_storage_bucket_object.notebook.bucket}/${google_storage_bucket_object.notebook.name}"
+    generation = google_storage_bucket_object.notebook.generation
   }
   
   service_account = "{{index $.TestEnvVars "service_account"}}"
@@ -83,7 +83,7 @@ resource "google_colab_notebook_execution" "{{$.PrimaryResourceId}}" {
   workbench_runtime {
     vm_image {
       project = "cloud-notebooks-managed"
-      family  = "workbench-instances-2603"
+      name    = "workbench-2603-20260809-2130-rc0"
     }
   }
 
@@ -92,5 +92,4 @@ resource "google_colab_notebook_execution" "{{$.PrimaryResourceId}}" {
     google_storage_bucket.output_bucket,
     google_colab_runtime_template.my_runtime_template,
   ]
-  
 }


### PR DESCRIPTION
Add support for `workbench_runtime` and nested `vm_image` (`project`, `name`, `family`) fields in `google_colab_notebook_execution`.

Fixes b/543479217

```release-note:enhancement
colab: added `workbench_runtime` and `workbench_runtime.vm_image` fields to `google_colab_notebook_execution` resource
```
