### PR TITLE
container: guard expandNodeConfig against nil/null raw config

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -1900,41 +1900,77 @@ func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *con
 		// start cpu_cfs_quota fix https://github.com/hashicorp/terraform-provider-google/issues/15767
 		// this makes the field conditional on appearance in configuration. This allows the API `true` default
 		// to override null, where currently we force-send null as false, which is wrong.
+		skipRawConfigSubFixes := false
 		rawConfigNPRoot := d.GetRawConfig()
-		// if we have a prefix, we're in `node_pool.N.` in GKE Cluster. Traverse the RawConfig object to reach that
-		// root, at which point local references work going forwards.
-		if prefix != "" {
+		if rawConfigNPRoot.IsNull() || !rawConfigNPRoot.IsKnown() {
+			skipRawConfigSubFixes = true
+		} else if prefix != "" {
 			parts := strings.Split(prefix, ".") // "node_pool.N." -> ["node_pool" "N", ""]
-			npIndex, err := strconv.Atoi(parts[1])
-			if err != nil { // no error return from expander
-			    panic(fmt.Errorf("unexpected format for node pool path prefix: %w. value: %v", err, prefix))
+			if len(parts) < 2 {
+				skipRawConfigSubFixes = true
+			} else {
+				npIndex, err := strconv.Atoi(parts[1])
+				if err != nil { // no error return from expander
+					skipRawConfigSubFixes = true
+				} else {
+					if rawConfigNPRoot.Type().HasAttribute("node_pool") {
+						nodePoolAttr := rawConfigNPRoot.GetAttr("node_pool")
+						if nodePoolAttr.IsNull() || !nodePoolAttr.IsKnown() || !nodePoolAttr.Type().IsCollectionType() || nodePoolAttr.LengthInt() <= int64(npIndex) {
+							skipRawConfigSubFixes = true
+						} else {
+							rawConfigNPRoot = nodePoolAttr.Index(cty.NumberIntVal(int64(npIndex)))
+						}
+					} else {
+						skipRawConfigSubFixes = true
+					}
+				}
 			}
-
-			rawConfigNPRoot = rawConfigNPRoot.GetAttr("node_pool").Index(cty.NumberIntVal(int64(npIndex)))
 		}
 
-		if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
-			if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
-				v := vKC.Index(cty.NumberIntVal(0)).GetAttr("cpu_cfs_quota");
-				if v == cty.NullVal(cty.Bool) {
-				    nc.KubeletConfig.CpuCfsQuota = true
-				} else if v.False() { // force-send explicit false to API
-					nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "CpuCfsQuota")
+		if !skipRawConfigSubFixes && !rawConfigNPRoot.IsNull() && rawConfigNPRoot.Type().HasAttribute("node_config") {
+			vNC := rawConfigNPRoot.GetAttr("node_config")
+			if !vNC.IsNull() && vNC.Type().IsCollectionType() && vNC.LengthInt() > 0 {
+				firstNC := vNC.Index(cty.NumberIntVal(0))
+				if firstNC.Type().HasAttribute("kubelet_config") {
+					vKC := firstNC.GetAttr("kubelet_config")
+					if !vKC.IsNull() && vKC.Type().IsCollectionType() && vKC.LengthInt() > 0 {
+						firstKC := vKC.Index(cty.NumberIntVal(0))
+						if firstKC.Type().HasAttribute("cpu_cfs_quota") {
+							v := firstKC.GetAttr("cpu_cfs_quota")
+							if v == cty.NullVal(cty.Bool) {
+								nc.KubeletConfig.CpuCfsQuota = true
+							} else if v.False() { // force-send explicit false to API
+								nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "CpuCfsQuota")
+							}
+						}
+					}
 				}
 			}
 		}
 		// end cpu_cfs_quota fix
 
 		// start shutdown_grace_period ForceSendFields fix
-		if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
-			if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
-				vSGP := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_seconds")
-				if vSGP != cty.NullVal(cty.Number) && !vSGP.IsNull() {
-					nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodSeconds")
-				}
-				vSGPC := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_critical_pods_seconds")
-				if vSGPC != cty.NullVal(cty.Number) && !vSGPC.IsNull() {
-					nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodCriticalPodsSeconds")
+		if !skipRawConfigSubFixes && !rawConfigNPRoot.IsNull() && rawConfigNPRoot.Type().HasAttribute("node_config") {
+			vNC := rawConfigNPRoot.GetAttr("node_config")
+			if !vNC.IsNull() && vNC.Type().IsCollectionType() && vNC.LengthInt() > 0 {
+				firstNC := vNC.Index(cty.NumberIntVal(0))
+				if firstNC.Type().HasAttribute("kubelet_config") {
+					vKC := firstNC.GetAttr("kubelet_config")
+					if !vKC.IsNull() && vKC.Type().IsCollectionType() && vKC.LengthInt() > 0 {
+						firstKC := vKC.Index(cty.NumberIntVal(0))
+						if firstKC.Type().HasAttribute("shutdown_grace_period_seconds") {
+							vSGP := firstKC.GetAttr("shutdown_grace_period_seconds")
+							if vSGP != cty.NullVal(cty.Number) && !vSGP.IsNull() {
+								nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodSeconds")
+							}
+						}
+						if firstKC.Type().HasAttribute("shutdown_grace_period_critical_pods_seconds") {
+							vSGPC := firstKC.GetAttr("shutdown_grace_period_critical_pods_seconds")
+							if vSGPC != cty.NullVal(cty.Number) && !vSGPC.IsNull() {
+								nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodCriticalPodsSeconds")
+							}
+						}
+					}
 				}
 			}
 		}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -779,3 +779,60 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 		})
 	}
 }
