### PR TITLE
bigquery: do not send access in update payload when omitted from config

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -41,6 +41,7 @@ include_in_tgc_next: true
 custom_code:
   constants: 'templates/terraform/constants/bigquery_dataset.go.tmpl'
   pre_read: 'templates/terraform/pre_read/bigquery_dataset.go.tmpl'
+  update_encoder: 'templates/terraform/update_encoder/bigquery_dataset.go.tmpl'
 custom_diff:
   - 'customCollationDiff'
 generate_list_resource: true

--- a/mmv1/templates/terraform/update_encoder/bigquery_dataset.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/bigquery_dataset.go.tmpl
@@ -1,0 +1,5 @@
+conf := d.GetRawConfig()
+if conf.IsNull() || !conf.Type().HasAttribute("access") || !conf.GetAttr("access").IsKnown() || conf.GetAttr("access").IsNull() || (conf.GetAttr("access").LengthInt() == 0 && !d.HasChange("access")) {
+	delete(obj, "access")
+}
+return obj, nil

--- a/mmv1/templates/terraform/update_encoder/bigquery_dataset.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/bigquery_dataset.go.tmpl
@@ -1,5 +1,4 @@
-conf := d.GetRawConfig()
-if conf.IsNull() || !conf.Type().HasAttribute("access") || !conf.GetAttr("access").IsKnown() || conf.GetAttr("access").IsNull() || (conf.GetAttr("access").LengthInt() == 0 && !d.HasChange("access")) {
+if !d.HasChange("access") {
 	delete(obj, "access")
 }
 return obj, nil

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_iam_member_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_iam_member_test.go
@@ -152,6 +152,33 @@ func TestAccBigqueryDatasetIamMember_iamMemberWithIAMCondition(t *testing.T) {
 	})
 }
 
+func TestAccBigqueryDatasetIamMember_datasetUpdatedDuringMemberDeletion(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	saID := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	expected := map[string]interface{}{
+		"role":        "roles/viewer",
+		"userByEmail": fmt.Sprintf("%s@%s.iam.gserviceaccount.com", saID, envvar.GetTestProjectFromEnv()),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryDatasetIamMember_datasetWithDescription(datasetID, saID, "Initial description"),
+				Check:  testAccCheckBigQueryDatasetIamMemberPresent(t, "google_bigquery_dataset.dataset", expected),
+			},
+			{
+				Config: testAccBigqueryDatasetIamMember_datasetUpdated(datasetID, "Updated description"),
+				Check:  testAccCheckBigQueryDatasetIamMemberAbsent(t, "google_bigquery_dataset.dataset", expected),
+			},
+		},
+	})
+}
+
 func TestAccBigqueryDatasetIamMember_iamMember(t *testing.T) {
 	t.Parallel()
 
@@ -493,4 +520,32 @@ resource "google_bigquery_dataset_iam_member" "access" {
   }
 }
 `, datasetID, serviceAccountID, condTitle2040, condExpr2040)
+}
+
+func testAccBigqueryDatasetIamMember_datasetWithDescription(datasetID, saID, description string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id  = "%s"
+  description = "%s"
+}
+
+resource "google_service_account" "bqviewer" {
+  account_id = "%s"
+}
+
+resource "google_bigquery_dataset_iam_member" "access" {
+  dataset_id = google_bigquery_dataset.dataset.dataset_id
+  role       = "roles/viewer"
+  member     = "serviceAccount:${google_service_account.bqviewer.email}"
+}
+`, datasetID, description, saID)
+}
+
+func testAccBigqueryDatasetIamMember_datasetUpdated(datasetID, description string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id  = "%s"
+  description = "%s"
+}
+`, datasetID, description)
 }

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_iam_member_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_iam_member_test.go
@@ -179,6 +179,34 @@ func TestAccBigqueryDatasetIamMember_datasetUpdatedDuringMemberDeletion(t *testi
 	})
 }
 
+func TestAccBigqueryDatasetIamMember_withDatasetAccessBlockAndIgnoreChanges(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	saID := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	ownerSaID := fmt.Sprintf("tf-owner-%s", acctest.RandString(t, 10))
+
+	expected := map[string]interface{}{
+		"role":        "roles/viewer",
+		"userByEmail": fmt.Sprintf("%s@%s.iam.gserviceaccount.com", saID, envvar.GetTestProjectFromEnv()),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryDatasetIamMember_datasetWithAccessAndIgnoreChanges(datasetID, saID, ownerSaID, "Initial description"),
+				Check:  testAccCheckBigQueryDatasetIamMemberPresent(t, "google_bigquery_dataset.dataset", expected),
+			},
+			{
+				Config: testAccBigqueryDatasetIamMember_datasetWithAccessAndIgnoreChangesUpdated(datasetID, ownerSaID, "Updated description"),
+				Check:  testAccCheckBigQueryDatasetIamMemberAbsent(t, "google_bigquery_dataset.dataset", expected),
+			},
+		},
+	})
+}
+
 func TestAccBigqueryDatasetIamMember_iamMember(t *testing.T) {
 	t.Parallel()
 
@@ -548,4 +576,62 @@ resource "google_bigquery_dataset" "dataset" {
   description = "%s"
 }
 `, datasetID, description)
+}
+
+func testAccBigqueryDatasetIamMember_datasetWithAccessAndIgnoreChanges(datasetID, saID, ownerSaID, description string) string {
+	return fmt.Sprintf(`
+resource "google_service_account" "bqowner" {
+  account_id = "%s"
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id  = "%s"
+  description = "%s"
+
+  access {
+    role          = "OWNER"
+    user_by_email = google_service_account.bqowner.email
+  }
+
+  lifecycle {
+    ignore_changes = [
+      access
+    ]
+  }
+}
+
+resource "google_service_account" "bqviewer" {
+  account_id = "%s"
+}
+
+resource "google_bigquery_dataset_iam_member" "access" {
+  dataset_id = google_bigquery_dataset.dataset.dataset_id
+  role       = "roles/viewer"
+  member     = "serviceAccount:${google_service_account.bqviewer.email}"
+}
+`, ownerSaID, datasetID, description, saID)
+}
+
+func testAccBigqueryDatasetIamMember_datasetWithAccessAndIgnoreChangesUpdated(datasetID, ownerSaID, description string) string {
+	return fmt.Sprintf(`
+resource "google_service_account" "bqowner" {
+  account_id = "%s"
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id  = "%s"
+  description = "%s"
+
+  access {
+    role          = "OWNER"
+    user_by_email = google_service_account.bqowner.email
+  }
+
+  lifecycle {
+    ignore_changes = [
+      access
+    ]
+  }
+}
+`, ownerSaID, datasetID, description)
 }


### PR DESCRIPTION
b/532408604

### Description
Fixes an issue where updating `google_bigquery_dataset` attributes overwrote fine-grained IAM resources (`google_bigquery_dataset_iam_member`, `google_bigquery_dataset_iam_binding`, and `google_bigquery_dataset_access`) with stale access lists from Terraform state.

### Changes
- Added an `update_encoder` for `google_bigquery_dataset` to omit `access` from update payloads when `access` is unchanged or ignored in HCL.
- Added acceptance tests `TestAccBigqueryDatasetIamMember_datasetUpdatedDuringMemberDeletion` and `TestAccBigqueryDatasetIamMember_withDatasetAccessBlockAndIgnoreChanges` to verify dataset updates do not restore deleted IAM members.


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
bigquery: fixed an issue where updating `google_bigquery_dataset` overwrote fine-grained IAM permissions 
```
