### PR TITLE
agenticapplications: add AnalystAgentPersona resource

### DIFF
--- a/mmv1/products/agenticapplications/AnalystAgentPersona.yaml
+++ b/mmv1/products/agenticapplications/AnalystAgentPersona.yaml
@@ -1,0 +1,141 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: AnalystAgentPersona
+description: Description of AnalystAgentPersona
+base_url: projects/{{project}}/locations/{{location}}/analystAgentPersonas
+self_link: projects/{{project}}/locations/{{location}}/analystAgentPersonas/{{analyst_agent_persona_id}}
+create_url: projects/{{project}}/locations/{{location}}/analystAgentPersonas?analystAgentPersonaId={{analyst_agent_persona_id}}
+update_mask: true
+update_verb: PATCH
+autogen_status: QW5hbHlzdEFnZW50UGVyc29uYUF1dG9nZW5WMkFnZW50
+autogen_async: true
+async:
+  actions: ['create', 'update', 'delete']
+  operation:
+    base_url: '{{op_id}}'
+custom_code:
+  encoder: templates/terraform/encoder/agentic_applications_analyst_agent_persona.go.tmpl
+import_format:
+  - projects/{{project}}/locations/{{location}}/analystAgentPersonas/{{analyst_agent_persona_id}}
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+samples:
+  - name: agentic_applications_analyst_agent_persona_basic
+    primary_resource_id: primary
+    steps:
+      - name: agentic_applications_analyst_agent_persona_basic
+        resource_id_vars:
+          analyst_agent_persona_id: persona-id
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: The location of the analyst agent persona.
+    immutable: true
+    url_param_only: true
+  - name: analystAgentPersonaId
+    type: String
+    required: true
+    description: The ID of the analyst agent persona.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: name
+    type: String
+    output: true
+    description: The resource name of the analyst agent persona.
+  - name: createTime
+    type: String
+    output: true
+    description: Create time stamp.
+  - name: updateTime
+    type: String
+    output: true
+    description: Update time stamp.
+  - name: displayName
+    type: String
+    required: true
+    description: The display name of the persona, shown to users.
+  - name: displayDescription
+    type: String
+    description: The description of the persona, shown to users.
+  - name: modelDescription
+    type: String
+    description: The description of the persona review, used by the model.
+  - name: role
+    type: Enum
+    description: The role selected for this persona.
+    enum_values:
+      - ANALYST_ROLE_UNSPECIFIED
+      - ANALYST_ROLE_GENERIC_FINANCE_ANALYST
+      - ANALYST_ROLE_CORPORATE_FINANCE_ANALYST
+      - ANALYST_ROLE_CROSS_ASSET_DERIVATIVES_STRATEGIST
+      - ANALYST_ROLE_KYC_ANALYST
+      - ANALYST_ROLE_SALES_TRADER
+      - ANALYST_ROLE_QUANT_ANALYST
+      - ANALYST_ROLE_EXCHANGE_MANAGER
+      - ANALYST_ROLE_PORTFOLIO_MANAGER
+      - ANALYST_ROLE_WEALTH_MANAGER
+      - ANALYST_ROLE_INSTITUTIONAL_PORTFOLIO_STRATEGIST
+      - ANALYST_ROLE_MNA_EXECUTION_ANALYST
+      - ANALYST_ROLE_ECM_ORIGINATION_STRATEGIST
+      - ANALYST_ROLE_LEVERAGED_FINANCE_SPECIALIST
+      - ANALYST_ROLE_INVESTMENT_RESEARCH_ANALYST
+      - ANALYST_ROLE_CORPORATE_BANKING_ANALYST
+      - ANALYST_ROLE_CREDIT_RISK_STRATEGIST
+      - ANALYST_ROLE_BEHAVIORAL_FINANCIAL_STRATEGIST
+      - ANALYST_ROLE_FUND_ACCOUNTANT
+      - ANALYST_ROLE_MODEL_VALIDATION_AUDITOR
+      - ANALYST_ROLE_PRIVATE_EQUITY_SPECIALIST
+      - ANALYST_ROLE_TREASURY_ANALYST
+      - ANALYST_ROLE_VENTURE_CAPITAL_ANALYST
+      - ANALYST_ROLE_AML_INVESTIGATOR
+      - ANALYST_ROLE_DUE_DILIGENCE_ANALYST
+      - ANALYST_ROLE_INSURANCE_CLAIMS_ANALYST
+      - ANALYST_ROLE_SPECIALTY_LIABILITY_UNDERWRITER
+      - ANALYST_ROLE_CATASTROPHE_EXPOSURE_MODELER
+  - name: skills
+    type: Array
+    description: Skills for the agent.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: skillId
+          type: String
+          required: true
+          description: The identifier of the skill.
+        - name: description
+          type: String
+          description: The description of the skill.
+        - name: content
+          type: String
+          required: true
+          description: The markdown text content of the skill.
+        - name: references
+          type: Array
+          description: References for the skill.
+          item_type:
+            type: NestedObject
+            properties:
+              - name: referenceId
+                type: String
+                required: true
+                description: The identifier of the reference.
+              - name: content
+                type: String
+                required: true
+                description: The content of the reference.

