### PR TITLE
Add immutable attribute to TlsInspectionPolicy parameters

### DIFF
--- a/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
+++ b/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
@@ -71,11 +71,13 @@ parameters:
       Short name of the TlsInspectionPolicy resource to be created.
     url_param_only: true
     required: true
+    immutable: true
   - name: location
     type: String
     description: |
       The location of the tls inspection policy.
     url_param_only: true
+    immutable: true
 properties:
   - name: createTime
     type: Time


### PR DESCRIPTION
### Description
Mark `name` and `location` parameters as `immutable: true` on `TlsInspectionPolicy`.

Previously, `immutable: true` was missing on the URL parameters `name` and `location` in `mmv1/products/networksecurity/TlsInspectionPolicy.yaml`. As a result, the generated Terraform schema did not have `ForceNew: true`, causing Terraform to erroneously plan an in-place update when either field was changed. During apply, this resulted in an invalid `PATCH` request to the new resource name/location endpoint and failed on subsequent state read with:

```text
Error: Provider produced inconsistent result after apply
Root object was present, but now absent.
```

Adding `immutable: true` ensures Terraform correctly plans a destroy-and-recreate (`ForceNew`) when `name` or `location` is changed.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
networksecurity: fixed `google_network_security_tls_inspection_policy` to force replacement (`ForceNew`) when `name` or `location` is modified
```