### PR TITLE
Convert cloud_control_details to TypeSet

### DIFF
--- a/mmv1/products/cloudsecuritycompliance/Framework.yaml
+++ b/mmv1/products/cloudsecuritycompliance/Framework.yaml
@@ -34,6 +34,8 @@ samples:
           framework_name: "example-framework"
         test_env_vars:
           org_id: "ORG_ID"
+        ignore_read_extra:
+          - "cloud_control_details"
   - name: "cloudsecuritycompliance_framework_project_basic"
     primary_resource_id: "example"
     steps:
@@ -42,6 +44,8 @@ samples:
           framework_name: "example-framework"
         test_env_vars:
           project_number: "PROJECT_NUMBER"
+        ignore_read_extra:
+          - "cloud_control_details"
   - name: "cloudsecuritycompliance_framework_org_basic_backward"
     primary_resource_id: "example"
     steps:
@@ -50,6 +54,8 @@ samples:
           framework_name: "example-framework"
         test_env_vars:
           org_id: "ORG_ID"
+        ignore_read_extra:
+          - "cloud_control_details"
 identity_schema_version: 2
 identity_upgraders: true
 autogen_status: RnJhbWV3b3Jr
@@ -63,6 +69,7 @@ custom_code:
   pre_delete: "templates/terraform/pre_delete/cloudsecuritycompliance_pre_delete.go.tmpl"
   post_import: "templates/terraform/post_import/cloudsecuritycompliance_post_import.go.tmpl"
   custom_import: "templates/terraform/custom_import/cloudsecuritycompliance_framework.go.tmpl"
+  constants: "templates/terraform/constants/cloudsecuritycompliance_framework.go.tmpl"
 parameters:
   - name: parent
     type: String
@@ -112,6 +119,8 @@ properties:
     output: true
   - name: cloudControlDetails
     type: Array
+    is_set: true
+    set_hash_func: 'cloudsecuritycomplianceFrameworkCloudControlDetailsHash'
     description: |-
       The details of the cloud controls directly added without any grouping in
       the framework.
@@ -122,6 +131,7 @@ properties:
           type: String
           description: Major revision of cloudcontrol
           required: true
+          diff_suppress_func: 'tpgresource.SuppressMajorRevisionId'
         - name: name
           type: String
           description: |-

--- a/mmv1/products/cloudsecuritycompliance/FrameworkDeployment.yaml
+++ b/mmv1/products/cloudsecuritycompliance/FrameworkDeployment.yaml
@@ -43,6 +43,8 @@ samples:
           framework_name: "example-framework"
         test_env_vars:
           org_id: "ORG_ID"
+        ignore_read_extra:
+          - "cloud_control_metadata"
   - name: "cloudsecuritycompliance_framework_deployment_folder_creation"
     primary_resource_id: "example"
     steps:
@@ -53,6 +55,8 @@ samples:
           folder_display_name: "cm-folder"
         test_env_vars:
           org_id: "ORG_ID"
+        ignore_read_extra:
+          - "cloud_control_metadata"
   - name: "cloudsecuritycompliance_framework_deployment_project_creation"
     primary_resource_id: "example"
     steps:
@@ -64,6 +68,8 @@ samples:
         test_env_vars:
           org_id: "ORG_ID"
           billing_account: "BILLING_ACCT"
+        ignore_read_extra:
+          - "cloud_control_metadata"
   - name: "cloudsecuritycompliance_framework_deployment_org_project_basic"
     primary_resource_id: "example"
     steps:
@@ -73,6 +79,8 @@ samples:
           framework_name: "example-framework"
         test_env_vars:
           org_id: "ORG_ID"
+        ignore_read_extra:
+          - "cloud_control_metadata"
   - name: "cloudsecuritycompliance_framework_deployment_project_application_basic"
     primary_resource_id: "example"
     steps:
@@ -90,6 +98,8 @@ samples:
           framework_name: "example-framework"
         test_env_vars:
           org_id: "ORG_ID"
+        ignore_read_extra:
+          - "cloud_control_metadata"
 autogen_async: true
 async:
   operation:

