### PR TITLE
Adjust random reviewer assignment

### DIFF
--- a/.ci/magician/github/membership_data.go
+++ b/.ci/magician/github/membership_data.go
@@ -61,18 +61,6 @@ var (
 
 	// This is for the random-assignee rotation.
 	reviewerRotation = map[string]ReviewerConfig{
-		"BBBmau": {
-			vacations: []Vacation{
-				{
-					startDate: newDate(2025, 7, 1),
-					endDate:   newDate(2025, 7, 17),
-				},
-				{
-					startDate: newDate(2026, 6, 11),
-					endDate:   newDate(2026, 6, 14),
-				},
-			},
-		},
 		"c2thorn": {
 			vacations: []Vacation{
 				{
@@ -88,9 +76,6 @@ var (
 					endDate:   newDate(2026, 7, 17),
 				},
 			},
-		},
-		"malhotrasagar2212": {
-			vacations: []Vacation{},
 		},
 		"melinath": {
 			vacations: []Vacation{
@@ -172,13 +157,15 @@ var (
 
 	// This is for new team members who are onboarding
 	trustedContributors = map[string]struct{}{
-		"bbasata":    {},
-		"tavasyag":   {},
-		"hao-nan-li": {},
-		"NickElliot": {},
-		"shuyama1":   {},
-		"trodge":     {},
-		"zli82016":   {},
-		"vr-ibm":     {},
+		"BBBmau":            {},
+		"malhotrasagar2212": {},
+		"bbasata":           {},
+		"tavasyag":          {},
+		"hao-nan-li":        {},
+		"NickElliot":        {},
+		"shuyama1":          {},
+		"trodge":            {},
+		"zli82016":          {},
+		"vr-ibm":            {},
 	}
 )


### PR DESCRIPTION
As discussed last week, send random review assignments to Googlers due to a temporary process adjustment on the Google side. This won't change direct assignment, just who the Magician assigns. 

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
