### PR TITLE
compute: add list resource for google_compute_health_check

### DIFF
--- a/mmv1/products/compute/HealthCheck.yaml
+++ b/mmv1/products/compute/HealthCheck.yaml
@@ -39,6 +39,7 @@ references:
 docs:
 base_url: 'projects/{{project}}/global/healthChecks'
 has_self_link: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20


### PR DESCRIPTION
Adds a new list resource `google_compute_health_check` for Terraform 1.14+ `terraform query` support. This allows users to list all Compute Engine health checks in a given project.

### Details
* Adds `generate_list_resource: true` to `mmv1/products/compute/HealthCheck.yaml`
* Adds generated list resource implementation for `google_compute_health_check`
* Adds generated acceptance test `TestAccComputeHealthCheckListQuery_generated`
* Adds generated documentation for the list resource

### Release Note Template for Downstream PRs (will be copied)
```release-note:enhancement
compute: added `google_compute_health_check` list resource for `terraform query` support
```