### PR TITLE
Align Plugin Framework provider block cardinality with SDKv2

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
@@ -5,6 +5,7 @@ import (
 
     sdk_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+    "github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
     "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
     "github.com/hashicorp/terraform-plugin-framework/datasource"
     "github.com/hashicorp/terraform-plugin-framework/ephemeral"
@@ -230,6 +231,9 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
         },
         Blocks: map[string]schema.Block{
             "batching": schema.ListNestedBlock{
+                Validators: []validator.List{
+                    listvalidator.SizeAtMost(1),
+                },
                 NestedObject: schema.NestedBlockObject{
                     Attributes: map[string]schema.Attribute{
                         "send_after": schema.StringAttribute{
@@ -245,6 +249,9 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
                 },
             },
             "external_credentials": schema.ListNestedBlock{
+                Validators: []validator.List{
+                    listvalidator.SizeAtMost(1),
+                },
                 NestedObject: schema.NestedBlockObject{
                     Attributes: map[string]schema.Attribute{
                         "audience": schema.StringAttribute{


### PR DESCRIPTION
The SDKv2 provider schema declares `external_credentials` and `batching` with `MaxItems: 1`. The duplicated Plugin Framework schema declares both as plain `ListNestedBlock` with no size validator, so the two halves of the muxed provider disagree on cardinality.

Adds `listvalidator.SizeAtMost(1)` to both blocks.

Note for reviewers: `listvalidator.SizeAtMost(1)` is deliberate rather than incidental. Downstream consumers (for example the Pulumi Terraform bridge) recover a Plugin Framework block's `MaxItems` by matching the validator's description string, `list must contain at most 1 elements`. An equivalent hand-rolled validator would satisfy Terraform but leave the constraint undetectable downstream.

Related: hashicorp/terraform-provider-google#19643 tracks the same class of SDKv2-vs-Plugin-Framework provider schema divergence for string validation.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
provider: added validation to reject more than one `external_credentials` or `batching` block, matching the existing SDK behavior
```
