### PR TITLE
compute: add list resource for google_compute_backend_service

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -31,6 +31,7 @@ references:
 docs:
 base_url: 'projects/{{project}}/global/backendServices'
 has_self_link: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20


### PR DESCRIPTION
Adds a new list resource `google_compute_backend_service` for Terraform 1.14+ `terraform query` support. This allows users to list all Compute Engine backend services in a given project.

### Details
* Adds `generate_list_resource: true` to `mmv1/products/compute/BackendService.yaml`
* Adds generated list resource implementation for `google_compute_backend_service`
* Adds generated acceptance test `TestAccComputeBackendServiceListQuery_generated`
* Adds generated documentation for the list resource

### Release Note Template for Downstream PRs (will be copied)
```release-note:enhancement
compute: added `google_compute_backend_service` list resource for `terraform query` support
```