### PR TITLE
[Filestore] Enable regional endpoint (REP) support

### DIFF
--- a/mmv1/products/filestore/product.yaml
+++ b/mmv1/products/filestore/product.yaml
@@ -25,5 +25,7 @@ scopes:
 versions:
   - name: ga
     base_url: https://file.googleapis.com/v1/
+    rep_url: https://file.{{location}}.rep.googleapis.com/v1/
   - name: beta
     base_url: https://file.googleapis.com/v1beta1/
+    rep_url: https://file.{{location}}.rep.googleapis.com/v1beta1/

--- a/mmv1/templates/terraform/constants/filestore_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/filestore_instance.go.tmpl
@@ -16,8 +16,9 @@ func ModifyFilestoreInstanceReplica(config *transport_tpg.Config, d *schema.Reso
 		return fmt.Errorf("Unable to %q google_filestore_instance %q: %s", method, d.Id(), err)
 	}
 
+	location := tpgresource.LocationFromId(d.Id())
 	err = FilestoreOperationWaitTime(
-		config, res, project, "Modifying Filestore Instance Replica", userAgent,
+		config, res, project, location, "Modifying Filestore Instance Replica", userAgent,
 		d.Timeout(schema.TimeoutUpdate))
 
 	if err != nil {


### PR DESCRIPTION
### Description
Enables Regional Endpoint (REP) support for Filestore resources (`google_filestore_instance`, `google_filestore_backup`, `google_filestore_snapshot`).

### Changes Made
1. Updated `mmv1/products/filestore/product.yaml` to include `rep_url` for both GA (`v1`) and Beta (`v1beta1`) endpoints.
2. Updated `mmv1/templates/terraform/constants/filestore_instance.go.tmpl` to extract `location` and pass it to `FilestoreOperationWaitTime`.

### Testing
- Generated GA and Beta provider code via `make provider PRODUCT=filestore`.
- Verified local compilation and tests passing via `go test ./google/services/filestore`.

```release-note:enhancement
filestore: added regional endpoint (REP) support for `google_filestore_instance`, `google_filestore_backup`, and `google_filestore_snapshot`
```