### PR TITLE
test(sql): set google-beta provider for google_project_service_identi…

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -7437,8 +7437,9 @@ resource "google_sql_database_instance" "instance" {
 func testAccSqlDatabaseInstance_withPSCEnabled_withAutoConnectionPolicy(instanceName string, networkName string, projectId string) string {
 	return fmt.Sprintf(`
 resource "google_project_service_identity" "gcp_sa_cloud_sql" {
-  project    = "%s"
-  service    = "sqladmin.googleapis.com"
+  provider = google-beta
+  project  = "%s"
+  service  = "sqladmin.googleapis.com"
 }
 
 resource "google_project_iam_member" "sa_consumer_network_admin" {
@@ -7499,8 +7500,9 @@ resource "google_sql_database_instance" "instance" {
 func testAccSqlDatabaseInstance_withPSCEnabled_withAutoConnectionPolicy_deleted(networkName string, projectId string) string {
 	return fmt.Sprintf(`
 resource "google_project_service_identity" "gcp_sa_cloud_sql" {
-  project    = "%s"
-  service    = "sqladmin.googleapis.com"
+  provider = google-beta
+  project  = "%s"
+  service  = "sqladmin.googleapis.com"
 }
 
 resource "google_project_iam_member" "sa_consumer_network_admin" {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -7437,21 +7437,20 @@ resource "google_sql_database_instance" "instance" {
 func testAccSqlDatabaseInstance_withPSCEnabled_withAutoConnectionPolicy(instanceName string, networkName string, projectId string) string {
 	return fmt.Sprintf(`
 resource "google_project_service_identity" "gcp_sa_cloud_sql" {
-  provider = google-beta
   project  = "%s"
   service  = "sqladmin.googleapis.com"
 }
 
 resource "google_project_iam_member" "sa_consumer_network_admin" {
-  project = "%s"
-  role    = "roles/networkconnectivity.consumerNetworkAdmin"
-  member  = google_project_service_identity.gcp_sa_cloud_sql.member
+  project  = "%s"
+  role     = "roles/networkconnectivity.consumerNetworkAdmin"
+  member   = google_project_service_identity.gcp_sa_cloud_sql.member
 }
 
 resource "google_project_iam_member" "sa_network_viewer" {
-  project = "%s"
-  role    = "roles/compute.networkViewer"
-  member  = google_project_service_identity.gcp_sa_cloud_sql.member
+  project  = "%s"
+  role     = "roles/compute.networkViewer"
+  member   = google_project_service_identity.gcp_sa_cloud_sql.member
 }
 
 resource "google_compute_network" "default" {
@@ -7500,21 +7499,20 @@ resource "google_sql_database_instance" "instance" {
 func testAccSqlDatabaseInstance_withPSCEnabled_withAutoConnectionPolicy_deleted(networkName string, projectId string) string {
 	return fmt.Sprintf(`
 resource "google_project_service_identity" "gcp_sa_cloud_sql" {
-  provider = google-beta
   project  = "%s"
   service  = "sqladmin.googleapis.com"
 }
 
 resource "google_project_iam_member" "sa_consumer_network_admin" {
-  project = "%s"
-  role    = "roles/networkconnectivity.consumerNetworkAdmin"
-  member  = google_project_service_identity.gcp_sa_cloud_sql.member
+  project  = "%s"
+  role     = "roles/networkconnectivity.consumerNetworkAdmin"
+  member   = google_project_service_identity.gcp_sa_cloud_sql.member
 }
 
 resource "google_project_iam_member" "sa_network_viewer" {
-  project = "%s"
-  role    = "roles/compute.networkViewer"
-  member  = google_project_service_identity.gcp_sa_cloud_sql.member
+  project  = "%s"
+  role     = "roles/compute.networkViewer"
+  member   = google_project_service_identity.gcp_sa_cloud_sql.member
 }
 
 resource "google_compute_network" "default" {


### PR DESCRIPTION
…ty in PSC auto connection policy test

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
update the provider of google_project_service_identity to beta, since it is not supported by GA.
```
