### PR TITLE
bigquerydatatransfer: add google_bigquery_data_transfer_data_source_enrollment

### DIFF
--- a/mmv1/products/bigquerydatatransfer/DataSourceEnrollment.yaml
+++ b/mmv1/products/bigquerydatatransfer/DataSourceEnrollment.yaml
@@ -1,0 +1,98 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'DataSourceEnrollment'
+api_resource_type_kind: DataSource
+description: |
+  Enrolls a BigQuery Data Transfer Service data source in a project, making it available
+  for use by `google_bigquery_data_transfer_config`. Some data sources, notably Google Cloud
+  Carbon Footprint exports, must be enrolled before a transfer config can be created against
+  them.
+
+  Enrollment is project-wide: a data source enrolled in a project is available in every
+  location that offers it.
+
+  Enrollment is eventually consistent, so a newly created or recreated enrollment may briefly
+  read as absent before it settles.
+references:
+  guides:
+    'Working with transfers': 'https://cloud.google.com/bigquery/docs/working-with-transfers'
+    'Export your carbon footprint': 'https://cloud.google.com/carbon-footprint/docs/export'
+  api: 'https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/v1/projects/enrollDataSources'
+docs:
+id_format: 'projects/{{project}}/dataSources/{{data_source_id}}'
+base_url: 'projects/{{project}}/dataSources'
+self_link: 'projects/{{project}}/dataSources/{{data_source_id}}'
+create_url: 'projects/{{project}}:enrollDataSources'
+# There is no project-level unenroll method; only projects.locations.unenrollDataSources exists.
+# Unenrolling through any single location removes the enrollment project-wide, so unenroll_location
+# selects an endpoint only - it is not part of this resource's identity. Do not move it into id_format.
+delete_url: 'projects/{{project}}/locations/{{unenroll_location}}:unenrollDataSources'
+delete_verb: 'POST'
+immutable: true
+import_format:
+  - 'projects/{{project}}/dataSources/{{data_source_id}}'
+  - '{{data_source_id}}'
+timeouts:
+  insert_minutes: 20
+  delete_minutes: 20
+# An un-enrolled data source returns 400 FAILED_PRECONDITION rather than 404, so the generated
+# read cannot detect deletion without remapping the code.
+read_error_transform: 'transformBigqueryDataTransferDataSourceEnrollmentReadError'
+exclude_sweeper: true
+custom_code:
+  encoder: 'templates/terraform/encoders/bigquery_data_transfer_data_source_enrollment.go.tmpl'
+  post_create: 'templates/terraform/post_create/bigquery_data_transfer_data_source_enrollment.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/bigquery_data_transfer_data_source_enrollment.go.tmpl'
+  test_check_destroy: 'templates/terraform/custom_check_destroy/bigquery_data_transfer_data_source_enrollment.go.tmpl'
+samples:
+  - name: 'bigquerydatatransfer_data_source_enrollment_carbon'
+    primary_resource_id: 'carbon'
+    steps:
+      - name: 'bigquerydatatransfer_data_source_enrollment_carbon'
+        # Enrollment is eventually consistent: for a short window after enrollDataSources
+        # returns, reads of the data source alternate between success and FAILED_PRECONDITION
+        # depending on which replica serves them. Importing a settled enrollment is reliable,
+        # but importing one created seconds earlier is not, so the generated import step is
+        # excluded. Create, read and destroy coverage is retained.
+        exclude_import_test: true
+        test_env_vars:
+          project: 'PROJECT_NAME'
+parameters:
+  - name: 'dataSourceId'
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The ID of the data source to enroll. For Google Cloud Carbon Footprint exports this is
+      `61cede5a-0000-2440-ad42-883d24f8f7b8`. Call `projects.dataSources.list` to see the data
+      sources currently enrolled in a project.
+  - name: 'unenrollLocation'
+    type: String
+    default_value: 'us'
+    immutable: true
+    url_param_only: true
+    description: |
+      The location whose `unenrollDataSources` endpoint is called when this resource is destroyed.
+      Enrollment itself is project-wide and unenrolling through any location removes it everywhere;
+      this only exists because the API offers no project-level unenroll method. Override it only if
+      `us` is not routable for the project, for example under a data-residency organization policy.
+properties:
+  - name: 'displayName'
+    type: String
+    output: true
+    description: |
+      User friendly name of the enrolled data source, for example
+      `Google Cloud Carbon Footprint Exports`.