--- a/mmv1/products/agenticapplications/product.yaml
+++ b/mmv1/products/agenticapplications/product.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'AgenticApplications'
+display_name: 'Agentic Applications'
+versions:
+  - name: 'ga'
+    base_url: 'https://agenticapplications.googleapis.com/v1main/'
+  - name: 'beta'
+    base_url: 'https://agenticapplications.googleapis.com/v1alpha/'
+scopes:
+  - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/templates/terraform/encoder/agentic_applications_analyst_agent_persona.go.tmpl
+++ b/mmv1/templates/terraform/encoder/agentic_applications_analyst_agent_persona.go.tmpl
@@ -1,0 +1,14 @@
+config := meta.(*transport_tpg.Config)
+project, err := tpgresource.GetProject(d, config)
+if err != nil {
+	return nil, err
+}
+location, err := tpgresource.GetLocation(d, config)
+if err != nil {
+	return nil, err
+}
+personaId := d.Get("analyst_agent_persona_id").(string)
+
+name := fmt.Sprintf("projects/%s/locations/%s/analystAgentPersonas/%s", project, location, personaId)
+obj["name"] = name
+return obj, nil

--- a/mmv1/templates/terraform/samples/services/agenticapplications/agentic_applications_analyst_agent_persona_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/agenticapplications/agentic_applications_analyst_agent_persona_basic.tf.tmpl
@@ -1,0 +1,8 @@
+resource "google_agentic_applications_analyst_agent_persona" "{{.PrimaryResourceId}}" {
+  analyst_agent_persona_id = "{{index $.ResourceIdVars "analyst_agent_persona_id"}}"
+  location                 = "us"
+  display_name             = "My Analyst Agent Persona"
+  display_description      = "Sample persona description"
+  model_description        = "Persona model description"
+  role                     = "ANALYST_ROLE_GENERIC_FINANCE_ANALYST"
+}

--- a/mmv1/third_party/terraform/services/agenticapplications/resource_agentic_applications_analyst_agent_persona_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/agenticapplications/resource_agentic_applications_analyst_agent_persona_test.go.tmpl
@@ -1,0 +1,79 @@
+package agenticapplications_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccAgenticApplicationsAnalystAgentPersona_update(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"analyst_agent_persona_id": "tf-test-persona-" + randomSuffix,
+		"random_suffix":            randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckAgenticApplicationsAnalystAgentPersonaDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgenticApplicationsAnalystAgentPersona_basic(context),
+			},
+			{
+				ResourceName:            "google_agentic_applications_analyst_agent_persona.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "analyst_agent_persona_id"},
+			},
+			{
+				Config: testAccAgenticApplicationsAnalystAgentPersona_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_agentic_applications_analyst_agent_persona.primary", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_agentic_applications_analyst_agent_persona.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "analyst_agent_persona_id"},
+			},
+		},
+	})
+}
+
+func testAccAgenticApplicationsAnalystAgentPersona_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_agentic_applications_analyst_agent_persona" "primary" {
+  provider = google-beta
+  analyst_agent_persona_id = "%{analyst_agent_persona_id}"
+  location                 = "us"
+  display_name             = "My Analyst Agent Persona"
+  display_description      = "Sample persona description"
+  model_description        = "Persona model description"
+  role                     = "ANALYST_ROLE_GENERIC_FINANCE_ANALYST"
+}
+`, context)
+}
+
+func testAccAgenticApplicationsAnalystAgentPersona_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_agentic_applications_analyst_agent_persona" "primary" {
+  provider = google-beta
+  analyst_agent_persona_id = "%{analyst_agent_persona_id}"
+  location                 = "us"
+  display_name             = "Updated Analyst Agent Persona"
+  display_description      = "Updated persona description"
+  model_description        = "Updated model description"
+  role                     = "ANALYST_ROLE_CORPORATE_FINANCE_ANALYST"
+}
+`, context)
+}


### PR DESCRIPTION
Add Terraform resource support for `google_agentic_applications_analyst_agent_persona`.

Fixes https://b.corp.google.com/issues/538188655

```release-note:new-resource
`google_agentic_applications_analyst_agent_persona`
```
