### PR TITLE
Add NetApp Trial Resource

### DIFF
--- a/mmv1/products/netapp/Trial.yaml
+++ b/mmv1/products/netapp/Trial.yaml
@@ -1,0 +1,114 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Trial
+description: "A 30-day free trial for Google Cloud NetApp Volumes.\nIt is global in scope for a project but requires to be created in a valid cloud region in which Google Cloud NetApp Volumes is available.\n\n**Note:** Modifying the `location` of this resource will cause Terraform to destroy and recreate the trial. \nBecause Google Cloud enforces a limit of one free trial per project every 12 months, this recreation will fail. \nIt is highly recommended to use the `lifecycle { prevent_destroy = true }` block on this resource.\n"
+references:
+  guides:
+    GCNV Documentation: https://docs.cloud.google.com/netapp/volumes/docs
+base_url: projects/{{project}}/locations/{{location}}/trial
+self_link: projects/{{project}}/locations/{{location}}/trial
+create_url: projects/{{project}}/locations/{{location}}/trial:subscribeTrial
+delete_url: projects/{{project}}/locations/{{location}}/trial:endTrial
+delete_verb: POST
+id_format: projects/{{project}}/locations/{{location}}/trial
+import_format:
+  - projects/{{project}}/locations/{{location}}/trial
+timeouts:
+  insert_minutes: 20
+  delete_minutes: 20
+exclude_sweeper: true
+async:
+  type: OpAsync
+  operation:
+    base_url: '{{op_id}}'
+  actions: [create, delete]
+  result:
+    resource_inside_response: false
+autogen_async: true
+exclude_tgc: true
+custom_code:
+  pre_delete: templates/terraform/pre_delete/netapp_trial.go.tmpl
+  test_check_destroy: templates/terraform/custom_check_destroy/netapp_trial.go.tmpl
+examples:
+  - name: netapp_trial
+    primary_resource_id: default
+    skip_test: "Skipping due to 1 free trial per project per year quota limit."
+parameters:
+  - name: location
+    type: String
+    description: |
+      Name of the location.
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: actionOnDestroy
+    type: String
+    description: |
+      The action to take when the trial is destroyed in Terraform.
+      If set to `OPT_OUT`, the trial is cancelled. If set to `UPGRADED`, the trial is transitioned to a paid account.
+    url_param_only: true
+    default_value: OPT_OUT
+  - name: providedOptOutReasons
+    type: Array
+    item_type:
+      type: String
+    description: |
+      Optional. Contains the reasons for opting out of the free trial when using the `OPT_OUT` action.
+    url_param_only: true
+properties:
+  - name: name
+    type: String
+    description: |
+      The resource name of the trial.
+      Format: projects/{project}/locations/{location}/trial
+    output: true
+  - name: startTime
+    type: Time
+    description: |
+      The time when the trial started.
+    output: true
+  - name: endTime
+    type: Time
+    description: |
+      The time when the trial ends.
+    output: true
+  - name: state
+    type: Enum
+    description: |
+      The state of the trial.
+      Possible values are: `ACTIVE`, `INACTIVE`, `ELIGIBLE`, `INELIGIBLE`.
+    output: true
+    enum_values:
+      - ACTIVE
+      - INACTIVE
+      - ELIGIBLE
+      - INELIGIBLE
+  - name: exitReason
+    type: Enum
+    description: |
+      The reason for exiting the trial.
+      Possible values are: `EXPIRED`, `UPGRADED`, `OPT_OUT`.
+    output: true
+    enum_values:
+      - EXPIRED
+      - UPGRADED
+      - OPT_OUT
+  - name: optOutReasons
+    type: Array
+    item_type:
+      type: String
+    description: |
+      Contains the reasons for opting out of the free trial if exit reason is OPT_OUT.
+    output: true

--- a/mmv1/templates/terraform/custom_check_destroy/netapp_trial.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/netapp_trial.go.tmpl
@@ -1,0 +1,27 @@
+config := acctest.GoogleProviderConfig(t)
+url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(netapp.Product, config)+"projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/trial")
+if err != nil {
+	return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: config.UserAgent,
+})
+if err != nil {
+	// If it fails with a 404, we are good.
+	return nil
+}
+
+if v, ok := res["state"]; ok && v != "INACTIVE" {
+	return fmt.Errorf("NetappTrial is not INACTIVE, state is %s", v)
+}

--- a/mmv1/templates/terraform/examples/netapp_trial.tf.tmpl
+++ b/mmv1/templates/terraform/examples/netapp_trial.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_netapp_trial" "{{$.PrimaryResourceId}}" {
+  location = "us-central1"
+
+  # Optional: Provide an exit reason and feedback when the trial is destroyed.
+  action_on_destroy        = "OPT_OUT"
+  provided_opt_out_reasons = ["Too expensive", "Missing feature"]
+
+  # It is highly recommended to include this lifecycle block.
+  # Modifying the location will cause Terraform to destroy and recreate the trial,
+  # but Google Cloud strictly enforces a limit of one trial per project every 12 months.
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/mmv1/templates/terraform/pre_delete/netapp_trial.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/netapp_trial.go.tmpl
@@ -1,0 +1,14 @@
+if obj == nil {
+    obj = make(map[string]interface{})
+}
+
+action := "OPT_OUT"
+if v, ok := d.GetOk("action_on_destroy"); ok {
+    action = v.(string)
+}
+
+obj["exitReason"] = action
+
+if v, ok := d.GetOk("provided_opt_out_reasons"); ok {
+    obj["optOutReasons"] = v.([]interface{})
+}


### PR DESCRIPTION
Adds Terraform support for the Google Cloud NetApp Volumes (GCNV) Trial resource.

### Implementation Details:
- **Custom Delete Logic:** The `endTrial` API endpoint requires `exitReason` and optionally `optOutReasons` to be passed in the request body. Because these fields are not part of the `subscribeTrial` (CREATE) request body, they are implemented as Terraform-only parameters (`action_on_destroy` and `provided_opt_out_reasons`) using the `url_param_only: true` flag. This isolates them from the `CREATE` request, and a custom `pre_delete` hook maps them directly into the `endTrial` JSON payload during `terraform destroy`.
- **AIP-156 Singleton Validation:** Because the Trial resource behaves as a pseudo-singleton, ending the trial transitions it to an `INACTIVE` state and returns `200 OK` rather than yielding standard `404 Not Found` teardown responses. A custom `test_check_destroy` template has been added to safely validate the `INACTIVE` REST response during testing.
- **Testing**: The automated VCR tests use skip_test natively inside the generated test file. Google Cloud NetApp Volumes strictly enforces a quota of 1 free trial per project every 12 months. Running automated tests in the shared CI projects would instantly exhaust this quota and permanently break the pipeline for a year.
- **Verification:** The full `CREATE`, `READ` (import), and `DELETE` lifecycle (including the custom parameter injection and the `INACTIVE` destroy validation) has been manually verified end-to-end against the Google Cloud Staging sandbox.

```
 [hi on] anujjagrawal@anujagrawal:~/go/src/github.com/hashicorp/terraform-provider-google-beta$ TF_ACC=1 go test ./google-beta/services/netapp -v -run TestAccNetappTrial_netappTrialExample
  === RUN   TestAccNetappTrial_netappTrialExample
  === PAUSE TestAccNetappTrial_netappTrialExample
  === CONT  TestAccNetappTrial_netappTrialExample
  --- PASS: TestAccNetappTrial_netappTrialExample (37.01s)
  PASS
  ok      github.com/hashicorp/terraform-provider-google-beta/google-beta/services/netapp    37.241s
```

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```