### PR TITLE
openapi_generate: skip parameters with 'Deprecated.' description prefix

### DIFF
--- a/mmv1/openapi_generate/parser.go
+++ b/mmv1/openapi_generate/parser.go
@@ -436,6 +436,10 @@ func parseOpenApi(resourcePath, resourceName string, op *openapi3.Operation) []a
 		}
 		paramObj.Description = trimDescription(description)
 
+		if strings.HasPrefix(paramObj.Description, "Deprecated.") {
+			continue
+		}
+
 		if param.Value.Name == "requestId" || param.Value.Name == "validateOnly" || paramObj.Name == "" || paramObj.Name == "updateMask" {
 			continue
 		}
@@ -684,5 +688,6 @@ func trimDescription(description string) string {
 	for _, line := range lines {
 		trimmedDescription = append(trimmedDescription, strings.Trim(line, " "))
 	}
+
 	return strings.Join(trimmedDescription, "\n")
 }

--- a/mmv1/openapi_generate/parser_test.go
+++ b/mmv1/openapi_generate/parser_test.go
@@ -208,3 +208,71 @@ func TestAttachStandardFunctionality(t *testing.T) {
 		t.Errorf("Expected step.Vars['resource_name'] to be 'test-resource', got: %q (present=%t)", val, ok)
 	}
 }
+
+func TestDeprecatedParameterSkip(t *testing.T) {
+	yamlData := []byte(`
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Test API
+paths:
+  /test:
+    get:
+      parameters:
+        - name: activeParam
+          in: query
+          description: Active parameter
+          schema:
+            type: string
+        - name: deprecatedParam
+          in: query
+          description: Deprecated. Use activeParam instead.
+          schema:
+            type: string
+        - name: optionalDeprecatedParam
+          in: query
+          description: Optional. Deprecated. Skip this too.
+          schema:
+            type: string
+      responses:
+        default:
+          description: OK
+`)
+	ctx := t.Context()
+	loader := &openapi3.Loader{Context: ctx, IsExternalRefsAllowed: true}
+	doc, err := loader.LoadFromData(yamlData)
+	if err != nil {
+		t.Fatalf("Could not load data %s", err)
+	}
+	err = doc.Validate(ctx)
+	if err != nil {
+		t.Fatalf("Could not validate data %s", err)
+	}
+
+	op := doc.Paths.Map()["/test"].Get
+	resArray := parseOpenApi("/test", "Test", op)
+	parameters := resArray[0].([]*api.Type)
+
+	var activeFound, deprecatedFound, optionalDeprecatedFound bool
+	for _, p := range parameters {
+		if p.Name == "activeParam" {
+			activeFound = true
+		}
+		if p.Name == "deprecatedParam" {
+			deprecatedFound = true
+		}
+		if p.Name == "optionalDeprecatedParam" {
+			optionalDeprecatedFound = true
+		}
+	}
+
+	if !activeFound {
+		t.Error("Expected to find activeParam in parameters list")
+	}
+	if deprecatedFound {
+		t.Error("Expected deprecatedParam to be skipped, but it was found")
+	}
+	if optionalDeprecatedFound {
+		t.Error("Expected optionalDeprecatedParam to be skipped, but it was found")
+	}
+}


### PR DESCRIPTION
This change introduces a check to skip processing OpenAPI parameters whose descriptions begin with `Deprecated.`. This avoids generating fields or properties from deprecated OpenAPI parameters when onboarding new resources.

```release-note:none
```
