### PR TITLE
vertexai: add memory customization fields to google_vertex_ai_reasoning_engine

### DIFF
--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -1102,6 +1102,87 @@ properties:
                   type: Boolean
                   description: |-
                     Optional. Generate memories in the third person if set to true.
+                - name: 'disableNaturalLanguageMemories'
+                  type: Boolean
+                  description: |-
+                    Optional. If true, natural language memory generation is disabled for the
+                    scopes that this customization config applies to. Set this to true when you
+                    only want to generate structured memories.
+                - name: 'generateMemoriesExamples'
+                  type: Array
+                  description: |-
+                    Optional. Few-shot examples of how to generate memories for the scopes that
+                    this customization config applies to. Each example pairs an input conversation
+                    with the memories that are expected to be generated from it.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'conversationSource'
+                        type: NestedObject
+                        description: |-
+                          Optional. The input conversation that the example memories are generated from.
+                        properties:
+                          - name: 'events'
+                            type: Array
+                            description: |-
+                              Optional. The conversation events of the example.
+                            item_type:
+                              type: NestedObject
+                              properties:
+                                - name: 'content'
+                                  type: NestedObject
+                                  required: true
+                                  description: |-
+                                    Required. The content of the event. Only textual content is
+                                    supported in Terraform.
+                                  properties:
+                                    - name: 'role'
+                                      type: String
+                                      description: |-
+                                        Optional. The producer of the content, such as "user" or "model".
+                                    - name: 'parts'
+                                      type: Array
+                                      description: |-
+                                        Optional. The ordered parts that make up the content.
+                                      item_type:
+                                        type: NestedObject
+                                        properties:
+                                          - name: 'text'
+                                            type: String
+                                            description: |-
+                                              Optional. The text content of the part.
+                      - name: 'generatedMemories'
+                        type: Array
+                        description: |-
+                          Optional. The memories that are expected to be generated from the input
+                          conversation. An empty list indicates that no memories are expected to be
+                          generated for the input conversation.
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: 'fact'
+                              type: String
+                              required: true
+                              description: |-
+                                Required. The fact to generate a memory from.
+                            - name: 'topics'
+                              type: Array
+                              description: |-
+                                Optional. The topics that the expected memory should be associated with.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'managedMemoryTopic'
+                                    type: String
+                                    description: |-
+                                      Optional. The managed memory topic that the memory should be
+                                      associated with (e.g. USER_PERSONAL_INFO, USER_PREFERENCES,
+                                      KEY_CONVERSATION_DETAILS, EXPLICIT_INSTRUCTIONS).
+                                  - name: 'customMemoryTopicLabel'
+                                    type: String
+                                    description: |-
+                                      Optional. The label of the custom memory topic that the memory
+                                      should be associated with.
           - name: 'structuredMemoryConfigs'
             type: Array
             description: |-

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
@@ -36,6 +36,32 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
             managed_topic_enum = "USER_PREFERENCES"
           }
         }
