### PR TITLE
tgc: guard send_empty_value against unconfigured nil properties

### DIFF
--- a/mmv1/templates/tgc/resource_converter.go.tmpl
+++ b/mmv1/templates/tgc/resource_converter.go.tmpl
@@ -129,7 +129,7 @@ func Get{{ $.ResourceName -}}ApiObject(d tpgresource.TerraformResourceData, conf
 {{- if not $prop.SendEmptyValue }}
     } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.CamelizeProperty -}}Prop)) && (ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop)) {
 {{- else }}
-    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop) {
+    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); ok || (v != nil && !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop)) {
 {{- end }}
         obj["{{ $prop.ApiName -}}"] = {{ $prop.CamelizeProperty -}}Prop
     }

--- a/mmv1/templates/tgc_next/tfplan2cai/resource_converter.go.tmpl
+++ b/mmv1/templates/tgc_next/tfplan2cai/resource_converter.go.tmpl
@@ -131,7 +131,7 @@ func Get{{ $.ResourceName -}}CaiObject(d tpgresource.TerraformResourceData, conf
 {{- if and (not $prop.SendEmptyValue) (not $prop.TGCSendEmptyValue) }}
     } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.CamelizeProperty -}}Prop)) && (ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop)) {
 {{- else }}
-    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop) {
+    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); ok || (v != nil && !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop)) {
 {{- end }}
         obj["{{ $prop.ApiName -}}"] = {{ $prop.CamelizeProperty -}}Prop
     }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

prevents the failure appearing in https://github.com/GoogleCloudPlatform/magic-modules/pull/18585. I'm adding this to the 8.0.0 feature branch because it's only really needed for https://github.com/GoogleCloudPlatform/magic-modules/pull/18585, and will be propagated back to `main` during the feature branch merge.

In TGC, `d.GetOkExists` returns `(nil, false)` for unconfigured fields while `d.Get` returns the schema zero value (e.g. `""`). The converter condition `ok || !reflect.DeepEqual(v, prop)` compared `nil` vs `""`, treating unconfigured fields as modified and incorrectly emitting zero values into CAI assets.

Adding `v != nil` ensures unconfigured fields are omitted as intended.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
