### PR TITLE
stop echoing credential contents in GetCredentials error

### DIFF
--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -626,7 +626,7 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 		if c.UniverseDomain != "" && c.UniverseDomain != "googleapis.com" {
 			creds, err := transport.Creds(c.Context, option.WithCredentialsJSON([]byte(contents)), option.WithScopes(clientScopes...), internaloption.EnableJwtWithScope())
 			if err != nil {
-				return googleoauth.Credentials{}, fmt.Errorf("unable to parse credentials from '%s': %s", contents, err)
+				return googleoauth.Credentials{}, fmt.Errorf("unable to parse credentials: %s", err)
 			}
 			log.Printf("[INFO] Authenticating using configured Google JSON 'credentials'...")
 			log.Printf("[INFO]   -- Scopes: %s", clientScopes)
@@ -635,7 +635,7 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 		} else {
 			creds, err := transport.Creds(c.Context, option.WithCredentialsJSON([]byte(contents)), option.WithScopes(clientScopes...))
 			if err != nil {
-				return googleoauth.Credentials{}, fmt.Errorf("unable to parse credentials from '%s': %s", contents, err)
+				return googleoauth.Credentials{}, fmt.Errorf("unable to parse credentials: %s", err)
 			}
 			log.Printf("[INFO] Authenticating using configured Google JSON 'credentials'...")
 			log.Printf("[INFO]   -- Scopes: %s", clientScopes)

--- a/mmv1/third_party/terraform/transport/config_test.go
+++ b/mmv1/third_party/terraform/transport/config_test.go
@@ -2,8 +2,10 @@ package transport_test
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -235,6 +237,29 @@ func TestConfigLoadAndValidate_accountFileJSONInvalid(t *testing.T) {
 
 	if config.LoadAndValidate(context.Background()) == nil {
 		t.Fatalf("expected error, but got nil")
+	}
+}
+
+func TestGetCredentials_doesNotLeakCredentialsInError(t *testing.T) {
+	// A service-account key whose "type" is corrupted: still valid JSON, so it
+	// reaches the credential load and fails to parse there. The returned error
+	// surfaces to the terminal and CI logs, so it must not echo the key material.
+	const secret = "MIISECRETKEYMATERIAL_DO_NOT_LEAK"
+	creds := fmt.Sprintf(`{"type":"service_acount","project_id":"my-proj","private_key_id":"abc","private_key":"-----BEGIN PRIVATE KEY-----\n%s\n-----END PRIVATE KEY-----\n","client_email":"sa@my-proj.iam.gserviceaccount.com","token_uri":"https://oauth2.googleapis.com/token"}`, secret)
+
+	config := &transport_tpg.Config{
+		Context:     context.Background(),
+		Credentials: creds,
+		Project:     "my-gce-project",
+		Region:      "us-central1",
+	}
+
+	_, err := config.GetCredentials([]string{testOauthScope}, false)
+	if err == nil {
+		t.Fatalf("expected an error loading invalid credentials, got nil")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("credentials leaked in error message: %s", err)
 	}
 }
 


### PR DESCRIPTION
`GetCredentials` resolves the provider `credentials` argument (a service account key, private key included) and, when the google auth library cannot load it, returns `unable to parse credentials from '<contents>': <err>` in `transport/config.go`. Any credentials value that is valid JSON but not loadable reaches that branch, so a mistyped or truncated key file has its full contents surfaced in a provider error that Terraform prints to the terminal and to CI logs, none of which is redacted.

Drop the credential contents from both error strings so only the underlying parse error is shown, which is what every other error path in this function already does. Keeping the redaction in the callee means no caller has to remember to scrub credentials before surfacing the failure.

```release-note:bug
provider: fixed an issue where an invalid `credentials` value could be echoed back in the error message when it failed to parse
```
