### PR TITLE
vertexai: add google_vertex_ai_agent_anomaly_detection_scope resource

### DIFF
--- a/mmv1/products/vertexai/AgentAnomalyDetectionScope.yaml
+++ b/mmv1/products/vertexai/AgentAnomalyDetectionScope.yaml
@@ -1,0 +1,104 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: AgentAnomalyDetectionScope
+description: |-
+  Agent Anomaly Detection Scope in Vertex AI.
+references:
+  guides:
+    Official Documentation: https://cloud.google.com/vertex-ai/docs
+  api: https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.agentAnomalyDetectionScopes
+base_url: projects/{{project}}/locations/{{region}}/agentAnomalyDetectionScopes
+self_link: projects/{{project}}/locations/{{region}}/agentAnomalyDetectionScopes/{{agent_anomaly_detection_scope_id}}
+create_url: projects/{{project}}/locations/{{region}}/agentAnomalyDetectionScopes?agentAnomalyDetectionScopeId={{agent_anomaly_detection_scope_id}}
+import_format:
+  - projects/{{project}}/locations/{{region}}/agentAnomalyDetectionScopes/{{agent_anomaly_detection_scope_id}}
+immutable: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+sweeper:
+  prefixes:
+    - tf-test-
+async:
+  type: OpAsync
+  operation:
+    base_url: '{{op_id}}'
+  actions: [create, delete]
+  result:
+    resource_inside_response: true
+samples:
+  - name: vertex_ai_agent_anomaly_detection_scope_basic
+    primary_resource_id: agent_anomaly_detection_scope
+    exclude_test: true
+    steps:
+      - name: vertex_ai_agent_anomaly_detection_scope_basic
+        resource_id_vars:
+          scope_id: tf-test-scope-id
+        test_env_vars:
+          project: PROJECT_NAME
+parameters:
+  - name: region
+    type: String
+    description: The region of the AgentAnomalyDetectionScope. eg us-central1
+    url_param_only: true
+    immutable: true
+    default_from_api: true
+  - name: agentAnomalyDetectionScopeId
+    type: String
+    required: true
+    description: |-
+      The ID to use for the AgentAnomalyDetectionScope, which will become the final component of the AgentAnomalyDetectionScope's resource name.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: name
+    type: String
+    description: |-
+      The resource name of the AgentAnomalyDetectionScope.
+      Format: `projects/{project}/locations/{location}/agentAnomalyDetectionScopes/{agent_anomaly_detection_scope}`
+    output: true
+  - name: displayName
+    type: String
+    description: User-provided display name of the AgentAnomalyDetectionScope.
+  - name: logBuckets
+    type: Array
+    required: true
+    description: |-
+      Customer-owned Cloud Logging bucket resource names attached to this scope.
+      Format: `projects/{project}/locations/{location}/buckets/{bucket}`.
+    item_type:
+      type: String
+  - name: observabilityBuckets
+    type: Array
+    required: true
+    description: |-
+      Customer-owned Cloud Observability bucket resource names attached to this scope.
+      Format: `projects/{project}/locations/{location}/observationBuckets/{observation_bucket}`.
+    item_type:
+      type: String
+  - name: state
+    type: String
+    description: The lifecycle state of the scope.
+    output: true
+  - name: encryptionSpec
+    type: NestedObject
+    description: Customer-managed encryption key spec for a Scope.
+    immutable: true
+    properties:
+      - name: kmsKeyName
+        type: String
+        description: The Cloud KMS resource identifier of the customer-managed encryption key used to protect a resource.
+        immutable: true

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_agent_anomaly_detection_scope_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_agent_anomaly_detection_scope_basic.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_vertex_ai_agent_anomaly_detection_scope" "{{$.PrimaryResourceId}}" {
+  agent_anomaly_detection_scope_id = "{{index $.ResourceIdVars "scope_id"}}"
+  region                           = "us-central1"
+  display_name                     = "sample-scope"
+  log_buckets                      = [
+    "projects/{{index $.TestEnvVars "project"}}/locations/us-central1/buckets/_Default"
+  ]
+  observability_buckets            = [
+    "projects/{{index $.TestEnvVars "project"}}/locations/us-central1/buckets/_Default"
+  ]
+}

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_agent_anomaly_detection_scope_custom_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_agent_anomaly_detection_scope_custom_test.go
@@ -110,4 +110,3 @@ func testAccCheckVertexAIAgentAnomalyDetectionScopeDestroyProducer(t *testing.T)
 		return nil
 	}
 }
-

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_agent_anomaly_detection_scope_custom_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_agent_anomaly_detection_scope_custom_test.go
@@ -1,0 +1,113 @@
+package vertexai_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/vertexai"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func TestAccVertexAIAgentAnomalyDetectionScope(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"basic": testAccVertexAIAgentAnomalyDetectionScope_basicTest,
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccVertexAIAgentAnomalyDetectionScope_basicTest(t *testing.T) {
+	resourcemanager.BootstrapIamMembers(t, []resourcemanager.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@gcp-sa-aiplatform.iam.gserviceaccount.com",
+			Role:   "roles/logging.configWriter",
+		},
+	})
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"project":  envvar.GetTestProjectFromEnv(),
+		"scope_id": "tf-test-scope-id" + randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVertexAIAgentAnomalyDetectionScopeDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIAgentAnomalyDetectionScope_basic(context),
+			},
+			{
+				ResourceName:            "google_vertex_ai_agent_anomaly_detection_scope.agent_anomaly_detection_scope",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"agent_anomaly_detection_scope_id", "region"},
+			},
+			{
+				ResourceName:       "google_vertex_ai_agent_anomaly_detection_scope.agent_anomaly_detection_scope",
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				ImportStateKind:    resource.ImportBlockWithResourceIdentity,
+			},
+		},
+	})
+}
+
+func testAccVertexAIAgentAnomalyDetectionScope_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vertex_ai_agent_anomaly_detection_scope" "agent_anomaly_detection_scope" {
+  agent_anomaly_detection_scope_id = "%{scope_id}"
+  region                           = "us-central1"
+  display_name                     = "sample-scope"
+  log_buckets                      = [
+    "projects/%{project}/locations/us-central1/buckets/_Default"
+  ]
+  observability_buckets            = [
+    "projects/%{project}/locations/us-central1/buckets/_Default"
+  ]
+}
+`, context)
+}
+
+func testAccCheckVertexAIAgentAnomalyDetectionScopeDestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_vertex_ai_agent_anomaly_detection_scope" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
+			config := acctest.GoogleProviderConfig(t)
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, "https://us-central1-aiplatform.googleapis.com/v1beta1/{{name}}")
+			if err != nil {
+				return err
+			}
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
+			if err == nil {
+				return fmt.Errorf("VertexAIAgentAnomalyDetectionScope still exists at %s", url)
+			}
+		}
+		return nil
+	}
+}
+


### PR DESCRIPTION
Add support for `google_vertex_ai_agent_anomaly_detection_scope` resource in Magic Modules for Vertex AI Agent Anomaly Detection Scope.

b/542714682

```release-note:new-resource
vertexai: added `google_vertex_ai_agent_anomaly_detection_scope` resource
```
