### PR TITLE
Update dataproc batch tests to use new public bucket.

### DIFF
--- a/mmv1/templates/terraform/samples/services/dataproc/dataproc_batch_pyspark.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dataproc/dataproc_batch_pyspark.tf.tmpl
@@ -13,14 +13,14 @@ resource "google_dataproc_batch" "{{$.PrimaryResourceId}}" {
     }
 
     pyspark_batch {
-      main_python_file_uri = "https://storage.googleapis.com/terraform-batches/test_util.py"
+      main_python_file_uri = "https://storage.googleapis.com/terraform-serverless/test_util.py"
       args                 = ["10"]
       jar_file_uris        = ["file:///usr/lib/spark/examples/jars/spark-examples.jar"]
       python_file_uris     = ["gs://dataproc-examples/pyspark/hello-world/hello-world.py"]
       archive_uris         = [
-        "https://storage.googleapis.com/terraform-batches/animals.txt.tar.gz#unpacked",
-        "https://storage.googleapis.com/terraform-batches/animals.txt.jar",
-        "https://storage.googleapis.com/terraform-batches/animals.txt"
+        "https://storage.googleapis.com/terraform-serverless/animals.txt.tar.gz#unpacked",
+        "https://storage.googleapis.com/terraform-serverless/animals.txt.jar",
+        "https://storage.googleapis.com/terraform-serverless/animals.txt"
       ]
       file_uris            = ["https://storage.googleapis.com/terraform-batches/people.txt"]
     }

--- a/mmv1/templates/terraform/samples/services/dataproc/dataproc_batch_sparkr.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dataproc/dataproc_batch_sparkr.tf.tmpl
@@ -17,8 +17,8 @@ resource "google_dataproc_batch" "{{$.PrimaryResourceId}}" {
     }
 
     spark_r_batch {
-      main_r_file_uri  = "https://storage.googleapis.com/terraform-batches/spark-r-flights.r"
-      args             = ["https://storage.googleapis.com/terraform-batches/flights.csv"]
+      main_r_file_uri  = "https://storage.googleapis.com/terraform-serverless/spark-r-flights.r"
+      args             = ["https://storage.googleapis.com/terraform-serverless/flights.csv"]
     }
 }
 


### PR DESCRIPTION
Update dataproc batch tests to use new public bucket.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/25952 
Fixes https://github.com/hashicorp/terraform-provider-google/issues/25955

```release-note:bug
dataproc: Updated `terraform-batches` bucket to `terraform-serverless` bucket to fix `google_dataproc_batch` resource tests.
```
