### PR TITLE
container: add node_pool_upgrade_concurrency_config to google_container_cluster

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2618,6 +2618,22 @@ func ResourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
+
+			"node_pool_upgrade_concurrency_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Description: `Node pool upgrade concurrency config of the cluster, used by node auto upgrade.`,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_count": {
+							Type:             schema.TypeInt,
+							Required:         true,
+							Description:      `No more than max_count node pools are upgraded concurrently.`,
+						},
+					},
+				},
+			},
 {{- end }}
 
 			"default_snat_status": {
@@ -3254,6 +3270,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		GkeAutoUpgradeConfig: expandGkeAutoUpgradeConfig(d.Get("gke_auto_upgrade_config")),
 {{- if ne $.TargetVersionName "ga" }}
 		ClusterTelemetry: expandClusterTelemetry(d.Get("cluster_telemetry")),
+		NodePoolUpgradeConcurrencyConfig: expandNodePoolUpgradeConcurrencyConfig(d.Get("node_pool_upgrade_concurrency_config")),
 {{- end }}
 		EnableTpu:               d.Get("enable_tpu").(bool),
 		NetworkConfig: &container.NetworkConfig{
@@ -3977,6 +3994,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if err := d.Set("cluster_telemetry", flattenClusterTelemetry(cluster.ClusterTelemetry)); err != nil {
+		return err
+	}
+
+	if err := d.Set("node_pool_upgrade_concurrency_config", flattenNodePoolUpgradeConcurrencyConfig(cluster.NodePoolUpgradeConcurrencyConfig)); err != nil {
 		return err
 	}
 {{- end }}
@@ -5876,6 +5897,49 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		log.Printf("[INFO] GKE cluster %s Cluster Telemetry has been updated to %#v", d.Id(), req.Update.DesiredClusterTelemetry)
 	}
+
+	if d.HasChange("node_pool_upgrade_concurrency_config") {
+		// Because GKE uses a non-RESTful update function, when removing the
+		// feature you need to specify a fairly full request body or it fails:
+		// "update": {"desiredNodePoolUpgradeConcurrencyConfig": {"maxCount": 0}}
+		req := &container.UpdateClusterRequest{}
+		if v, ok := d.GetOk("node_pool_upgrade_concurrency_config"); !ok {
+			req.Update = &container.ClusterUpdate{
+				DesiredNodePoolUpgradeConcurrencyConfig: &container.NodePoolUpgradeConcurrencyConfig{
+					MaxCount:        0,
+					ForceSendFields: []string{"MaxCount"},
+				},
+			}
+		} else {
+			req.Update = &container.ClusterUpdate{
+				DesiredNodePoolUpgradeConcurrencyConfig: expandNodePoolUpgradeConcurrencyConfig(v),
+			}
+		}
+		updateF := func() error {
+			log.Println("[DEBUG] updating node_pool_upgrade_concurrency_config")
+			name := containerClusterFullName(project, location, clusterName)
+			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
+			if config.UserProjectOverride {
+				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
+			}
+			op, err := clusterUpdateCall.Do()
+			if err != nil {
+				return err
+			}
+
+			// Wait until it's updated
+			err = ContainerOperationWait(config, op, project, location, "updating Node Pool Upgrade Concurrency Config", userAgent, d.Timeout(schema.TimeoutUpdate))
+			log.Println("[DEBUG] done updating node_pool_upgrade_concurrency_config")
+			return err
+		}
+
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s node pool upgrade concurrency config has been updated to %#v", d.Id(), req.Update.DesiredNodePoolUpgradeConcurrencyConfig)
+	}
 {{- end }}
 
 	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, userAgent, d.Timeout(schema.TimeoutUpdate)); err != nil {
@@ -7289,6 +7353,17 @@ func expandClusterTelemetry(configured interface{}) *container.ClusterTelemetry 
 	}
 }
 
+func expandNodePoolUpgradeConcurrencyConfig(configured interface{}) *container.NodePoolUpgradeConcurrencyConfig {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	config := l[0].(map[string]interface{})
+	return &container.NodePoolUpgradeConcurrencyConfig{
+		MaxCount: int64(config["max_count"].(int)),
+	}
+}
+
 {{ end }}
 func expandDefaultSnatStatus(configured interface{}) *container.DefaultSnatStatus {
 	l := configured.([]interface{})
@@ -8223,6 +8298,16 @@ func flattenClusterTelemetry(c *container.ClusterTelemetry) []map[string]interfa
 	if c != nil {
 		result = append(result, map[string]interface{}{
 			"type": c.Type,
+		})
+	}
+	return result
+}
+
+func flattenNodePoolUpgradeConcurrencyConfig(c *container.NodePoolUpgradeConcurrencyConfig) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	if c != nil {
+		result = append(result, map[string]interface{}{
+			"max_count": c.MaxCount,
 		})
 	}
 	return result

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -872,6 +872,9 @@ fields:
     api_field: 'nodePoolDefaults.nodeConfigDefaults.nodeKubeletConfig.insecureKubeletReadonlyPortEnabled'
   - field: 'node_pool_defaults.node_config_defaults.logging_variant'
     api_field: 'nodePoolDefaults.nodeConfigDefaults.loggingConfig.variantConfig.variant'
