### PR TITLE
Vmware: Add nsx_edge_config to google_vmwareengine_private_cloud

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -165,19 +165,20 @@ properties:
     description: |
       Network configuration in the consumer project with which the peering has to be done.
     required: true
-    immutable: true
     properties:
       - name: managementCidr
         type: String
         description: |
           Management CIDR used by VMware management appliances.
         required: true
+        immutable: true
       - name: vmwareEngineNetwork
         type: String
         description: |
           The relative resource name of the VMware Engine network attached to the private cloud.
           Specify the name in the following form: projects/{project}/locations/{location}/vmwareEngineNetworks/{vmwareEngineNetworkId}
           where {project} can either be a project number or a project ID.
+        immutable: true
       - name: vmwareEngineNetworkCanonical
         type: String
         description: |
@@ -199,6 +200,31 @@ properties:
         description: |
           DNS Server IP of the Private Cloud.
         output: true
+      - name: nsxEdgeConfig
+        type: NestedObject
+        description: |
+          The NSX Edge Cluster configuration.
+        properties:
+          - name: count
+            type: Integer
+            description: |
+              The number of NSX Edge nodes in the Edge Cluster.
+              Possible values are 2, 4, 6, 8.
+          - name: haMode
+            type: Enum
+            description: |
+              HA mode of the NSX Edge Cluster.
+            enum_values:
+              - ACTIVE_ACTIVE
+              - ACTIVE_STANDBY
+          - name: size
+            type: Enum
+            description: |
+              Form factor of the NSX Edge Cluster.
+            enum_values:
+              - SMALL
+              - LARGE
+              - XLARGE
   - name: managementCluster
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/samples/services/vmwareengine/vmware_engine_private_cloud_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vmwareengine/vmware_engine_private_cloud_full.tf.tmpl
@@ -6,6 +6,11 @@ resource "google_vmwareengine_private_cloud" "{{$.PrimaryResourceId}}" {
   network_config {
     management_cidr       = "192.168.30.0/24"
     vmware_engine_network = google_vmwareengine_network.pc-nw.id
+    nsx_edge_config {
+      count   = 2
+      ha_mode = "ACTIVE_STANDBY"
+      size    = "LARGE"
+    }
   }
   management_cluster {
     cluster_id = "{{index $.ResourceIdVars "management_cluster_id"}}"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -207,6 +207,11 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
   network_config {
     management_cidr = "192.168.0.0/24"
     vmware_engine_network = google_vmwareengine_network.vmw-engine-nw.id
+    nsx_edge_config {
+      count = 2
+      ha_mode = "ACTIVE_STANDBY"
+      size = "LARGE"
+    }
   }
   management_cluster {
     cluster_id = "tf-test-sample-mgmt-cluster-custom-core-count%{random_suffix}"
@@ -254,6 +259,11 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
   network_config {
     management_cidr = "192.168.0.0/24"
     vmware_engine_network = google_vmwareengine_network.vmw-engine-nw.id
+    nsx_edge_config {
+      count = 4
+      ha_mode = "ACTIVE_ACTIVE"
+      size = "XLARGE"
+    }
   }
   management_cluster {
     cluster_id = "tf-test-sample-mgmt-cluster-custom-core-count%{random_suffix}"


### PR DESCRIPTION
Adds `nsx_edge_config` block to the `google_vmwareengine_private_cloud` resource for public GA, enabling users to specify the number of edges, HA mode, and size for their Private Cloud.

Also transitions `network_config` immutability to its individual child fields to allow in-place updates for edge config mutations.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
vmwareengine: added `nsx_edge_config` block to `google_vmwareengine_private_cloud`
```