### PR TITLE
datastream: fix perpetual replacement of postgresql connection profiles using server_verification

### DIFF
--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -135,6 +135,23 @@ samples:
           deletion_protection: "false"
         ignore_read_extra:
           - postgresql_profile.0.password
+  - name: datastream_connection_profile_postgresql_sslconfig_server_verification
+    primary_resource_id: default
+    external_providers: [random]
+    skip_vcr: true
+    tgc_skip_test: ssl_config examples are not supported in the TGC suite
+    steps:
+      - name: datastream_connection_profile_postgresql_sslconfig_server_verification
+        resource_id_vars:
+          connection_profile_id: profile-id
+          deletion_protection: "true"
+          database_instance_name: my-instance
+        test_vars_overrides:
+          deletion_protection: "false"
+        oics_vars_overrides:
+          deletion_protection: "false"
+        ignore_read_extra:
+          - postgresql_profile.0.password
   - name: datastream_connection_profile_salesforce
     primary_resource_id: default
     exclude_test: true
@@ -438,6 +455,11 @@ properties:
             exactly_one_of:
               - ssl_config.0.server_verification
               - ssl_config.0.server_and_client_verification
+            # caCertificate is "Input only" in the API, which returns serverVerification
+            # as an empty object; without block-level ignore_read the flattener nils the
+            # block before the field-level ignore_read applies, forcing replacement of
+            # the profile (and dependent streams) on every refresh.
+            ignore_read: true
             properties:
               - name: caCertificate
                 type: String

--- a/mmv1/templates/terraform/samples/services/datastream/datastream_connection_profile_postgresql_sslconfig_server_verification.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/datastream/datastream_connection_profile_postgresql_sslconfig_server_verification.tf.tmpl
@@ -1,0 +1,62 @@
+data "google_datastream_static_ips" "datastream_ips" {
+  location           = "us-central1"
+}
+
+resource "google_sql_database_instance" "instance" {
+  name             = "{{index $.ResourceIdVars "database_instance_name"}}"
+  database_version = "POSTGRES_15"
+  region           = "us-central1"
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled = true
+      ssl_mode = "ENCRYPTED_ONLY"
+      dynamic "authorized_networks" {
+        for_each = data.google_datastream_static_ips.datastream_ips.static_ips
+        iterator = ip
+
+        content {
+          name  = format("datastream-%d", ip.key)
+          value = ip.value
+        }
+      }
+    }
+  }
+
+  deletion_protection  = {{index $.ResourceIdVars "deletion_protection"}}
+}
+
+resource "google_sql_database" "db" {
+    instance = google_sql_database_instance.instance.name
+    name     = "db"
+}
+
+resource "random_password" "pwd" {
+  length  = 16
+  special = false
+}
+
+resource "google_sql_user" "user" {
+    name = "user"
+    instance = google_sql_database_instance.instance.name
+    password = random_password.pwd.result
+}
+
+resource "google_datastream_connection_profile" "{{$.PrimaryResourceId}}" {
+    display_name          = "Connection Profile"
+    location              = "us-central1"
+    connection_profile_id = "{{index $.ResourceIdVars "connection_profile_id"}}"
+
+    postgresql_profile {
+        hostname = google_sql_database_instance.instance.public_ip_address
+        port     = 5432
+        username = "user"
+        password = random_password.pwd.result
+        database = google_sql_database.db.name
+        ssl_config {
+            server_verification {
+              ca_certificate = google_sql_database_instance.instance.server_ca_cert.0.cert
+            }
+        }
+    }
+}


### PR DESCRIPTION
The Datastream API marks `serverVerification.caCertificate` as "Input only" and returns `serverVerification` as an empty object on read. The generated flatten nils the empty parent block (`len(original) == 0`) before the field-level `ignore_read` can apply, so every refresh empties the block in state and — the field being immutable — forces replacement of the connection profile and any dependent `google_datastream_stream`, triggering a full re-backfill on every apply.

`serverAndClientVerification` already carries block-level `ignore_read` and is unaffected; this applies the same to `serverVerification`. Also adds the previously missing `server_verification`-only example, whose generated test's post-apply plan check reproduces the bug (fails without this fix, passes with it).

Verified against the live API with a locally generated GA provider: with a healthy state, the released provider wipes the block on refresh and plans destroy/create; the patched provider preserves it and plans no changes.

Related to https://github.com/hashicorp/terraform-provider-google/issues/17352 (same defect class for MySQL, where per-field workarounds suffice because `*Set` marker booleans keep the block non-empty; PostgreSQL's API has no marker fields, so the block-level form is required).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
datastream: fixed perpetual diff and resource replacement on `google_datastream_connection_profile` for `postgresql_profile.ssl_config.server_verification`
```