### PR TITLE
Set gatewaySecurityPolicy and location as immutable

### DIFF
--- a/mmv1/products/networksecurity/GatewaySecurityPolicy.yaml
+++ b/mmv1/products/networksecurity/GatewaySecurityPolicy.yaml
@@ -77,6 +77,7 @@ parameters:
       gatewaySecurityPolicy should match the pattern:(^a-z?$).
     url_param_only: true
     required: true
+    immutable: true
   - name: location
     type: String
     description: |
@@ -84,6 +85,7 @@ parameters:
       The default value is `global`.
     url_param_only: true
     default_value: global
+    immutable: true
 properties:
   - name: selfLink
     type: String


### PR DESCRIPTION
### Description
Mark `name` and `location` parameters as `immutable: true` on `GatewaySecurityPolicy`.

Previously, `immutable: true` was missing on the URL parameters `name` and `location` in `mmv1/products/networksecurity/GatewaySecurityPolicy.yaml`. As a result, the generated Terraform schema did not have `ForceNew: true`, causing Terraform to plan an in-place update when either field changed. During apply, this resulted in an invalid `PATCH` request to the new resource name/location endpoint and failed on subsequent state read with:

```text
Error: Provider produced inconsistent result after apply
Root object was present, but now absent.
```

Adding `immutable: true` ensures Terraform correctly plans a destroy-and-recreate (`ForceNew`) when `name` or `location` is changed.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
networksecurity: fixed `google_network_security_gateway_security_policy` to force replacement (`ForceNew`) when `name` or `location` is modified
```
