### PR TITLE
Add tags field to Certificate Manager for TagsR2401

### DIFF
--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -343,3 +343,11 @@ properties:
                 address the configuration issues.
                 Not guaranteed to be stable. For programmatic access use `failure_reason` field.
               output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
+++ b/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
@@ -128,3 +128,11 @@ properties:
               "projects/{project}/locations/{location}/caPools/{caPool}".
             required: true
             diff_suppress_func: tpgresource.CompareResourceNames
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -113,3 +113,11 @@ properties:
             Proxy name must be in the format projects/*/locations/*/targetSslProxies/*.
             This field is part of a union field `target_proxy`: Only one of `targetHttpsProxy` or
             `targetSslProxy` may be set.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -138,3 +138,11 @@ properties:
         description: |
           Data of the DNS Resource Record.
         output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -144,3 +144,11 @@ properties:
           description: |
             PEM certificate that is allowlisted. The certificate can be up to 5k bytes, and must be a parseable X.509 certificate.
           required: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificate_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificate_test.go
@@ -10,134 +10,45 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/certificatemanager"
 	"github.com/hashicorp/terraform-provider-google/google/services/tags"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-func TestAccCertificateManagerTrustConfig_update(t *testing.T) {
+func TestAccCertificateManagerCertificate_tags(t *testing.T) {
 	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckCertificateManagerTrustConfigDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCertificateManagerTrustConfig_update0(context),
-			},
-			{
-				ResourceName:            "google_certificate_manager_trust_config.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-			{
-				Config: testAccCertificateManagerTrustConfig_update1(context),
-			},
-			{
-				ResourceName:            "google_certificate_manager_trust_config.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-		},
-	})
-}
-
-func testAccCertificateManagerTrustConfig_update0(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_certificate_manager_trust_config" "default" {
-  name        = "tf-test-trust-config%{random_suffix}"
-  description = "sample description for the trust config"
-  location = "global"
-
-  trust_stores {
-    trust_anchors { 
-      pem_certificate = file("test-fixtures/cert.pem")
-    }
-    intermediate_cas { 
-      pem_certificate = file("test-fixtures/cert.pem")
-    }
-  }
-
-  allowlisted_certificates  {
-    pem_certificate = file("test-fixtures/cert.pem") 
-  }
-
-  labels = {
-    "foo" = "bar"
-  }
-}
-`, context)
-}
-
-func testAccCertificateManagerTrustConfig_update1(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_certificate_manager_trust_config" "default" {
-  name        = "tf-test-trust-config%{random_suffix}"
-  description = "sample description for the trust config 2"
-  location    = "global"
-
-  trust_stores {
-    trust_anchors { 
-      pem_certificate = file("test-fixtures/cert2.pem")
-    }
-    intermediate_cas { 
-      pem_certificate = file("test-fixtures/cert2.pem")
-    }
-  }
-
-  allowlisted_certificates  {
-    pem_certificate = file("test-fixtures/cert.pem") 
-  }
-
-  labels = {
-    "bar" = "foo"
-  }
-}
-`, context)
-}
-
-func TestAccCertificateManagerTrustConfig_tags(t *testing.T) {
-	t.Parallel()
-	tagKey := tags.BootstrapSharedTestOrganizationTagKey(t, "trust-config-tagkey", map[string]interface{}{})
+	tagKey := tags.BootstrapSharedTestOrganizationTagKey(t, "cert-manager-tagkey", map[string]interface{}{})
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		"org":           envvar.GetTestOrgFromEnv(t),
 		"tagKey":        tagKey,
-		"tagValue":      tags.BootstrapSharedTestOrganizationTagValue(t, "trust-config-tagvalue", tagKey),
+		"tagValue":      tags.BootstrapSharedTestOrganizationTagValue(t, "cert-manager-tagvalue", tagKey),
 	}
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckCertificateManagerTrustConfigDestroyProducer(t),
+		CheckDestroy:             testAccCheckCertificateManagerCertificateDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCertificateManagerTrustConfigWithTags(context),
+				Config: testAccCertificateManagerCertificateTags(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_certificate_manager_trust_config.test", "tags.%"),
-					checkCertificateManagerTrustConfigWithTags(t),
+					resource.TestCheckResourceAttrSet("google_certificate_manager_certificate.test", "tags.%"),
+					checkCertificateManagerCertificateTags(t),
 				),
 			},
 			{
-				ResourceName:            "google_certificate_manager_trust_config.test",
+				ResourceName:            "google_certificate_manager_certificate.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"tags", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"tags"},
 			},
 		},
 	})
 }
 
-func checkCertificateManagerTrustConfigWithTags(t *testing.T) func(s *terraform.State) error {
+func checkCertificateManagerCertificateTags(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		for name, rs := range s.RootModule().Resources {
-			if rs.Type != "google_certificate_manager_trust_config" {
+			if rs.Type != "google_certificate_manager_certificate" {
 				continue
 			}
 			if strings.HasPrefix(name, "data.") {
@@ -189,22 +100,17 @@ func checkCertificateManagerTrustConfigWithTags(t *testing.T) func(s *terraform.
 				return fmt.Errorf("tag value details (name) not found in response for namespaced name: %q, response: %v", configuredTagValueNamespacedName, respDescribe)
 			}
 
-			// 3. Get the tag bindings from the Certificate Manager Trust Config.
+			// 3. Get the tag bindings from the Certificate Manager Certificates.
 			parts := strings.Split(rs.Primary.ID, "/")
 			if len(parts) != 6 {
 				return fmt.Errorf("invalid resource ID format: %s", rs.Primary.ID)
 			}
 			project := parts[1]
 			location := parts[3]
-			trustConfigs_id := parts[5]
+			certificate_id := parts[5]
 
-			parentURL := fmt.Sprintf("//certificatemanager.googleapis.com/projects/%s/locations/%s/trustConfigs/%s", project, location, trustConfigs_id)
-			var listBindingsURL string
-			if location == "global" || location == "" {
-				listBindingsURL = fmt.Sprintf("https://cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", url.QueryEscape(parentURL))
-			} else {
-				listBindingsURL = fmt.Sprintf("https://%s-cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", location, url.QueryEscape(parentURL))
-			}
+			parentURL := fmt.Sprintf("//certificatemanager.googleapis.com/projects/%s/locations/%s/certificates/%s", project, location, certificate_id)
+			listBindingsURL := fmt.Sprintf("https://%s-cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", location, url.QueryEscape(parentURL))
 
 			resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
@@ -251,17 +157,18 @@ func checkCertificateManagerTrustConfigWithTags(t *testing.T) func(s *terraform.
 	}
 }
 
-func testAccCertificateManagerTrustConfigWithTags(context map[string]interface{}) string {
+func testAccCertificateManagerCertificateTags(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-	resource "google_certificate_manager_trust_config" "test" {
-	  name        = "tf-test-trust-config%{random_suffix}"
-        description = "sample description for the trust config 2"
-        location    = "global"
-        allowlisted_certificates  {
-          pem_certificate = file("test-fixtures/cert.pem") 
-        }
-tags = {
-	"%{org}/%{tagKey}" = "%{tagValue}"
-  }
+	resource "google_certificate_manager_certificate" "test" {
+	  name    = "tf-test-cert-%{random_suffix}"
+	  description = "Global cert"
+	  location = "us-east1"
+	  self_managed {
+	    pem_certificate = file("test-fixtures/cert.pem")
+    	    pem_private_key = file("test-fixtures/private-key.pem")
+	  }
+	  tags = {
+	    "%{org}/%{tagKey}" = "%{tagValue}"
+	  }
 	}`, context)
 }

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificate_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificate_test.go
@@ -39,7 +39,7 @@ func TestAccCertificateManagerCertificate_tags(t *testing.T) {
 				ResourceName:            "google_certificate_manager_certificate.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"tags"},
+				ImportStateVerifyIgnore: []string{"tags", "self_managed"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemap_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemap_test.go
@@ -10,134 +10,45 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/certificatemanager"
 	"github.com/hashicorp/terraform-provider-google/google/services/tags"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-func TestAccCertificateManagerTrustConfig_update(t *testing.T) {
+func TestAccCertificateManagerCertificateMap_tags(t *testing.T) {
 	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckCertificateManagerTrustConfigDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCertificateManagerTrustConfig_update0(context),
-			},
-			{
-				ResourceName:            "google_certificate_manager_trust_config.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-			{
-				Config: testAccCertificateManagerTrustConfig_update1(context),
-			},
-			{
-				ResourceName:            "google_certificate_manager_trust_config.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-		},
-	})
-}
-
-func testAccCertificateManagerTrustConfig_update0(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_certificate_manager_trust_config" "default" {
-  name        = "tf-test-trust-config%{random_suffix}"
-  description = "sample description for the trust config"
-  location = "global"
-
-  trust_stores {
-    trust_anchors { 
-      pem_certificate = file("test-fixtures/cert.pem")
-    }
-    intermediate_cas { 
-      pem_certificate = file("test-fixtures/cert.pem")
-    }
-  }
-
-  allowlisted_certificates  {
-    pem_certificate = file("test-fixtures/cert.pem") 
-  }
-
-  labels = {
-    "foo" = "bar"
-  }
-}
-`, context)
-}
-
-func testAccCertificateManagerTrustConfig_update1(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_certificate_manager_trust_config" "default" {
-  name        = "tf-test-trust-config%{random_suffix}"
-  description = "sample description for the trust config 2"
-  location    = "global"
-
-  trust_stores {
-    trust_anchors { 
-      pem_certificate = file("test-fixtures/cert2.pem")
-    }
-    intermediate_cas { 
-      pem_certificate = file("test-fixtures/cert2.pem")
-    }
-  }
-
-  allowlisted_certificates  {
-    pem_certificate = file("test-fixtures/cert.pem") 
-  }
-
-  labels = {
-    "bar" = "foo"
-  }
-}
-`, context)
-}
-
-func TestAccCertificateManagerTrustConfig_tags(t *testing.T) {
-	t.Parallel()
-	tagKey := tags.BootstrapSharedTestOrganizationTagKey(t, "trust-config-tagkey", map[string]interface{}{})
+	tagKey := tags.BootstrapSharedTestOrganizationTagKey(t, "cert-map-tagkey", map[string]interface{}{})
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		"org":           envvar.GetTestOrgFromEnv(t),
 		"tagKey":        tagKey,
-		"tagValue":      tags.BootstrapSharedTestOrganizationTagValue(t, "trust-config-tagvalue", tagKey),
+		"tagValue":      tags.BootstrapSharedTestOrganizationTagValue(t, "cert-map-tagvalue", tagKey),
 	}
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckCertificateManagerTrustConfigDestroyProducer(t),
+		CheckDestroy:             testAccCheckCertificateManagerCertificateMapDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCertificateManagerTrustConfigWithTags(context),
+				Config: testAccCertificateManagerCertificateMapWithTags(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_certificate_manager_trust_config.test", "tags.%"),
-					checkCertificateManagerTrustConfigWithTags(t),
+					resource.TestCheckResourceAttrSet("google_certificate_manager_certificate_map.test", "tags.%"),
+					checkCertificateManagerCertificateMapWithTags(t),
 				),
 			},
 			{
-				ResourceName:            "google_certificate_manager_trust_config.test",
+				ResourceName:            "google_certificate_manager_certificate_map.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"tags", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"tags"},
 			},
 		},
 	})
 }
 
-func checkCertificateManagerTrustConfigWithTags(t *testing.T) func(s *terraform.State) error {
+func checkCertificateManagerCertificateMapWithTags(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		for name, rs := range s.RootModule().Resources {
-			if rs.Type != "google_certificate_manager_trust_config" {
+			if rs.Type != "google_certificate_manager_certificate_map" {
 				continue
 			}
 			if strings.HasPrefix(name, "data.") {
@@ -189,18 +100,19 @@ func checkCertificateManagerTrustConfigWithTags(t *testing.T) func(s *terraform.
 				return fmt.Errorf("tag value details (name) not found in response for namespaced name: %q, response: %v", configuredTagValueNamespacedName, respDescribe)
 			}
 
-			// 3. Get the tag bindings from the Certificate Manager Trust Config.
+			// 3. Get the tag bindings from the Certificate Manager Certificate Maps.
 			parts := strings.Split(rs.Primary.ID, "/")
 			if len(parts) != 6 {
 				return fmt.Errorf("invalid resource ID format: %s", rs.Primary.ID)
 			}
 			project := parts[1]
 			location := parts[3]
-			trustConfigs_id := parts[5]
+			certificateMap_id := parts[5]
 
-			parentURL := fmt.Sprintf("//certificatemanager.googleapis.com/projects/%s/locations/%s/trustConfigs/%s", project, location, trustConfigs_id)
+			parentURL := fmt.Sprintf("//certificatemanager.googleapis.com/projects/%s/locations/%s/certificateMaps/%s", project, location, certificateMap_id)
+			// Handle global vs regional endpoints for tag bindings
 			var listBindingsURL string
-			if location == "global" || location == "" {
+			if location == "global" {
 				listBindingsURL = fmt.Sprintf("https://cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", url.QueryEscape(parentURL))
 			} else {
 				listBindingsURL = fmt.Sprintf("https://%s-cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", location, url.QueryEscape(parentURL))
@@ -251,17 +163,13 @@ func checkCertificateManagerTrustConfigWithTags(t *testing.T) func(s *terraform.
 	}
 }
 
-func testAccCertificateManagerTrustConfigWithTags(context map[string]interface{}) string {
+func testAccCertificateManagerCertificateMapWithTags(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-	resource "google_certificate_manager_trust_config" "test" {
-	  name        = "tf-test-trust-config%{random_suffix}"
-        description = "sample description for the trust config 2"
-        location    = "global"
-        allowlisted_certificates  {
-          pem_certificate = file("test-fixtures/cert.pem") 
-        }
-tags = {
-	"%{org}/%{tagKey}" = "%{tagValue}"
-  }
+	resource "google_certificate_manager_certificate_map" "test" {
+	  name    = "tf-test-cert-map-%{random_suffix}"
+	  description = "A basic certificate map for testing"
+	  tags = {
+	    "%{org}/%{tagKey}" = "%{tagValue}"
+	  }
 	}`, context)
 }

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_test.go
@@ -1,11 +1,18 @@
 package certificatemanager_test
 
 import (
+	"fmt"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/certificatemanager"
+	"github.com/hashicorp/terraform-provider-google/google/services/tags"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccCertificateManagerDnsAuthorization_update(t *testing.T) {
@@ -66,4 +73,162 @@ resource "google_certificate_manager_dns_authorization" "default" {
   domain      = "%{random_suffix}.hashicorptest.com"
 }
 `, context)
+}
+
+func TestAccCertificateManagerDnsAuthorization_tags(t *testing.T) {
+	t.Parallel()
+	tagKey := tags.BootstrapSharedTestOrganizationTagKey(t, "dns-authz-tagkey", map[string]interface{}{})
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"org":           envvar.GetTestOrgFromEnv(t),
+		"tagKey":        tagKey,
+		"tagValue":      tags.BootstrapSharedTestOrganizationTagValue(t, "dns-authz-tagvalue", tagKey),
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCertificateManagerDnsAuthorizationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerDnsAuthorizationWithTags(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_certificate_manager_dns_authorization.test", "tags.%"),
+					checkCertificateManagerDnsAuthorizationWithTags(t),
+				),
+			},
+			{
+				ResourceName:            "google_certificate_manager_dns_authorization.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"tags", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func checkCertificateManagerDnsAuthorizationWithTags(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_certificate_manager_dns_authorization" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
+
+			config := acctest.GoogleProviderConfig(t)
+
+			// 1. Get the configured tag key and value from the state.
+			var configuredTagValueNamespacedName string
+			var tagKeyNamespacedName, tagValueShortName string
+			for key, val := range rs.Primary.Attributes {
+				if strings.HasPrefix(key, "tags.") && key != "tags.%" {
+					tagKeyNamespacedName = strings.TrimPrefix(key, "tags.")
+					tagValueShortName = val
+					if tagValueShortName != "" {
+						configuredTagValueNamespacedName = fmt.Sprintf("%s/%s", tagKeyNamespacedName, tagValueShortName)
+						break
+					}
+				}
+			}
+
+			if configuredTagValueNamespacedName == "" {
+				return fmt.Errorf("could not find a configured tag value in the state for resource %s", rs.Primary.ID)
+			}
+
+			// Check if placeholders are still present.
+			if strings.Contains(configuredTagValueNamespacedName, "%{") {
+				return fmt.Errorf("tag namespaced name contains unsubstituted variables: %q. Ensure the context map in the test step is populated", configuredTagValueNamespacedName)
+			}
+
+			// 2. Describe the tag value using the namespaced name to get its full resource name.
+			safeNamespacedName := url.QueryEscape(configuredTagValueNamespacedName)
+			describeTagValueURL := fmt.Sprintf("https://cloudresourcemanager.googleapis.com/v3/tagValues/namespaced?name=%s", safeNamespacedName)
+
+			respDescribe, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    describeTagValueURL,
+				UserAgent: config.UserAgent,
+			})
+
+			if err != nil {
+				return fmt.Errorf("error describing tag value using namespaced name %q: %v", configuredTagValueNamespacedName, err)
+			}
+
+			fullTagValueName, ok := respDescribe["name"].(string)
+			if !ok || fullTagValueName == "" {
+				return fmt.Errorf("tag value details (name) not found in response for namespaced name: %q, response: %v", configuredTagValueNamespacedName, respDescribe)
+			}
+
+			// 3. Get the tag bindings from the Certificate Manager DNS Authorizations.
+			parts := strings.Split(rs.Primary.ID, "/")
+			if len(parts) != 6 {
+				return fmt.Errorf("invalid resource ID format: %s", rs.Primary.ID)
+			}
+			project := parts[1]
+			location := parts[3]
+			dnsAuthorizations_id := parts[5]
+
+			parentURL := fmt.Sprintf("//certificatemanager.googleapis.com/projects/%s/locations/%s/dnsAuthorizations/%s", project, location, dnsAuthorizations_id)
+			listBindingsURL := fmt.Sprintf("https://cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", url.QueryEscape(parentURL))
+
+			resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    listBindingsURL,
+				UserAgent: config.UserAgent,
+			})
+
+			if err != nil {
+				return fmt.Errorf("error calling TagBindings API: %v", err)
+			}
+
+			tagBindingsVal, exists := resp["tagBindings"]
+			if !exists {
+				tagBindingsVal = []interface{}{}
+			}
+
+			tagBindings, ok := tagBindingsVal.([]interface{})
+			if !ok {
+				return fmt.Errorf("'tagBindings' is not a slice in response for resource %s. Response: %v", rs.Primary.ID, resp)
+			}
+
+			// 4. Perform the comparison.
+			foundMatch := false
+			for _, binding := range tagBindings {
+				bindingMap, ok := binding.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if bindingMap["tagValue"] == fullTagValueName {
+					foundMatch = true
+					break
+				}
+			}
+
+			if !foundMatch {
+				return fmt.Errorf("expected tag value %s (from namespaced %q) not found in tag bindings for resource %s. Bindings: %v", fullTagValueName, configuredTagValueNamespacedName, rs.Primary.ID, tagBindings)
+			}
+
+			t.Logf("Successfully found matching tag binding for %s with tagValue %s", rs.Primary.ID, fullTagValueName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCertificateManagerDnsAuthorizationWithTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+	resource "google_certificate_manager_dns_authorization" "test" {
+	  name          = "tf-test-dns-auth%{random_suffix}"
+        description = "The default dns"
+        labels = {
+                a = "a"
+        }
+        domain          = "%{random_suffix}.hashicorptest.com"
+	tags = {
+	"%{org}/%{tagKey}" = "%{tagValue}"
+  }
+	}`, context)
 }

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_issuance_config_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_issuance_config_test.go
@@ -10,122 +10,32 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/certificatemanager"
 	"github.com/hashicorp/terraform-provider-google/google/services/tags"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-func TestAccCertificateManagerTrustConfig_update(t *testing.T) {
+func TestAccCertificateManagerIssuanceConfig_tags(t *testing.T) {
 	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckCertificateManagerTrustConfigDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCertificateManagerTrustConfig_update0(context),
-			},
-			{
-				ResourceName:            "google_certificate_manager_trust_config.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-			{
-				Config: testAccCertificateManagerTrustConfig_update1(context),
-			},
-			{
-				ResourceName:            "google_certificate_manager_trust_config.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-		},
-	})
-}
-
-func testAccCertificateManagerTrustConfig_update0(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_certificate_manager_trust_config" "default" {
-  name        = "tf-test-trust-config%{random_suffix}"
-  description = "sample description for the trust config"
-  location = "global"
-
-  trust_stores {
-    trust_anchors { 
-      pem_certificate = file("test-fixtures/cert.pem")
-    }
-    intermediate_cas { 
-      pem_certificate = file("test-fixtures/cert.pem")
-    }
-  }
-
-  allowlisted_certificates  {
-    pem_certificate = file("test-fixtures/cert.pem") 
-  }
-
-  labels = {
-    "foo" = "bar"
-  }
-}
-`, context)
-}
-
-func testAccCertificateManagerTrustConfig_update1(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_certificate_manager_trust_config" "default" {
-  name        = "tf-test-trust-config%{random_suffix}"
-  description = "sample description for the trust config 2"
-  location    = "global"
-
-  trust_stores {
-    trust_anchors { 
-      pem_certificate = file("test-fixtures/cert2.pem")
-    }
-    intermediate_cas { 
-      pem_certificate = file("test-fixtures/cert2.pem")
-    }
-  }
-
-  allowlisted_certificates  {
-    pem_certificate = file("test-fixtures/cert.pem") 
-  }
-
-  labels = {
-    "bar" = "foo"
-  }
-}
-`, context)
-}
-
-func TestAccCertificateManagerTrustConfig_tags(t *testing.T) {
-	t.Parallel()
-	tagKey := tags.BootstrapSharedTestOrganizationTagKey(t, "trust-config-tagkey", map[string]interface{}{})
+	tagKey := tags.BootstrapSharedTestOrganizationTagKey(t, "issuance-config-tagkey", map[string]interface{}{})
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		"org":           envvar.GetTestOrgFromEnv(t),
 		"tagKey":        tagKey,
-		"tagValue":      tags.BootstrapSharedTestOrganizationTagValue(t, "trust-config-tagvalue", tagKey),
+		"tagValue":      tags.BootstrapSharedTestOrganizationTagValue(t, "issuance-config-tagvalue", tagKey),
 	}
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckCertificateManagerTrustConfigDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCertificateManagerTrustConfigWithTags(context),
+				Config: testAccCertificateManagerIssuanceConfigWithTags(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_certificate_manager_trust_config.test", "tags.%"),
-					checkCertificateManagerTrustConfigWithTags(t),
+					resource.TestCheckResourceAttrSet("google_certificate_manager_certificate_issuance_config.test", "tags.%"),
+					checkCertificateManagerIssuanceConfigWithTags(t),
 				),
 			},
 			{
-				ResourceName:            "google_certificate_manager_trust_config.test",
+				ResourceName:            "google_certificate_manager_certificate_issuance_config.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"tags", "labels", "terraform_labels"},
@@ -134,10 +44,10 @@ func TestAccCertificateManagerTrustConfig_tags(t *testing.T) {
 	})
 }
 
-func checkCertificateManagerTrustConfigWithTags(t *testing.T) func(s *terraform.State) error {
+func checkCertificateManagerIssuanceConfigWithTags(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		for name, rs := range s.RootModule().Resources {
-			if rs.Type != "google_certificate_manager_trust_config" {
+			if rs.Type != "google_certificate_manager_certificate_issuance_config" {
 				continue
 			}
 			if strings.HasPrefix(name, "data.") {
@@ -189,16 +99,16 @@ func checkCertificateManagerTrustConfigWithTags(t *testing.T) func(s *terraform.
 				return fmt.Errorf("tag value details (name) not found in response for namespaced name: %q, response: %v", configuredTagValueNamespacedName, respDescribe)
 			}
 
-			// 3. Get the tag bindings from the Certificate Manager Trust Config.
+			// 3. Get the tag bindings from the Certificate Manager Issuance Config.
 			parts := strings.Split(rs.Primary.ID, "/")
 			if len(parts) != 6 {
 				return fmt.Errorf("invalid resource ID format: %s", rs.Primary.ID)
 			}
 			project := parts[1]
 			location := parts[3]
-			trustConfigs_id := parts[5]
+			certificateIssuanceConfigs_id := parts[5]
 
-			parentURL := fmt.Sprintf("//certificatemanager.googleapis.com/projects/%s/locations/%s/trustConfigs/%s", project, location, trustConfigs_id)
+			parentURL := fmt.Sprintf("//certificatemanager.googleapis.com/projects/%s/locations/%s/certificateIssuanceConfigs/%s", project, location, certificateIssuanceConfigs_id)
 			var listBindingsURL string
 			if location == "global" || location == "" {
 				listBindingsURL = fmt.Sprintf("https://cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", url.QueryEscape(parentURL))
@@ -251,17 +161,65 @@ func checkCertificateManagerTrustConfigWithTags(t *testing.T) func(s *terraform.
 	}
 }
 
-func testAccCertificateManagerTrustConfigWithTags(context map[string]interface{}) string {
+func testAccCertificateManagerIssuanceConfigWithTags(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-	resource "google_certificate_manager_trust_config" "test" {
-	  name        = "tf-test-trust-config%{random_suffix}"
-        description = "sample description for the trust config 2"
-        location    = "global"
-        allowlisted_certificates  {
-          pem_certificate = file("test-fixtures/cert.pem") 
-        }
-tags = {
+	resource "google_certificate_manager_certificate_issuance_config" "test" {
+  name    = "tf-test-issuance-config%{random_suffix}"
+  description = "sample description for the certificate issuanceConfigs"
+  certificate_authority_config {
+    certificate_authority_service_config {
+        ca_pool = google_privateca_ca_pool.pool.id
+    }
+  }
+  lifetime = "1814400s"
+  rotation_window_percentage = 34
+  key_algorithm = "ECDSA_P256"
+  labels = { "name": "wrench", "count": "3" }
+  depends_on=[google_privateca_certificate_authority.ca_authority]
+  tags = {
 	"%{org}/%{tagKey}" = "%{tagValue}"
   }
-	}`, context)
+}
+resource "google_privateca_ca_pool" "pool" {
+  name     = "ca-pool%{random_suffix}"
+  location = "us-central1"
+  tier     = "ENTERPRISE"
+}
+resource "google_privateca_certificate_authority" "ca_authority" {
+  location = "us-central1"
+  pool = google_privateca_ca_pool.pool.name
+  certificate_authority_id = "ca-authority"
+  config {
+    subject_config {
+      subject {
+        organization = "HashiCorp"
+        common_name = "my-certificate-authority"
+      }
+      subject_alt_name {
+        dns_names = ["hashicorp.com"]
+      }
+    }
+    x509_config {
+      ca_options {
+        is_ca = true
+      }
+      key_usage {
+        base_key_usage {
+          cert_sign = true
+          crl_sign = true
+        }
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+  key_spec {
+    algorithm = "RSA_PKCS1_4096_SHA256"
+  }
+  // Disable CA deletion related safe checks for easier cleanup.
+  deletion_protection                    = false
+  skip_grace_period                      = true
+  ignore_active_certificates_on_deletion = true
+}`, context)
 }


### PR DESCRIPTION
Add tags field to service resource to allow setting tags on service resources at creation time.
Bug - b/337048407

```release-note:enhancement
certificatemanager: added `tags` field to `google_certificate_manager_certificate`, `google_certificate_manager_certificate_map`, `google_certificate_manager_certificate_issuance_config`, `google_certificate_manager_trust_config`, and `google_certificate_manager_dns_authorization` to allow setting tags at creation time
```

The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository
