### PR TITLE
cloudbuild: Add list resources for Trigger and BitbucketServerConfig

### DIFF
--- a/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
+++ b/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
@@ -32,6 +32,7 @@ async:
   result:
     resource_inside_response: true
 autogen_async: true
+generate_list_resource: true
 include_in_tgc_next: true
 custom_code:
   encoder: templates/terraform/encoders/cloudbuild_bitbucketserver_config.go.tmpl

--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -34,6 +34,7 @@ update_verb: 'PATCH'
 import_format:
   - 'projects/{{project}}/triggers/{{trigger_id}}'
   - 'projects/{{project}}/locations/{{location}}/triggers/{{trigger_id}}'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -29,6 +29,7 @@ docs:
 id_format: 'projects/{{project}}/locations/{{location}}/triggers/{{trigger_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/triggers'
 self_link: 'projects/{{project}}/locations/{{location}}/triggers/{{trigger_id}}'
+collection_url_key: 'triggers'
 update_verb: 'PATCH'
 # import by default only works with old-style self links ending in a name
 import_format:
@@ -184,10 +185,9 @@ parameters:
     type: String
     description: |
       The [Cloud Build location](https://cloud.google.com/build/docs/locations) for the trigger.
-      If not specified, "global" is used.
     url_param_only: true
     immutable: true
-    default_value: "global"
+    required: true
 properties:
   - name: 'trigger_id'
     type: String


### PR DESCRIPTION
Add list resource support for CloudBuild Trigger and BitbucketServerConfig resources.

This enables users to query and list existing CloudBuild Triggers and BitbucketServerConfig resources using Terraform data sources.

Testing:
- Acceptance tests ran and PASSED:
  - `TestAccCloudBuildBitbucketServerConfigListQuery_generated` — PASS
  - `TestAccCloudBuildTriggerListQuery_generated` — PASS

Fixes included:
- Marked location parameter as `required: true` for Trigger resource
- Set `collection_url_key: 'triggers'` for Trigger resource to match API response schema

```release-note:enhancement
cloudbuild: Add list resource support for `google_cloudbuild_trigger` and `google_cloudbuild_bitbucket_server_config`
```