--- a/mmv1/templates/terraform/constants/cloudsecuritycompliance_framework.go.tmpl
+++ b/mmv1/templates/terraform/constants/cloudsecuritycompliance_framework.go.tmpl
@@ -1,0 +1,23 @@
+{{/*
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func cloudsecuritycomplianceFrameworkCloudControlDetailsHash(v interface{}) int {
+        if v == nil {
+                return 0
+        }
+
+        var buf bytes.Buffer
+        m := v.(map[string]interface{})
+
+        buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+
+        return tpgresource.Hashcode(buf.String())
+}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -143,7 +143,7 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
 {{-       end }}
         },
 {{- end }}
-{{- if or (and (or $.HasProject $.HasRegion $.HasZone) (not $.ExcludeDefaultCdiff)) $.CustomDiff }}
+{{- if or (and (or $.HasProject $.HasRegion $.HasZone) (not $.ExcludeDefaultCdiff)) $.CustomDiff $.UnorderedListProperties }}
         CustomizeDiff: customdiff.All(
 {{-   if $.UnorderedListProperties }}
 {{-     range $prop := $.UnorderedListProperties }}

--- a/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_deployment_folder_creation.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudsecuritycompliance/cloudsecuritycompliance_framework_deployment_folder_creation.tf.tmpl
@@ -43,7 +43,7 @@ resource "google_cloud_security_compliance_framework_deployment" "{{$.PrimaryRes
     enforcement_mode = "DETECTIVE"
     
     cloud_control_details {
-      name              = google_cloud_security_compliance_framework.example.cloud_control_details[0].name
+      name              = tolist(google_cloud_security_compliance_framework.example.cloud_control_details)[0].name
       major_revision_id = "2"
       
       parameters {

--- a/mmv1/third_party/terraform/services/cloudsecuritycompliance/resource_cloud_security_compliance_framework_test.go
+++ b/mmv1/third_party/terraform/services/cloudsecuritycompliance/resource_cloud_security_compliance_framework_test.go
@@ -69,7 +69,7 @@ func TestAccCloudSecurityComplianceFramework_update(t *testing.T) {
 				ResourceName:            "google_cloud_security_compliance_framework.example",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"framework_id", "location", "parent", "organization"},
+				ImportStateVerifyIgnore: []string{"framework_id", "location", "parent", "organization", "supported_enforcement_modes", "cloud_control_details"},
 			},
 			{
 				Config: testAccCloudSecurityComplianceFramework_update(context),
@@ -83,7 +83,11 @@ func TestAccCloudSecurityComplianceFramework_update(t *testing.T) {
 				ResourceName:            "google_cloud_security_compliance_framework.example",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"framework_id", "location", "parent", "organization"},
+				ImportStateVerifyIgnore: []string{"framework_id", "location", "parent", "organization", "supported_enforcement_modes", "cloud_control_details"},
+			},
+			{
+				Config:   testAccCloudSecurityComplianceFramework_reorder(context),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -127,7 +131,6 @@ resource "google_cloud_security_compliance_framework" "example" {
 }
 `, context)
 }
-
 func TestAccCloudSecurityComplianceFramework_backwardCompatibility(t *testing.T) {
 	t.Parallel()
 
@@ -147,7 +150,7 @@ func TestAccCloudSecurityComplianceFramework_backwardCompatibility(t *testing.T)
 				ResourceName:            "google_cloud_security_compliance_framework.example",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"framework_id", "location", "parent", "organization"},
+				ImportStateVerifyIgnore: []string{"framework_id", "location", "parent", "organization", "supported_enforcement_modes", "cloud_control_details"},
 			},
 		},
 	})
@@ -171,6 +174,45 @@ resource "google_cloud_security_compliance_framework" "example" {
       name = "location"
       parameter_value {
         string_value = "us-central1"
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccCloudSecurityComplianceFramework_reorder(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_security_compliance_framework" "example" {
+  parent       = "organizations/%{org_id}"
+  location     = "global"
+  framework_id = "tf-test-example-framework%{random_suffix}"
+  
+  display_name = "Updated Terraform Framework Name"
+  description  = "An updated description for the framework with additional details"
+  
+  cloud_control_details {
+    name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-assess-resource-availability"
+    major_revision_id = "1"
+    
+    parameters {
+      name = "location"
+      parameter_value {
+        string_value = "us-east1"
+      }
+    }
+  }
+
+  cloud_control_details {
+    name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-cmek-key-in-use-for-bigquery-table"
+    major_revision_id = "1"
+    
+    parameters {
+      name = "location"
+      parameter_value {
+        string_list_value {
+          values = ["us-central1"]
+        }
       }
     }
   }

--- a/mmv1/third_party/terraform/services/cloudsecuritycompliance/resource_cloud_security_compliance_framework_test.go
+++ b/mmv1/third_party/terraform/services/cloudsecuritycompliance/resource_cloud_security_compliance_framework_test.go
@@ -22,6 +22,20 @@ resource "google_cloud_security_compliance_framework" "example" {
   description  = "An Terraform description for the framework"
   
   cloud_control_details {
+    name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-cmek-key-in-use-for-bigquery-table"
+    major_revision_id = "1"
+    
+    parameters {
+      name = "location"
+      parameter_value {
+        string_list_value {
+          values = ["us-central1"]
+        }
+      }
+    }
+  }
+
+  cloud_control_details {
 		name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-assess-resource-availability"
 		major_revision_id = "2"
     
@@ -29,52 +43,6 @@ resource "google_cloud_security_compliance_framework" "example" {
       name = "location"
       parameter_value {
         string_value = "us-central1"
-      }
-    }
-    parameters {
-      name = "oneof-parameter"
-      parameter_value {
-        oneof_value {
-          name = "test-oneof"
-          parameter_value {
-            string_value = "test-value"
-          }
-        }
-      }
-    }
-    parameters {
-      name = "bool-parameter"
-      parameter_value {
-        oneof_value {
-          name = "bool-oneof"
-          parameter_value {
-            bool_value = true
-          }
-        }
-      }
-    }
-    parameters {
-      name = "number-parameter"
-      parameter_value {
-        oneof_value {
-          name = "number-oneof"
-          parameter_value {
-            number_value = 123.45
-          }
-        }
-      }
-    }
-    parameters {
-      name = "string-list-parameter"
-      parameter_value {
-        oneof_value {
-          name = "string-list-oneof"
-          parameter_value {
-            string_list_value {
-              values = ["value1", "value2"]
-            }
-          }
-        }
       }
     }
   }
@@ -132,59 +100,27 @@ resource "google_cloud_security_compliance_framework" "example" {
   description  = "An updated description for the framework with additional details"
   
   cloud_control_details {
-    name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-data-access-governance"
+    name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-cmek-key-in-use-for-bigquery-table"
     major_revision_id = "1"
     
     parameters {
-      name = "region"
+      name = "location"
       parameter_value {
-        string_value = "eu"
-      }
-    }
-    parameters {
-      name = "oneof-parameter"
-      parameter_value {
-        oneof_value {
-          name = "updated-oneof"
-          parameter_value {
-            string_value = "updated-value"
-          }
+        string_list_value {
+          values = ["us-central1"]
         }
       }
     }
+  }
+
+  cloud_control_details {
+    name              = "organizations/%{org_id}/locations/global/cloudControls/builtin-assess-resource-availability"
+    major_revision_id = "1"
+    
     parameters {
-      name = "bool-parameter"
+      name = "location"
       parameter_value {
-        oneof_value {
-          name = "bool-oneof"
-          parameter_value {
-            bool_value = true
-          }
-        }
-      }
-    }
-    parameters {
-      name = "number-parameter"
-      parameter_value {
-        oneof_value {
-          name = "number-oneof"
-          parameter_value {
-            number_value = 678.90
-          }
-        }
-      }
-    }
-    parameters {
-      name = "string-list-parameter"
-      parameter_value {
-        oneof_value {
-          name = "string-list-oneof"
-          parameter_value {
-            string_list_value {
-              values = ["value3", "value4"]
-            }
-          }
-        }
+        string_value = "us-east1"
       }
     }
   }

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go
@@ -5,6 +5,7 @@ package tpgresource
 import (
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -160,4 +161,18 @@ func Base64DiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 
 func CaseInsensitiveHash(v interface{}) int {
 	return Hashcode(strings.ToLower(v.(string)))
+}
+
+// Suppress diffs where the API returns a larger or equal major revision ID than configured.
+// This handles cases where the server automatically upgrades the major revision of a control.
+func SuppressMajorRevisionId(_, old, new string, _ *schema.ResourceData) bool {
+	if old == new {
+		return true
+	}
+	oldVal, err1 := strconv.Atoi(old)
+	newVal, err2 := strconv.Atoi(new)
+	if err1 == nil && err2 == nil {
+		return oldVal >= newVal
+	}
+	return false
 }

--- a/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
@@ -106,6 +106,12 @@ Previously, the max length of `name_prefix` for `google_container_node_pool` and
 
 In 8.0.0, providing a `name_prefix` larger than 14 characters will prompt the provider to use a shortened suffix of only 9 characters, leading to a new max of 31 characters for `name_prefix`. This shortened suffix is inevitably more prone to collisions, so use the longer max `name_prefix` length with caution.
 
+## Resource: `google_cloud_security_compliance_framework`
+
+### `cloud_control_details` is now a set
+
+`cloud_control_details` has been converted from a `list` to a `set` to resolve perpetual diffs caused by non-deterministic API ordering. References that use list indexing (for example, `google_cloud_security_compliance_framework.<name>.cloud_control_details[0]`) should be updated to use `tolist(google_cloud_security_compliance_framework.<name>.cloud_control_details)[0]` or `for` expressions.
+
 ## Resource: `google_cloud_run_v2_worker_pool`
 
 ### `custom_audiences` is now removed


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27543

### Description

This PR adopts and retargets https://github.com/GoogleCloudPlatform/magic-modules/pull/17770 by @Capstan to the `FEATURE-BRANCH-major-release-8.0.0` branch.

All core implementation credits go to @Capstan for:
- Converting `cloud_control_details` on `google_cloud_security_compliance_framework` to `TypeSet` with custom set hashing (`cloudsecuritycomplianceFrameworkCloudControlDetailsHash`).
- Implementing `SuppressMajorRevisionId` to handle server-side major revision auto-upgrades.
- Updating acceptance tests and dependent samples.

#### Additions in this PR:
- Retargeted to base branch `FEATURE-BRANCH-major-release-8.0.0`.
- Added migration entry in `version_8_upgrade.html.markdown`.

```release-note:breaking-change
cloudsecuritycompliance: `cloud_control_details` on `google_cloud_security_compliance_framework` is now a `TypeSet` instead of `TypeList`
```