### PR TITLE
compute: update Address purpose description to include SYSTEM_MANAGED

### DIFF
--- a/mmv1/products/compute/Address.yaml
+++ b/mmv1/products/compute/Address.yaml
@@ -188,6 +188,10 @@ properties:
       configure Private Service Connect. Only global internal addresses can use
       this purpose.
 
+      * SYSTEM_MANAGED for regional internal IP address that is reserved and
+      managed internally. It can not be assigned to compute resources such as
+      VM and internal load balancer.
+
       This should only be set when using an Internal address.
     default_from_api: true
   - name: 'networkTier'


### PR DESCRIPTION
Updated Address purpose description to include the new `SYSTEM_MANAGED` value, which is used for Custom Hardware / Project Butter.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: updated `purpose` field description on `google_compute_address` to include `SYSTEM_MANAGED` (beta)
```
