### PR TITLE
cloudrunv2: add sandbox_launcher to google_cloud_run_v2_job

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -66,6 +66,14 @@ samples:
           cloud_run_job_name: cloudrun-job
         ignore_read_extra:
           - deletion_protection
+  - name: cloudrunv2_job_sandbox
+    primary_resource_id: default
+    steps:
+      - name: cloudrunv2_job_sandbox
+        resource_id_vars:
+          cloud_run_job_name: cloudrun-job
+        ignore_read_extra:
+          - deletion_protection
   - name: cloudrunv2_job_sql
     primary_resource_id: default
     steps:
@@ -433,6 +441,9 @@ properties:
                       - name: containerPort
                         type: Integer
                         description: Port number the container listens on. This must be a valid TCP port number, 0 < containerPort < 65536.
+                - name: sandboxLauncher
+                  type: Boolean
+                  description: Indicates that this container can act as a sandbox supervisor and launch sandboxes.
                 - name: volumeMounts
                   type: Array
                   description: Volume to mount into the container's filesystem.

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_job_sandbox.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_job_sandbox.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_cloud_run_v2_job" "{{$.PrimaryResourceId}}" {
+  name                = "{{index $.ResourceIdVars "cloud_run_job_name"}}"
+  location            = "us-central1"
+  deletion_protection = false
+  launch_stage        = "BETA"
+
+  template {
+    template {
+      containers {
+        image            = "us-docker.pkg.dev/cloudrun/container/job"
+        sandbox_launcher = true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds `sandbox_launcher` to `google_cloud_run_v2_job`, mirroring #18396 which added it to `google_cloud_run_v2_service`.

The Cloud Run API already accepts this on Jobs — `sandboxLauncher` is a field on `GoogleCloudRunV2Container`, and both `GoogleCloudRunV2TaskTemplate` and `GoogleCloudRunV2RevisionTemplate` reference that same type:

```
$ curl -s 'https://run.googleapis.com/$discovery/rest?version=v2' | jq '.schemas.GoogleCloudRunV2Container.properties.sandboxLauncher'
{
  "description": "Optional. Indicates that this container can act as a sandbox supervisor and launch sandboxes.",
  "type": "boolean"
}
```

`gcloud beta run jobs update --sandbox-launcher` is documented at https://cloud.google.com/run/docs/configuring/jobs/sandboxes, so the surface is reachable everywhere except Terraform. Same property, same description, placed after `ports` exactly as on the Service, plus a sample.

Not included: `templates.sandboxes` from #18486. That field isn't on `GoogleCloudRunV2TaskTemplate` in the v2 discovery document, so it looks Service-only for now.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: added `sandbox_launcher` field to the containers of `google_cloud_run_v2_job` resource
```
