### PR TITLE
tgc: update bigquery dataset fixtures for default_collation

### DIFF
--- a/mmv1/third_party/tgc/tests/data/example_bigquery_dataset.json
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_dataset.json
@@ -18,6 +18,7 @@
           "goog-terraform-provisioned": "true"
         },
         "location": "EU",
+        "defaultCollation": "",
         "defaultTableExpirationMs": 3.6e+06
       }
     }

--- a/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_binding.json
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_binding.json
@@ -18,6 +18,7 @@
           "goog-terraform-provisioned": "true"
         },
         "location": "EU",
+        "defaultCollation": "",
         "friendlyName": ""
       }
     },

--- a/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_member.json
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_member.json
@@ -18,6 +18,7 @@
           "goog-terraform-provisioned": "true"
         },
         "location": "EU",
+        "defaultCollation": "",
         "friendlyName": ""
       }
     },

--- a/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_policy.json
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_policy.json
@@ -18,6 +18,7 @@
           "goog-terraform-provisioned": "true"
         },
         "location": "EU",
+        "defaultCollation": "",
         "friendlyName": ""
       }
     },

--- a/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_policy_empty_policy_data.json
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_policy_empty_policy_data.json
@@ -16,6 +16,7 @@
           "goog-terraform-provisioned": "true"
         },
         "location": "US",
+        "defaultCollation": "",
         "friendlyName": ""
       }
     },

--- a/mmv1/third_party/tgc/tests/data/example_google_datastream_stream.json
+++ b/mmv1/third_party/tgc/tests/data/example_google_datastream_stream.json
@@ -11,6 +11,7 @@
                 "datasetReference": {
                     "datasetId": "stpostgres"
                 },
+                "defaultCollation": "",
                 "description": "Database of postgres",
                 "friendlyName": "stpostgres",
                 "labels": {

--- a/mmv1/third_party/tgc/tests/data/example_google_datastream_stream_append_only.json
+++ b/mmv1/third_party/tgc/tests/data/example_google_datastream_stream_append_only.json
@@ -11,6 +11,7 @@
                 "datasetReference": {
                     "datasetId": "stpostgres"
                 },
+                "defaultCollation": "",
                 "description": "Database of postgres",
                 "friendlyName": "stpostgres",
                 "labels": {

--- a/mmv1/third_party/tgc/tests/data/example_google_logging_project_sink.json
+++ b/mmv1/third_party/tgc/tests/data/example_google_logging_project_sink.json
@@ -33,6 +33,7 @@
     "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
     "data": {
       "friendlyName": "",
+      "defaultCollation": "",
       "datasetReference": {
         "datasetId": "basic_logsink_dataset"
       },


### PR DESCRIPTION
Update BigQuery dataset TGC test fixtures as a followup to https://github.com/GoogleCloudPlatform/magic-modules/pull/18585.

Because `default_collation` is no longer computed, TGC now includes `"defaultCollation": ""` in the asset output for unconfigured datasets.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
