### PR TITLE
feat: (storage) add crc32c verification for object content

### DIFF
--- a/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content.go
@@ -3,14 +3,16 @@ package storage
 import (
 	"crypto/sha512"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"hash/crc32"
 	"io/ioutil"
 	"net/http"
 
-	"github.com/hashicorp/terraform-provider-google/google/registry"
-	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/registry"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/storage/v1"
@@ -67,6 +69,10 @@ func dataSourceGoogleStorageBucketObjectContentRead(d *schema.ResourceData, meta
 
 	objectsService := storage.NewObjectsService(NewClient(config, userAgent))
 	getCall := objectsService.Get(bucket, name)
+	objectMeta, err := getCall.Do()
+	if err != nil {
+		return fmt.Errorf("Error reading storage bucket object metadata: %s", err)
+	}
 
 	res, err := getCall.Download()
 	if err != nil {
@@ -82,6 +88,20 @@ func dataSourceGoogleStorageBucketObjectContentRead(d *schema.ResourceData, meta
 			return fmt.Errorf("Error reading all  from res.Body: %s", err)
 		}
 		objectBytes = bodyBytes
+	}
+
+	crc32cTable := crc32.MakeTable(crc32.Castagnoli)
+	checksum := crc32.Checksum(objectBytes, crc32cTable)
+	crc32cBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(crc32cBytes, checksum)
+	calculatedCrc32c := base64.StdEncoding.EncodeToString(crc32cBytes)
+
+	if objectMeta.Crc32c != "" && calculatedCrc32c != objectMeta.Crc32c {
+		return fmt.Errorf("CRC32C checksum mismatch for storage bucket object %s: computed %s, expected %s from metadata", name, calculatedCrc32c, objectMeta.Crc32c)
+	}
+
+	if err := d.Set("crc32c", calculatedCrc32c); err != nil {
+		return fmt.Errorf("Error setting crc32c: %s", err)
 	}
 
 	if err := d.Set("content", string(objectBytes)); err != nil {

--- a/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content.go
@@ -10,9 +10,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/registry"
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/storage/v1"

--- a/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
@@ -82,6 +82,9 @@ func TestAccDataSourceStorageBucketObjectContent_Crc32cMismatch(t *testing.T) {
 
 	providerInstance := provider.Provider()
 	oldConfigureFunc := providerInstance.ConfigureContextFunc
+	t.Cleanup(func() {
+		providerInstance.ConfigureContextFunc = oldConfigureFunc
+	})
 	providerInstance.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		c, diagnostics := oldConfigureFunc(ctx, d)
 		if diagnostics.HasError() {
@@ -155,10 +158,10 @@ func TestAccDataSourceStorageBucketObjectContent_FileContentBase64(t *testing.T)
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		ExternalProviders: map[string]resource.ExternalProvider{
-			"local": resource.ExternalProvider{
+			"local": {
 				VersionConstraint: "> 2.5.0",
 			},
-			"archive": resource.ExternalProvider{
+			"archive": {
 				VersionConstraint: "> 2.5.0",
 			},
 		},
@@ -219,7 +222,6 @@ func testAccDataSourceStorageBucketObjectContent_FileContentBase64(bucket, folde
 resource "google_storage_bucket" "this" {
   name                        = "%s"
   location                    = "us-east4"
-  uniform_bucket_level_access = true
 }
 
 data "archive_file" "this" {
@@ -278,13 +280,23 @@ func TestAccDataSourceStorageBucketObjectContent_Issue15717BackwardCompatibility
 	content := "qwertyuioasdfghjk1234567!!@#$*"
 
 	config := fmt.Sprintf(`
-%s
+resource "google_storage_bucket" "contenttest" {
+	name          = "%s"
+	location      = "US"
+	force_destroy = true
+}
+
+resource "google_storage_bucket_object" "object" {
+	name    = "butterfly01"
+	content = "%s"
+	bucket  = google_storage_bucket.contenttest.name
+}
 
 data "google_storage_bucket_object_content" "new" {
 	bucket  = google_storage_bucket.contenttest.name
 	content = "%s"
 	name    = google_storage_bucket_object.object.name
-}`, testAccDataSourceStorageBucketObjectContent_Basic(content, bucket), content)
+}`, bucket, content, content)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
@@ -2,17 +2,115 @@ package storage_test
 
 import (
 	"archive/zip"
+	"bytes"
+	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/provider"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/storage"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
+
+type crc32cMismatchRoundTripper struct {
+	http.RoundTripper
+	bucketName string
+	objectName string
+}
+
+func (t *crc32cMismatchRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	response, err := t.RoundTripper.RoundTrip(r)
+	if err != nil || response.StatusCode != http.StatusOK {
+		return response, err
+	}
+
+	// Intercept object metadata GET requests and mutate the returned CRC32c checksum.
+	// We distinguish metadata GET requests from payload download requests by ensuring
+	// the `alt=media` query parameter is NOT present.
+	if r.Method == http.MethodGet &&
+		strings.Contains(r.URL.Path, fmt.Sprintf("/b/%s/o/%s", t.bucketName, t.objectName)) &&
+		r.URL.Query().Get("alt") != "media" {
+
+		responseBytes, readErr := io.ReadAll(response.Body)
+		response.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		var responseMap map[string]interface{}
+		if jsonErr := json.Unmarshal(responseBytes, &responseMap); jsonErr != nil {
+			return nil, jsonErr
+		}
+
+		// Inject a mismatched base64-encoded CRC32c checksum.
+		// Standard valid GCS CRC32c hashes are 4 bytes, base64-encoded.
+		responseMap["crc32c"] = "MismatchedCrc32cForTesting=="
+
+		newBytes, marshalErr := json.Marshal(responseMap)
+		if marshalErr != nil {
+			return nil, marshalErr
+		}
+
+		response.Body = io.NopCloser(bytes.NewReader(newBytes))
+		response.ContentLength = int64(len(newBytes))
+		response.Header.Set("Content-Length", strconv.Itoa(len(newBytes)))
+	}
+
+	return response, err
+}
+
+func TestAccDataSourceStorageBucketObjectContent_Crc32cMismatch(t *testing.T) {
+	acctest.SkipIfVcr(t)
+
+	bucket := "tf-bucket-object-content-" + acctest.RandString(t, 10)
+	content := "qwertyuioasdfghjk1234567!!@#$*"
+	objectName := "butterfly01"
+
+	providerInstance := provider.Provider()
+	oldConfigureFunc := providerInstance.ConfigureContextFunc
+	providerInstance.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		c, diagnostics := oldConfigureFunc(ctx, d)
+		if diagnostics.HasError() {
+			return c, diagnostics
+		}
+		config := c.(*transport_tpg.Config)
+		config.Client.Transport = &crc32cMismatchRoundTripper{
+			RoundTripper: config.Client.Transport,
+			bucketName:   bucket,
+			objectName:   objectName,
+		}
+		return c, diagnostics
+	}
+
+	providers := map[string]*schema.Provider{
+		"google": providerInstance,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:  func() { acctest.AccTestPreCheck(t) },
+		Providers: providers,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceStorageBucketObjectContent_Basic(content, bucket),
+				ExpectError: regexp.MustCompile("CRC32C checksum mismatch for storage bucket object"),
+			},
+		},
+	})
+}
 
 func TestAccDataSourceStorageBucketObjectContent_Basic(t *testing.T) {
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
storage: added crc32c verification for data `google_storage_bucket_object_content`
```