+        generate_memories_examples {
+          conversation_source {
+            events {
+              content {
+                role = "user"
+                parts {
+                  text = "Keep your answers short, I don't have much time."
+                }
+              }
+            }
+            events {
+              content {
+                role = "model"
+                parts {
+                  text = "Understood, I'll keep it brief."
+                }
+              }
+            }
+          }
+          generated_memories {
+            fact = "Prefers short answers."
+            topics {
+              managed_memory_topic = "USER_PREFERENCES"
+            }
+          }
+        }
       }
 
       # 2. Session-level Customization Config (Transient scratchpad)

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -890,6 +890,168 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 }
 `, context)
 }
+
+func TestAccVertexAIReasoningEngine_memoryCustomizationUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIReasoningEngine_memoryCustomizationGenerateMemoriesExamples(context),
+			},
+			{
+				ResourceName:      "google_vertex_ai_reasoning_engine.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccVertexAIReasoningEngine_memoryCustomizationDisableNaturalLanguageMemories(context),
+			},
+			{
+				ResourceName:      "google_vertex_ai_reasoning_engine.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccVertexAIReasoningEngine_memoryCustomizationGenerateMemoriesExamples(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_vertex_ai_reasoning_engine" "primary" {
+  provider     = google-beta
+  display_name = "tf-test-reasoning-engine-%{random_suffix}"
+  description  = "Reasoning engine testing memory customization"
+  region       = "us-central1"
+
+  context_spec {
+    memory_bank_config {
+      generation_config {
+        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-2.5-flash"
+      }
+      similarity_search_config {
+        embedding_model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"
+      }
+      customization_configs {
+        scope_keys = ["user_id"]
+        memory_topics {
+          managed_memory_topic {
+            managed_topic_enum = "USER_PREFERENCES"
+          }
+        }
+        memory_topics {
+          custom_memory_topic {
+            label       = "jargon"
+            description = "Domain-specific terms used by the user."
+          }
+        }
+        generate_memories_examples {
+          conversation_source {
+            events {
+              content {
+                role = "user"
+                parts {
+                  text = "Keep your answers short, I don't have much time."
+                }
+              }
+            }
+            events {
+              content {
+                role = "model"
+                parts {
+                  text = "Understood, I'll keep it brief."
+                }
+              }
+            }
+          }
+          generated_memories {
+            fact = "Prefers short answers."
+            topics {
+              managed_memory_topic = "USER_PREFERENCES"
+            }
+          }
+        }
+        generate_memories_examples {
+          conversation_source {
+            events {
+              content {
+                role = "user"
+                parts {
+                  text = "What's the weather like today?"
+                }
+              }
+            }
+          }
+          # No memories are expected to be generated for this conversation.
+          generated_memories {
+            fact = "Asks about the weather."
+            topics {
+              custom_memory_topic_label = "jargon"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccVertexAIReasoningEngine_memoryCustomizationDisableNaturalLanguageMemories(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_vertex_ai_reasoning_engine" "primary" {
+  provider     = google-beta
+  display_name = "tf-test-reasoning-engine-%{random_suffix}"
+  description  = "Reasoning engine testing memory customization"
+  region       = "us-central1"
+
+  context_spec {
+    memory_bank_config {
+      generation_config {
+        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-2.5-flash"
+      }
+      similarity_search_config {
+        embedding_model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"
+      }
+      customization_configs {
+        scope_keys                        = ["user_id"]
+        disable_natural_language_memories = true
+      }
+      structured_memory_configs {
+        scope_keys = ["user_id"]
+        schema_configs {
+          id            = "user-profile"
+          memory_schema = jsonencode({
+            type = "OBJECT"
+            properties = {
+              name = {
+                type        = "STRING"
+                description = "Name of the user."
+              }
+            }
+          })
+        }
+      }
+    }
+  }
+}
+`, context)
+}
 {{- end }}
 
 func TestAccVertexAIReasoningEngine_apiParityExternal(t *testing.T) {


### PR DESCRIPTION
Follow-up to #18498, split out per [reviewer request](https://github.com/GoogleCloudPlatform/magic-modules/pull/18498#discussion_r3714714781).

Adds the two remaining `contextSpec.memoryBankConfig.customizationConfigs[]` fields for API parity:

- `disable_natural_language_memories`
- `generate_memories_examples` (few-shot examples: input conversation → expected memories)

**On documentation:** the [REST API reference page](https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1beta1/projects.locations.reasoningEngines) is not up to date — its `MemoryBankConfig` section omits `customizationConfigs` entirely. The fields are public and documented in:

- [v1beta1 discovery document](https://aiplatform.googleapis.com/$discovery/rest?version=v1beta1) — `GoogleCloudAiplatformV1beta1MemoryBankCustomizationConfig`, `...GenerateMemoriesExample`
- [Memory Bank setup guide — customization config](https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank/setup#customization-config)
- [Memory Profiles guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/memory-bank/profiles#schema) (`disable_natural_language_memories`)
- [Python SDK type reference](https://docs.cloud.google.com/python/docs/reference/vertexai/latest/vertexai._genai.types.MemoryBankCustomizationConfig)

Per-attribute source references are added as inline review comments on the YAML.

**Test coverage:** new handwritten `TestAccVertexAIReasoningEngine_memoryCustomizationUpdate` exercises both fields (create with examples + managed/custom topics, update to structured-only with NL memories disabled, import verify at each step), and the `vertex_ai_reasoning_engine_context_spec` example now includes `generate_memories_examples`.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vertexai: added `context_spec.memory_bank_config.customization_configs.disable_natural_language_memories` and `context_spec.memory_bank_config.customization_configs.generate_memories_examples` fields to `google_vertex_ai_reasoning_engine` (beta)
```