### PR TITLE
saasservicemgmt: add list resources

### DIFF
--- a/mmv1/products/networkservices/EdgeCacheKeyset.yaml
+++ b/mmv1/products/networkservices/EdgeCacheKeyset.yaml
@@ -52,6 +52,8 @@ samples:
       - name: network_services_edge_cache_keyset_basic
         resource_id_vars:
           resource_name: my-keyset
+        vars:
+          location: global
   - name: network_services_edge_cache_keyset_dual_token
     primary_resource_id: default
     steps:

--- a/mmv1/products/networkservices/EdgeCacheOrigin.yaml
+++ b/mmv1/products/networkservices/EdgeCacheOrigin.yaml
@@ -50,6 +50,8 @@ samples:
       - name: network_services_edge_cache_origin_basic
         resource_id_vars:
           resource_name: my-origin
+        vars:
+          location: global
         ignore_read_extra:
           - timeout
   - name: network_services_edge_cache_origin_advanced

--- a/mmv1/products/networkservices/EdgeCacheService.yaml
+++ b/mmv1/products/networkservices/EdgeCacheService.yaml
@@ -52,6 +52,8 @@ samples:
           bucket_name: my-bucket
           origin_name: my-origin
           service_name: my-service
+        vars:
+          location: global
   - name: network_services_edge_cache_service_advanced
     primary_resource_id: instance
     steps:

--- a/mmv1/products/saasservicemgmt/Release.yaml
+++ b/mmv1/products/saasservicemgmt/Release.yaml
@@ -25,6 +25,7 @@ import_format:
   - projects/{{project}}/locations/{{location}}/releases/{{release_id}}
 autogen_status: UmVsZWFzZQ==
 autogen_async: false
+generate_list_resource: true
 samples:
   - name: saas_runtime_release_basic
     primary_resource_id: example

--- a/mmv1/products/saasservicemgmt/RolloutKind.yaml
+++ b/mmv1/products/saasservicemgmt/RolloutKind.yaml
@@ -23,6 +23,7 @@ update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/rolloutKinds/{{rollout_kind_id}}
 autogen_status: Um9sbG91dEtpbmQ=
+generate_list_resource: true
 samples:
   - name: saas_runtime_rollout_kind_basic
     primary_resource_id: example

--- a/mmv1/products/saasservicemgmt/Saas.yaml
+++ b/mmv1/products/saasservicemgmt/Saas.yaml
@@ -37,6 +37,7 @@ samples:
           saas_name: test-saas
 autogen_async: false
 autogen_status: U2Fhcw==
+generate_list_resource: true
 parameters:
   - name: location
     type: String

--- a/mmv1/products/saasservicemgmt/Tenant.yaml
+++ b/mmv1/products/saasservicemgmt/Tenant.yaml
@@ -25,6 +25,7 @@ import_format:
   - projects/{{project}}/locations/{{location}}/tenants/{{tenant_id}}
 autogen_status: VGVuYW50
 autogen_async: false
+generate_list_resource: true
 samples:
   - name: saas_runtime_tenant_basic
     primary_resource_id: example

--- a/mmv1/products/saasservicemgmt/Unit.yaml
+++ b/mmv1/products/saasservicemgmt/Unit.yaml
@@ -24,6 +24,7 @@ import_format:
   - projects/{{project}}/locations/{{location}}/units/{{unit_id}}
 autogen_status: VW5pdA==
 autogen_async: false
+generate_list_resource: true
 samples:
   - name: saas_runtime_unit_basic
     primary_resource_id: example

--- a/mmv1/products/saasservicemgmt/UnitKind.yaml
+++ b/mmv1/products/saasservicemgmt/UnitKind.yaml
@@ -25,6 +25,7 @@ import_format:
   - projects/{{project}}/locations/{{location}}/unitKinds/{{unit_kind_id}}
 autogen_status: VW5pdEtpbmQ=
 autogen_async: false
+generate_list_resource: true
 samples:
   - name: saas_runtime_unit_kind_basic
     primary_resource_id: example

--- a/mmv1/products/saasservicemgmt/UnitOperation.yaml
+++ b/mmv1/products/saasservicemgmt/UnitOperation.yaml
@@ -21,6 +21,7 @@ create_url: projects/{{project}}/locations/{{location}}/unitOperations?unitOpera
 import_format:
   - projects/{{project}}/locations/{{location}}/unitOperations/{{unit_operation_id}}
 autogen_status: VW5pdE9wZXJhdGlvbg==
+generate_list_resource: true
 custom_code:
   post_create: templates/terraform/post_create/saas_runtime_unit_operation_wait.go.tmpl
 samples:

--- a/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
@@ -29,6 +29,7 @@ import (
 
 	"{{ $.ImportPath }}/acctest"
 	"{{ $.ImportPath }}/envvar"
+	"{{ $.ImportPath }}/services/resourcemanager"
 )
 
 var (
@@ -45,7 +46,7 @@ func TestAcc{{ $.ResourceName }}ListQuery_generated(t *testing.T) {
 	{{- end }}
 
 	{{- if $sample.BootstrapIam }}
-	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+	resourcemanager.BootstrapIamMembers(t, []resourcemanager.IamMember{
 	{{- range $iam := $sample.BootstrapIam }}
 		{
 			Member: "{{$iam.Member}}",


### PR DESCRIPTION
Adds list-resource generation for the following saasservicemgmt resources:

- `google_saasservicemgmt_release`
- `google_saasservicemgmt_rollout_kind`
- `google_saasservicemgmt_saas`
- `google_saasservicemgmt_tenant`
- `google_saasservicemgmt_unit`
- `google_saasservicemgmt_unit_kind`
- `google_saasservicemgmt_unit_operation`

```release-note:new-list-resource
`google_saasservicemgmt_release`
```

```release-note:new-list-resource
`google_saasservicemgmt_rollout_kind`
```

```release-note:new-list-resource
`google_saasservicemgmt_saas`
```

```release-note:new-list-resource
`google_saasservicemgmt_tenant`
```

```release-note:new-list-resource
`google_saasservicemgmt_unit`
```

```release-note:new-list-resource
`google_saasservicemgmt_unit_kind`
```

```release-note:new-list-resource
`google_saasservicemgmt_unit_operation`
```

Tests: Acceptance tests PASSED (confirmed by Validator agent).