### PR TITLE
feat: add model, instruction, voice_sample_gcs_uri, and consent_audio_gcs_uri to google_ces_app synthesize_speech_configs

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -144,12 +144,35 @@ properties:
                 voice based on the other parameters such as language_code.
                 For the list of available voices, please refer to Supported voices and
                 languages from Cloud Text-to-Speech.
+            - name: voiceSampleGcsUri
+              type: String
+              description: |-
+                The Cloud Storage URI to the audio sample for voice cloning. The audio sample
+                should be a mono-channel, 24kHz WAV file.
+                Note: Please make sure the CES service agent
+                `service-<PROJECT-NUMBER>@gcp-sa-ces.iam.gserviceaccount.com` has
+                `storage.objects.get` permission to the Cloud Storage object.
             - name: speakingRate
               type: Double
               description: |-
                 The speaking rate/speed in the range [0.25, 2.0]. 1.0 is the normal native
                 speed supported by the specific voice. 2.0 is twice as fast, and 0.5 is
                 half as fast. Values outside of the range [0.25, 2.0] will return an error.
+            - name: model
+              type: String
+              description: |-
+                The model used to synthesize audio.
+                Currently supported values:
+                - "gemini-3.1-flash-tts-preview"
+                If empty, Chirp3-HD is used.
+            - name: instruction
+              type: String
+              description: |-
+                The instruction used to synthesize speech when using a generative model.
+            - name: consentAudioGcsUri
+              type: String
+              description: |-
+                The Cloud Storage URI to the consent audio for voice cloning.
         key_name: language_code
   - name: createTime
     type: String

--- a/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
@@ -38,11 +38,15 @@ resource "google_ces_app" "ces_app_basic" {
       language_code = "en-US"
       voice         = "en-US-Standard-A"
       speaking_rate = 1.0
+      model         = "gemini-3.1-flash-tts-preview"
+      instruction   = "Speak clearly in a professional and helpful tone."
     }
     synthesize_speech_configs {
       language_code = "es-ES"
       voice         = "es-ES-Standard-A"
       speaking_rate = 0.95
+      model         = "gemini-3.1-flash-tts-preview"
+      instruction   = "Habla de manera clara y profesional."
     }
 
     barge_in_config {

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -90,14 +90,20 @@ resource "google_ces_app" "ces_app_basic" {
 
   audio_processing_config {
     synthesize_speech_configs {
-      language_code = "en-US"
-      voice         = "en-US-Standard-A"
-      speaking_rate = 1.0
+      language_code         = "en-US"
+      voice                 = "en-US-Standard-A"
+      speaking_rate         = 1.0
+      model                 = "gemini-3.1-flash-tts-preview"
+      instruction           = "Speak clearly in a professional tone."
+      voice_sample_gcs_uri  = "gs://fake-app-audio-recordings/voice-sample.wav"
+      consent_audio_gcs_uri = "gs://fake-app-audio-recordings/consent.wav"
     }
     synthesize_speech_configs {
       language_code = "es-ES"
       voice         = "es-ES-Standard-A"
       speaking_rate = 0.95
+      model         = "gemini-3.1-flash-tts-preview"
+      instruction   = "Habla claramente."
     }
 
     barge_in_config {
@@ -282,14 +288,20 @@ resource "google_ces_app" "ces_app_basic" {
 
   audio_processing_config {
     synthesize_speech_configs {
-      language_code = "en-US"
-      voice         = "en-US-Standard-A"
-      speaking_rate = 1.0
+      language_code         = "en-US"
+      voice                 = "en-US-Standard-A"
+      speaking_rate         = 1.05
+      model                 = "gemini-3.1-flash-tts-preview"
+      instruction           = "Speak in an updated friendly tone."
+      voice_sample_gcs_uri  = "gs://fake-app-audio-recordings/voice-sample-updated.wav"
+      consent_audio_gcs_uri = "gs://fake-app-audio-recordings/consent-updated.wav"
     }
     synthesize_speech_configs {
       language_code = "es-ES"
       voice         = "es-ES-Standard-A"
-      speaking_rate = 0.95
+      speaking_rate = 1.0
+      model         = "gemini-3.1-flash-tts-preview"
+      instruction   = "Habla con tono amigable."
     }
 
     barge_in_config {


### PR DESCRIPTION
Supports generative TTS configuration and voice cloning fields in `google_ces_app.audio_processing_config.synthesize_speech_configs`:
- `model`: TTS model used to synthesize audio (e.g. `gemini-3.1-flash-tts-preview`, default `Chirp3-HD`).
- `instruction`: Instruction used to synthesize speech when using a generative model.
- `voice_sample_gcs_uri`: GCS URI to audio sample for voice cloning.
- `consent_audio_gcs_uri`: GCS URI to consent audio for voice cloning.

API Reference: https://docs.cloud.google.com/gemini-enterprise-cx/cx-agent-studio/reference/rest/v1/projects.locations.apps#App.SynthesizeSpeechConfig

```release-note:enhancement
ces: added `model`, `instruction`, `voice_sample_gcs_uri`, and `consent_audio_gcs_uri` fields to `google_ces_app.audio_processing_config.synthesize_speech_configs`
```
