### PR TITLE
Update project name in TestAccProjectServiceListResource

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service_test.go
@@ -20,7 +20,7 @@ func TestAccProjectServiceListResource_queryIdentity(t *testing.T) {
 	t.Parallel()
 
 	service := "iam.googleapis.com"
-	project := resourcemanager.BootstrapProject(t, "tf-boot-proj-svc-list-", envvar.GetTestBillingAccountFromEnv(t), []string{service}).ProjectId
+	project := resourcemanager.BootstrapProject(t, "tf-boot-rms-list-", envvar.GetTestBillingAccountFromEnv(t), []string{service}).ProjectId
 
 	acctest.VcrTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{


### PR DESCRIPTION
The existing pattern ends up exceeding the max project ID length of 30 characters.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28063

```release-note:none

```