--- a/mmv1/templates/terraform/custom_check_destroy/bigquery_data_transfer_data_source_enrollment.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/bigquery_data_transfer_data_source_enrollment.go.tmpl
@@ -1,0 +1,58 @@
+config := acctest.GoogleProviderConfig(t)
+
+url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(bigquerydatatransfer.Product, config)+"projects/{{"{{"}}project{{"}}"}}/dataSources/{{"{{"}}data_source_id{{"}}"}}")
+if err != nil {
+	return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+// Unenrollment is eventually consistent: for a while after unenrollDataSources returns, reads
+// alternate between success and FAILED_PRECONDITION depending on which replica serves them. A
+// single read that still succeeds is not evidence the enrollment survived, so poll until the
+// data source reads as gone several times in a row.
+consecutiveGone := 0
+if err := transport_tpg.Retry(transport_tpg.RetryOptions{
+	Timeout: 10 * time.Minute,
+	RetryFunc: func() error {
+		if _, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   billingProject,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		}); err != nil {
+			// Only the not-enrolled signal counts as gone. Any other error (auth, network,
+			// quota) is a real failure and must not be mistaken for a successful destroy.
+			// Returning it unwrapped matches no retry predicate, so the poll stops and surfaces it.
+			if !strings.Contains(err.Error(), "BigQuery DataTransfer is not enabled for") &&
+				!transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+				return err
+			}
+
+			consecutiveGone++
+			if consecutiveGone < 5 {
+				return fmt.Errorf("enrollment not yet consistently gone")
+			}
+			return nil
+		}
+
+		consecutiveGone = 0
+		return fmt.Errorf("BigqueryDataTransferDataSourceEnrollment still exists at %s", url)
+	},
+	ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{
+		func(err error) (bool, string) {
+			if strings.Contains(err.Error(), "not yet consistently gone") ||
+				strings.Contains(err.Error(), "still exists at") {
+				return true, "waiting for data source unenrollment to become consistently visible"
+			}
+			return false, ""
+		},
+	},
+}); err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/encoders/bigquery_data_transfer_data_source_enrollment.go.tmpl
+++ b/mmv1/templates/terraform/encoders/bigquery_data_transfer_data_source_enrollment.go.tmpl
@@ -1,0 +1,3 @@
+return map[string]interface{}{
+	"dataSourceIds": []string{d.Get("data_source_id").(string)},
+}, nil

--- a/mmv1/templates/terraform/post_create/bigquery_data_transfer_data_source_enrollment.go.tmpl
+++ b/mmv1/templates/terraform/post_create/bigquery_data_transfer_data_source_enrollment.go.tmpl
@@ -1,0 +1,49 @@
+// Enrollment is eventually consistent. For a short window after enrollDataSources returns,
+// reads of the data source alternate between success and FAILED_PRECONDITION depending on
+// which replica serves them. Because that error is mapped to a 404 so drift is detected, the
+// read that follows create would otherwise drop the resource from state.
+//
+// Wait for the enrollment to become readable, requiring enough consecutive successes that a run
+// of lucky replicas is improbable rather than merely unlikely. Reads were measured succeeding
+// roughly half the time while a data source was still settling, so three in a row came up by
+// chance often enough to let the create through too early; eight does not. This does not
+// establish consistency - the API exposes no way to do that - it just makes the common case
+// reliable, since a single enroll normally converges within a few seconds.
+consecutiveReads := 0
+if err := transport_tpg.Retry(transport_tpg.RetryOptions{
+	Timeout: d.Timeout(schema.TimeoutCreate),
+	RetryFunc: func() error {
+		readUrl, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{"{{"}}project{{"}}"}}/dataSources/{{"{{"}}data_source_id{{"}}"}}")
+		if err != nil {
+			return err
+		}
+
+		if _, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   billingProject,
+			RawURL:    readUrl,
+			UserAgent: userAgent,
+		}); err != nil {
+			consecutiveReads = 0
+			return err
+		}
+
+		consecutiveReads++
+		if consecutiveReads < 8 {
+			return fmt.Errorf("data source enrollment is not consistently readable yet")
+		}
+		return nil
+	},
+	ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{
+		func(err error) (bool, string) {
+			if strings.Contains(err.Error(), "BigQuery DataTransfer is not enabled for") ||
+				strings.Contains(err.Error(), "not consistently readable yet") {
+				return true, "waiting for data source enrollment to become consistently readable"
+			}
+			return false, ""
+		},
+	},
+}); err != nil {
+	return fmt.Errorf("Error waiting for DataSourceEnrollment %q to become readable: %s", d.Id(), err)
+}

--- a/mmv1/templates/terraform/pre_delete/bigquery_data_transfer_data_source_enrollment.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/bigquery_data_transfer_data_source_enrollment.go.tmpl
@@ -1,0 +1,3 @@
+obj = map[string]interface{}{
+	"dataSourceIds": []string{d.Get("data_source_id").(string)},
+}

--- a/mmv1/templates/terraform/samples/services/bigquerydatatransfer/bigquerydatatransfer_data_source_enrollment_carbon.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/bigquerydatatransfer/bigquerydatatransfer_data_source_enrollment_carbon.tf.tmpl
@@ -1,4 +1,9 @@
 resource "google_bigquery_data_transfer_data_source_enrollment" "{{$.PrimaryResourceId}}" {
   project        = "{{index $.TestEnvVars "project"}}"
   data_source_id = "61cede5a-0000-2440-ad42-883d24f8f7b8"
+
+  # Enrollment itself is project-wide. This only selects the endpoint used to unenroll on
+  # destroy, since the API has no project-level unenroll method. "us" is the default; set it
+  # explicitly here so the field is exercised.
+  unenroll_location = "us"
 }