+{{- if ne $.TargetVersionName "ga" }}
+  - api_field: 'nodePoolUpgradeConcurrencyConfig.maxCount'
+{{- end }}
   - field: 'node_version'
     api_field: 'currentNodeVersion'
   - api_field: 'notificationConfig.pubsub.enabled'

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1526,6 +1526,61 @@ func TestAccContainerCluster_withTelemetryEnabled(t *testing.T) {
 		},
 	})
 }
+
+func TestAccContainerCluster_withNodePoolUpgradeConcurrencyConfig(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withNodePoolUpgradeConcurrencyConfig(clusterName, 2, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_node_pool_upgrade_concurrency_config", "node_pool_upgrade_concurrency_config.0.max_count", "2"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_node_pool_upgrade_concurrency_config",
+				ImportStateIdPrefix:     "us-central1-a/",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withNodePoolUpgradeConcurrencyConfig(clusterName, 5, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_node_pool_upgrade_concurrency_config", "node_pool_upgrade_concurrency_config.0.max_count", "5"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_node_pool_upgrade_concurrency_config",
+				ImportStateIdPrefix:     "us-central1-a/",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+			{
+				// Removing the block sends an explicit zero max_count to clear the field.
+				Config: testAccContainerCluster_withoutNodePoolUpgradeConcurrencyConfig(clusterName, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_node_pool_upgrade_concurrency_config", "node_pool_upgrade_concurrency_config.#", "0"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_node_pool_upgrade_concurrency_config",
+				ImportStateIdPrefix:     "us-central1-a/",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+		},
+	})
+}
 {{- end }}
 
 {{- if ne $.TargetVersionName "ga" }}
@@ -9177,6 +9232,39 @@ resource "google_container_cluster" "with_cluster_telemetry" {
   deletion_protection = false
 }
 `, clusterName, telemetryType, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withNodePoolUpgradeConcurrencyConfig(clusterName string, maxCount int, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_node_pool_upgrade_concurrency_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  node_pool_upgrade_concurrency_config {
+    max_count = %d
+  }
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
+}
+`, clusterName, maxCount, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withoutNodePoolUpgradeConcurrencyConfig(clusterName, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_node_pool_upgrade_concurrency_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
+}
+`, clusterName, networkName, subnetworkName)
 }
 {{- end }}
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -380,6 +380,10 @@ clusters with private nodes. Structure is [documented below](#nested_private_clu
    [ClusterTelemetry](https://cloud.google.com/monitoring/kubernetes-engine/installing#controlling_the_collection_of_application_logs) feature,
    Structure is [documented below](#nested_cluster_telemetry).
 
+* `node_pool_upgrade_concurrency_config` - (Optional, [Beta](../guides/provider_versions.html.markdown))
+   Node pool upgrade concurrency config of the cluster, used by node auto upgrade.
+   Structure is [documented below](#nested_node_pool_upgrade_concurrency_config).
+
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
@@ -513,6 +517,9 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
 <a name="nested_cluster_telemetry"></a>The `cluster_telemetry` block supports
 * `type` - Telemetry integration for the cluster. Supported values (`ENABLED, DISABLED, SYSTEM_ONLY`);
    `SYSTEM_ONLY` (Only system components are monitored and logged) is only available in GKE versions 1.15 and later.
+
+<a name="nested_node_pool_upgrade_concurrency_config"></a>The `node_pool_upgrade_concurrency_config` block supports
+* `max_count` - (Required) No more than `max_count` node pools are upgraded concurrently by node auto upgrade.
 
 <a name="nested_addons_config"></a>The `addons_config` block supports:
 

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
@@ -2435,6 +2435,22 @@ func ResourceContainerCluster() *schema.Resource {
 				},
 			},
 
+			"node_pool_upgrade_concurrency_config": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Node pool upgrade concurrency config of the cluster, used by node auto upgrade.`,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_count": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: `No more than max_count node pools are upgraded concurrently.`,
+						},
+					},
+				},
+			},
+
 			"default_snat_status": {
 				Type:        schema.TypeList,
 				MaxItems:    1,


### PR DESCRIPTION
## What

- Adds a beta-only `node_pool_upgrade_concurrency_config` block with a `max_count` field to `google_container_cluster`, mapping to `Cluster.nodePoolUpgradeConcurrencyConfig` and `ClusterUpdate.desiredNodePoolUpgradeConcurrencyConfig`.
- Wires create, read and update. Removing the block sends an explicit zero `max_count` with `ForceSendFields`, matching how `workload_identity_config` already handles GKE's non-RESTful update.
- Acceptance test covers create, update and removal of the block.

## Why

- The field caps how many node pools GKE upgrades concurrently during node auto-upgrade. It is available in the v1beta1 API and via `gcloud beta container clusters update --node-pool-upgrade-concurrency-config`, but had no Terraform equivalent.
- It is beta-only — the field is absent from `container/v1` — so schema, expand, flatten, create, read and update are all behind version guards, and the field is excluded from the GA meta.yaml.
- The field is `Optional` and not `Computed`: GKE returns no value for it on a cluster that never set it, so marking it Computed would only make the block impossible to clear.

```release-note:enhancement
container: added `node_pool_upgrade_concurrency_config` field to `google_container_cluster` resource (beta)
```