### PR TITLE
Add binding-level dry-run access levels to GCP user access bindings

### DIFF
--- a/mmv1/products/accesscontextmanager/GcpUserAccessBinding.yaml
+++ b/mmv1/products/accesscontextmanager/GcpUserAccessBinding.yaml
@@ -86,6 +86,14 @@ properties:
       type: String
     min_size: 1
     max_size: 1
+  - name: dryRunAccessLevels
+    type: Array
+    description: |
+      Optional. Dry run access level that will be evaluated but will not be enforced. The access denial based on dry run policy will be logged. Only one access level is supported, not multiple. This list must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted"
+    item_type:
+      type: String
+    min_size: 1
+    max_size: 1
   - name: sessionSettings
     type: NestedObject
     description: |

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
@@ -28,6 +28,11 @@ func testAccAccessContextManagerGcpUserAccessBinding_basicTest(t *testing.T) {
 		"cust_id":       envvar.GetTestCustIdFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),
 	}
+	bindingResourceName := "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding"
+	accessLevelResourceName := fmt.Sprintf(
+		"google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%s",
+		context["random_suffix"],
+	)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -35,25 +40,75 @@ func testAccAccessContextManagerGcpUserAccessBinding_basicTest(t *testing.T) {
 		CheckDestroy:             testAccCheckAccessContextManagerGcpUserAccessBindingDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context),
+				Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingDryRunOnlyExample(t, context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(bindingResourceName, "dry_run_access_levels.#", "1"),
+					resource.TestCheckResourceAttrPair(bindingResourceName, "dry_run_access_levels.0", accessLevelResourceName, "name"),
+					resource.TestCheckNoResourceAttr(bindingResourceName, "access_levels.0"),
+					resource.TestCheckNoResourceAttr(bindingResourceName, "session_settings.#"),
+					resource.TestCheckNoResourceAttr(bindingResourceName, "scoped_access_settings.#"),
+				),
 			},
 			{
-				ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
+				ResourceName:      bindingResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// organization_id is URL-only and is not returned by the API.
+				ImportStateVerifyIgnore: []string{"organization_id"},
+			},
+			{
+				Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(bindingResourceName, "access_levels.#", "1"),
+					resource.TestCheckResourceAttrPair(bindingResourceName, "access_levels.0", accessLevelResourceName, "name"),
+					resource.TestCheckNoResourceAttr(bindingResourceName, "dry_run_access_levels.0"),
+				),
+			},
+			{
+				ResourceName:            bindingResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"organization_id"},
 			},
 			{
 				Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingNamedExample(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(bindingResourceName, "access_levels.#", "1"),
+					resource.TestCheckResourceAttrPair(bindingResourceName, "access_levels.0", accessLevelResourceName, "name"),
+					resource.TestCheckResourceAttr(bindingResourceName, "dry_run_access_levels.#", "1"),
+					resource.TestCheckResourceAttrPair(bindingResourceName, "dry_run_access_levels.0", accessLevelResourceName, "name"),
+				),
 			},
 			{
-				ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
+				ResourceName:            bindingResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"organization_id"},
 			},
 		},
 	})
+}
+
+func testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingDryRunOnlyExample(t *testing.T, context map[string]interface{}) string {
+	t.Helper()
+
+	dependencies, _, found := strings.Cut(
+		testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context),
+		"\nresource \"google_access_context_manager_gcp_user_access_binding\" \"gcp_user_access_binding\" {\n",
+	)
+	if !found {
+		t.Fatal("basic fixture does not contain the GCP user access binding")
+	}
+
+	return dependencies + acctest.Nprintf(`
+resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_access_binding" {
+  organization_id = "%{org_id}"
+  group_key       = trimprefix(google_cloud_identity_group.group.id, "groups/")
+  dry_run_access_levels = [
+    google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
+  ]
+}
+`, context)
 }
 
 func testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context map[string]interface{}) string {
@@ -181,6 +236,9 @@ resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_acces
   organization_id = "%{org_id}"
   group_key       = trimprefix(google_cloud_identity_group.group.id, "groups/")
   access_levels   = [
+    google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
+  ]
+  dry_run_access_levels = [
     google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
   ]
   session_settings {


### PR DESCRIPTION
## Why

`google_access_context_manager_gcp_user_access_binding` cannot evaluate binding-level access policies across all applications in dry-run mode without enforcing them or enumerating individual applications.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20395.

## What

- Add optional `dry_run_access_levels`, limited to one access level, to both Google providers.
- Extend acceptance coverage for unscoped dry-run-only, enforced-only, combined, update, and import behavior.

Related: #18446 includes this field within a broader change; this PR isolates binding-level dry-run support and its regression coverage.

## Validation

- `go test ./...` from `mmv1`.
- Generated and inspected GA/beta schemas, API requests, update masks, state, metadata, documentation, and acceptance tests.
- YAML lint and Go formatting checks passed.
- Live acceptance tests were not run because they mutate organization-level resources.

```release-note:enhancement
accesscontextmanager: added `dry_run_access_levels` field to `google_access_context_manager_gcp_user_access_binding` resource
```