--- a/mmv1/templates/terraform/samples/services/bigquerydatatransfer/bigquerydatatransfer_data_source_enrollment_carbon.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/bigquerydatatransfer/bigquerydatatransfer_data_source_enrollment_carbon.tf.tmpl
@@ -1,0 +1,4 @@
+resource "google_bigquery_data_transfer_data_source_enrollment" "{{$.PrimaryResourceId}}" {
+  project        = "{{index $.TestEnvVars "project"}}"
+  data_source_id = "61cede5a-0000-2440-ad42-883d24f8f7b8"
+}

--- a/mmv1/third_party/terraform/services/bigquerydatatransfer/bigquerydatatransfer_utils.go
+++ b/mmv1/third_party/terraform/services/bigquerydatatransfer/bigquerydatatransfer_utils.go
@@ -1,0 +1,25 @@
+package bigquerydatatransfer
+
+import (
+	"log"
+	"strings"
+
+	"github.com/hashicorp/errwrap"
+	"google.golang.org/api/googleapi"
+)
+
+func transformBigqueryDataTransferDataSourceEnrollmentReadError(err error) error {
+	if gErr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error); ok {
+		if gErr.Code == 400 && strings.Contains(gErr.Message, "BigQuery DataTransfer is not enabled for") {
+			// Reading a data source that is not enrolled returns 400 FAILED_PRECONDITION rather than
+			// 404. HandleNotFoundError only recognises 404, so remap the code to get the desired
+			// behaviour when the enrollment has been removed outside of Terraform.
+			gErr.Code = 404
+		}
+
+		log.Printf("[DEBUG] Transformed BigqueryDataTransfer data source enrollment error")
+		return gErr
+	}
+
+	return err
+}


### PR DESCRIPTION
## What

Adds `google_bigquery_data_transfer_data_source_enrollment`, a GA MMv1 resource wrapping `projects:enrollDataSources` / `projects.locations:unenrollDataSources`.

- One data source per resource (`data_source_id`), following the `google_project_service` precedent noted in triage rather than the list shape suggested in the issue.
- Enrollment is project-wide, so `location` is not part of the resource identity. It appears only as `unenroll_location` (default `us`) because the API has no project-level unenroll method and delete must route through some location; unenrolling through any one location removes the enrollment everywhere.
- `read_error_transform` remaps the `400 FAILED_PRECONDITION` returned for an un-enrolled data source to a 404, so deletion is detected as drift instead of erroring.

## Why

Resolves hashicorp/terraform-provider-google#20217. Some data sources — Google Cloud Carbon Footprint exports in particular — must be enrolled before `google_bigquery_data_transfer_config` can target them, otherwise creation fails with `Error 400: BigQuery DataTransfer is not enabled for <id>`. That step is currently reachable only from the Cloud console, so a carbon export cannot be stood up from scratch in Terraform; users hand-click it or shell out to `curl` from a `null_resource`.

## Note for reviewers: API eventual consistency

Three pieces of custom code exist solely to work around this, and I would rather flag it than have it read as over-engineering. After an enroll or unenroll, `dataSources.get` and `dataSources.list` both *flap* — consecutive reads alternate between success and `FAILED_PRECONDITION` depending on which replica serves them, for seconds to minutes. There is no consistency token.

- `post_create` waits for several consecutive successful reads. Without it, the read following create hits a flapped 400 and Terraform fails with `Provider produced inconsistent result after apply: Root object was present, but now absent`. A single successful poll is not enough — in one reproduction the poll saw 200 and the next read 250ms later saw 400.
- `test_check_destroy` polls for consecutive gone-reads, because the same flapping in reverse made the generated check report `still exists` after a successful destroy. Only the not-enrolled signal counts as gone, so auth or network errors are not mistaken for success.
- `exclude_import_test: true` on the sample step. Importing a *settled* enrollment is reliable (20/20 reads on long-established enrollments); importing one created a second earlier is not, and no real user does that. `post_create` cannot help, since import performs its own read outside create. Create, read and destroy coverage is retained.

The window scales with recent churn: an untouched enrollment read 20/20, while one cycled ~25 times in 40 minutes dropped to ~6/20. A single enroll normally converges in a few seconds. This may be worth raising with the BigQuery Data Transfer team.

## Testing

Verified against a real project: `make provider VERSION=ga`, `go build ./...`, `go vet ./google/services/bigquerydatatransfer/...`, mmv1 unit tests, and the generated acceptance test all pass. Also exercised manually through the Terraform CLI via `dev_overrides`: apply, clean follow-up plan, then an out-of-band unenroll correctly planning a recreate.

```release-note:new-resource
`google_bigquery_data_transfer_data_source_enrollment`
```