### PR TITLE
Add immutable property to Gateway resource fields

### DIFF
--- a/mmv1/products/networkservices/Gateway.yaml
+++ b/mmv1/products/networkservices/Gateway.yaml
@@ -116,6 +116,7 @@ parameters:
       Name of the Gateway resource.
     url_param_only: true
     required: true
+    immutable: true
   - name: location
     type: String
     description: |
@@ -123,6 +124,7 @@ parameters:
       The default value is `global`.
     url_param_only: true
     default_value: global
+    immutable: true
 properties:
   - name: selfLink
     type: String


### PR DESCRIPTION
### Description
Mark `name` and `location` parameters as `immutable: true` on `Gateway`.

Previously, `immutable: true` was missing on the URL parameters `name` and `location` in `mmv1/products/networkservices/Gateway.yaml`. As a result, the generated Terraform schema did not have `ForceNew: true`, causing Terraform to erroneously plan an in-place update when either field was changed. During apply, this resulted in an invalid `PATCH` request to the new resource name/location endpoint and failed on subsequent state read with:

```text
Error: Provider produced inconsistent result after apply
Root object was present, but now absent.
```

Adding immutable: true ensures Terraform correctly plans a destroy-and-recreate (ForceNew) when name or location is changed.

Release Note Template for Downstream PRs (will be copied)

```release-note:bug
networkservices: fixed `google_network_services_gateway` to force replacement (`ForceNew`) when `name` or `location` is modified
```