+
+func TestUnitExpandNodeConfig_nilNodePoolRawConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterSchema := map[string]*schema.Schema{
+		"node_config": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"kubelet_config": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"cpu_cfs_quota": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+								"shutdown_grace_period_seconds": {
+									Type:     schema.TypeInt,
+									Optional: true,
+								},
+								"shutdown_grace_period_critical_pods_seconds": {
+									Type:     schema.TypeInt,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	d := schema.TestResourceDataRaw(t, clusterSchema, map[string]interface{}{
+		"node_config": []interface{}{
+			map[string]interface{}{
+				"kubelet_config": []interface{}{
+					map[string]interface{}{
+						"cpu_cfs_quota": true,
+					},
+				},
+			},
+		},
+	})
+
+	v := d.Get("node_config")
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("expandNodeConfig panicked: %v", r)
+		}
+	}()
+	_ = expandNodeConfig(d, "node_pool.0.", v)
+}

--- a/mmv1/third_party/tgc_next/pkg/services/container/node_config.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/node_config.go
@@ -1792,26 +1792,53 @@ func expandNodeConfig(d tpgresource.TerraformResourceData, prefix string, v inte
 	if v, ok := nodeConfig["kubelet_config"]; ok {
 		nc.KubeletConfig = expandKubeletConfig(v)
 
+		skipRawConfigSubFixes := false
 		rawConfigNPRoot := d.GetRawConfig()
-		if !rawConfigNPRoot.IsNull() && rawConfigNPRoot.Type().IsObjectType() {
-			if prefix != "" {
-				parts := strings.Split(prefix, ".")
+		if rawConfigNPRoot.IsNull() || !rawConfigNPRoot.IsKnown() {
+			skipRawConfigSubFixes = true
+		} else if prefix != "" {
+			parts := strings.Split(prefix, ".")
+			if len(parts) < 2 {
+				skipRawConfigSubFixes = true
+			} else {
 				npIndex, err := strconv.Atoi(parts[1])
 				if err != nil {
-					panic(fmt.Errorf("unexpected format for node pool path prefix: %w. value: %v", err, prefix))
-				}
-				rawConfigNPRoot = rawConfigNPRoot.GetAttr("node_pool").Index(cty.NumberIntVal(int64(npIndex)))
-			}
-
-			if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
-				if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
-					vSGP := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_seconds")
-					if vSGP != cty.NullVal(cty.Number) && !vSGP.IsNull() {
-						nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodSeconds")
+					skipRawConfigSubFixes = true
+				} else {
+					if rawConfigNPRoot.Type().HasAttribute("node_pool") {
+						nodePoolAttr := rawConfigNPRoot.GetAttr("node_pool")
+						if nodePoolAttr.IsNull() || !nodePoolAttr.IsKnown() || !nodePoolAttr.Type().IsCollectionType() || nodePoolAttr.LengthInt() <= int64(npIndex) {
+							skipRawConfigSubFixes = true
+						} else {
+							rawConfigNPRoot = nodePoolAttr.Index(cty.NumberIntVal(int64(npIndex)))
+						}
+					} else {
+						skipRawConfigSubFixes = true
 					}
-					vSGPC := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_critical_pods_seconds")
-					if vSGPC != cty.NullVal(cty.Number) && !vSGPC.IsNull() {
-						nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodCriticalPodsSeconds")
+				}
+			}
+		}
+
+		if !skipRawConfigSubFixes && !rawConfigNPRoot.IsNull() && rawConfigNPRoot.Type().HasAttribute("node_config") {
+			vNC := rawConfigNPRoot.GetAttr("node_config")
+			if !vNC.IsNull() && vNC.Type().IsCollectionType() && vNC.LengthInt() > 0 {
+				firstNC := vNC.Index(cty.NumberIntVal(0))
+				if firstNC.Type().HasAttribute("kubelet_config") {
+					vKC := firstNC.GetAttr("kubelet_config")
+					if !vKC.IsNull() && vKC.Type().IsCollectionType() && vKC.LengthInt() > 0 {
+						firstKC := vKC.Index(cty.NumberIntVal(0))
+						if firstKC.Type().HasAttribute("shutdown_grace_period_seconds") {
+							vSGP := firstKC.GetAttr("shutdown_grace_period_seconds")
+							if vSGP != cty.NullVal(cty.Number) && !vSGP.IsNull() {
+								nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodSeconds")
+							}
+						}
+						if firstKC.Type().HasAttribute("shutdown_grace_period_critical_pods_seconds") {
+							vSGPC := firstKC.GetAttr("shutdown_grace_period_critical_pods_seconds")
+							if vSGPC != cty.NullVal(cty.Number) && !vSGPC.IsNull() {
+								nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodCriticalPodsSeconds")
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

### Description
This PR fixes a provider panic ("value is null") in `expandNodeConfig` that occurs when programmatic or generated clients (such as Config Connector, Crossplane's upjet, or specific sparse configurations) provision `google_container_cluster` without explicitly defining a `node_config` block.

#### Root Cause:
In GKE provider, `expandNodeConfig` attempts to safely traverse the raw HCL configuration (`d.GetRawConfig()`) to determine if `cpu_cfs_quota` or `shutdown_grace_period` fields were explicitly set, enabling their conditional API transmission. However, when the configuration lacks a `node_config` block or when `GetRawConfig()` is null, calling `.GetAttr("node_pool").Index(...)` on the null/nil cty value triggers a panic.

#### Changes:
1. **Defense-in-depth Safety Guards** (`mmv1/third_party/terraform/services/container/node_config.go.tmpl`):
   - Introduced a `skipRawConfigSubFixes` flag that skips raw-config-derived overrides if raw config is null, unknown, or missing attributes.
   - Guarded GKE cluster `node_pool` indexing logic to safely handle out-of-bounds indices and non-iterable collections before extracting child attributes.
   - Fully hardened all lookups to use `.Type().HasAttribute(...)` and `.Type().IsCollectionType()` defensively before querying indices.
2. **TGC_Next Sync** (`mmv1/third_party/tgc_next/pkg/services/container/node_config.go`):
   - Replicated identical safety guards in the TGC path for GKE to keep provider behavior consistent.
3. **Unit Testing** (`mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl`):
   - Added a new unit test `TestUnitExpandNodeConfig_nilNodePoolRawConfig` that builds a `ResourceData` with a null raw config via `schema.TestResourceDataRaw`, reproduces the scenario, and asserts that no panic occurs.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28190

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:container
gke: Guarded `expandNodeConfig` against `nil`/`null` raw configurations to prevent provider panic when `node_config` is missing or unconfigured.
```
