### PR TITLE
ci: Add disallow-legacy-apiary presubmit check to basic-pr-checks

### DIFF
--- a/.github/workflows/unit-test-mmv1.yml
+++ b/.github/workflows/unit-test-mmv1.yml
@@ -72,6 +72,29 @@ jobs:
             echo $newtmplfiles
             go run main.go unused-tmpl --file-list $newtmplfiles
           fi
+  disallow-legacy-apiary:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: repo
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Merge base branch
+        if: github.event_name == 'pull_request'
+        id: pull_request
+        run: |
+          cd repo
+          git config user.name "modular-magician"
+          git config user.email "magic-modules@google.com"
+          git fetch origin ${GITHUB_BASE_REF} # Fetch the base branch
+          git merge --no-ff origin/${GITHUB_BASE_REF} # Merge with the base branch
+      - name: Check for legacy Apiary usage
+        run: |
+          cd repo/tools/template-check
+          base_ref="${GITHUB_BASE_REF:-main}"
+          go run main.go disallow-legacy-apiary --base-ref "origin/${base_ref}"
   lint-yaml:
     runs-on: ubuntu-22.04
     steps:

--- a/tools/template-check/cmd/disallow_legacy_apiary.go
+++ b/tools/template-check/cmd/disallow_legacy_apiary.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const disallowLegacyApiaryDesc = "Check git diff for forbidden legacy Apiary Compute client imports and invocations."
+
+var (
+	legacyComputeImportRegex = regexp.MustCompile(`^\+[[:space:]]*(?:import[[:space:]]+)?(?:[a-zA-Z0-9_.]+[[:space:]]+)?"google\.golang\.org/api/compute/`)
+	legacyComputeCallRegex   = regexp.MustCompile(`^\+[[:space:]]*.*(?:DEPRECATED_LegacyApiaryClient|tpgcompute\.(?:NewClient|DEPRECATED_LegacyApiaryClient)|compute_tpg\.(?:NewClient|DEPRECATED_LegacyApiaryClient))`)
+
+	checkedPathspecs = []string{
+		"mmv1/templates/terraform/**.tmpl",
+		"mmv1/third_party/terraform/**.go",
+		"mmv1/third_party/terraform/**.go.tmpl",
+		"mmv1/third_party/cai2hcl/**.go",
+		"mmv1/third_party/tgc*/**.go",
+		"mmv1/third_party/tgc*/**.go.tmpl",
+	}
+)
+
+type DisallowedMatch struct {
+	File    string
+	Line    string
+	Pattern string
+}
+
+type disallowLegacyApiaryOptions struct {
+	rootOptions *rootOptions
+	stdout      io.Writer
+	stderr      io.Writer
+	baseRef     string
+	repoDir     string
+	diffFile    string
+}
+
+func newDisallowLegacyApiaryCmd(rootOptions *rootOptions) *cobra.Command {
+	o := &disallowLegacyApiaryOptions{
+		rootOptions: rootOptions,
+		stdout:      os.Stdout,
+		stderr:      os.Stderr,
+	}
+
+	command := &cobra.Command{
+		Use:   "disallow-legacy-apiary",
+		Short: disallowLegacyApiaryDesc,
+		Long:  disallowLegacyApiaryDesc,
+		RunE: func(c *cobra.Command, args []string) error {
+			return o.run()
+		},
+	}
+
+	command.Flags().StringVar(&o.baseRef, "base-ref", "", "base git ref to diff against (e.g. origin/main)")
+	command.Flags().StringVar(&o.repoDir, "repo-dir", "", "path to repository root (defaults to git repository root)")
+	command.Flags().StringVar(&o.diffFile, "diff-file", "", "optional path to a unified diff file to inspect instead of running git diff")
+
+	return command
+}
+
+func (o *disallowLegacyApiaryOptions) run() error {
+	var diffReader io.Reader
+
+	if o.diffFile != "" {
+		if o.diffFile == "-" {
+			diffReader = os.Stdin
+		} else {
+			f, err := os.Open(o.diffFile)
+			if err != nil {
+				return fmt.Errorf("failed to open diff file %s: %w", o.diffFile, err)
+			}
+			defer f.Close()
+			diffReader = f
+		}
+	} else {
+		repoDir := o.repoDir
+		if repoDir == "" {
+			var err error
+			repoDir, err = findRepoRoot(".")
+			if err != nil {
+				return err
+			}
+		}
+
+		baseRef := o.baseRef
+		if baseRef == "" || baseRef == "origin/" {
+			var err error
+			baseRef, err = resolveDefaultBaseRef(repoDir)
+			if err != nil {
+				return err
+			}
+		}
+
+		diffOutput, err := runGitDiff(repoDir, baseRef, checkedPathspecs)
+		if err != nil {
+			return err
+		}
+		diffReader = bytes.NewReader(diffOutput)
+	}
+
+	matches, err := CheckLegacyApiaryDiff(diffReader)
+	if err != nil {
+		return err
+	}
+
+	if len(matches) > 0 {
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
+			fmt.Fprintln(o.stderr, "::error::New calls or imports of the legacy Apiary Compute client are strictly forbidden:")
+		} else {
+			fmt.Fprintln(o.stderr, "New calls or imports of the legacy Apiary Compute client are strictly forbidden:")
+		}
+
+		for _, m := range matches {
+			if m.File != "" {
+				fmt.Fprintf(o.stderr, "  %s: %s\n", m.File, strings.TrimSpace(m.Line))
+			} else {
+				fmt.Fprintf(o.stderr, "  %s\n", strings.TrimSpace(m.Line))
+			}
+		}
+
+		fmt.Fprintln(o.stderr, "Please use transport_tpg.SendRequest instead. See PR #16847 for details.")
+		return fmt.Errorf("found %d forbidden legacy Apiary Compute client reference(s)", len(matches))
+	}
+
+	return nil
+}
+
+// CheckLegacyApiaryDiff scans a unified diff stream and identifies newly added lines
+// that import or call the legacy Apiary Compute client.
+func CheckLegacyApiaryDiff(r io.Reader) ([]DisallowedMatch, error) {
+	var matches []DisallowedMatch
+	var currentFile string
+
+	scanner := bufio.NewScanner(r)
+	// Allow scanning lines up to 10MB to handle large diff hunks
+	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.HasPrefix(line, "diff --git ") {
+			parts := strings.Fields(line)
+			if len(parts) >= 4 && strings.HasPrefix(parts[3], "b/") {
+				currentFile = strings.TrimPrefix(parts[3], "b/")
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, "+++ b/") {
+			currentFile = strings.TrimPrefix(line, "+++ b/")
+			continue
+		}
+
+		// Ignore diff headers and non-added lines
+		if strings.HasPrefix(line, "+++") || !strings.HasPrefix(line, "+") {
+			continue
+		}
+
+		if legacyComputeImportRegex.MatchString(line) {
+			matches = append(matches, DisallowedMatch{
+				File:    currentFile,
+				Line:    strings.TrimPrefix(line, "+"),
+				Pattern: "legacy compute import",
+			})
+		} else if legacyComputeCallRegex.MatchString(line) {
+			matches = append(matches, DisallowedMatch{
+				File:    currentFile,
+				Line:    strings.TrimPrefix(line, "+"),
+				Pattern: "legacy compute invocation",
+			})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading diff: %w", err)
+	}
+
+	return matches, nil
+}
+
+func findRepoRoot(startDir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = startDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to find git repository root: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func resolveDefaultBaseRef(repoDir string) (string, error) {
+	candidates := []string{"origin/main", "upstream/main", "main"}
+	for _, c := range candidates {
+		cmd := exec.Command("git", "rev-parse", "--verify", c)
+		cmd.Dir = repoDir
+		if err := cmd.Run(); err == nil {
+			return c, nil
+		}
+	}
+	return "HEAD~1", nil
+}
+
+func runGitDiff(repoDir, baseRef string, pathspecs []string) ([]byte, error) {
+	args := []string{"diff", "-U0", baseRef, "--"}
+	args = append(args, pathspecs...)
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoDir
+
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("git diff failed: %s (stderr: %s)", exitErr, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("git diff failed: %w", err)
+	}
+
+	return out, nil
+}

--- a/tools/template-check/cmd/disallow_legacy_apiary_test.go
+++ b/tools/template-check/cmd/disallow_legacy_apiary_test.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckLegacyApiaryDiff_ForbiddenImports(t *testing.T) {
+	testCases := []struct {
+		name string
+		diff string
+	}{
+		{
+			name: "single line import",
+			diff: `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -10,0 +11,1 @@
++import "google.golang.org/api/compute/v1"
+`,
+		},
+		{
+			name: "single line import with alias",
+			diff: `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -10,0 +11,1 @@
++import compute "google.golang.org/api/compute/v1"
+`,
+		},
+		{
+			name: "block import line",
+			diff: `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -10,0 +11,1 @@
++	"google.golang.org/api/compute/v1"
+`,
+		},
+		{
+			name: "block import line with alias",
+			diff: `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -10,0 +11,1 @@
++	compute "google.golang.org/api/compute/v0.alpha"
+`,
+		},
+		{
+			name: "blank import",
+			diff: `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -10,0 +11,1 @@
++	_ "google.golang.org/api/compute/v1"
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches, err := CheckLegacyApiaryDiff(strings.NewReader(tc.diff))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(matches) != 1 {
+				t.Fatalf("expected 1 match, got %d", len(matches))
+			}
+			if matches[0].File != "mmv1/third_party/terraform/services/compute/resource_instance.go" {
+				t.Errorf("expected file mmv1/third_party/terraform/services/compute/resource_instance.go, got %s", matches[0].File)
+			}
+			if matches[0].Pattern != "legacy compute import" {
+				t.Errorf("expected pattern 'legacy compute import', got %s", matches[0].Pattern)
+			}
+		})
+	}
+}
+
+func TestCheckLegacyApiaryDiff_ForbiddenCalls(t *testing.T) {
+	testCases := []struct {
+		name string
+		diff string
+	}{
+		{
+			name: "tpgcompute.NewClient",
+			diff: `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -50,0 +51,1 @@
++	c, err := tpgcompute.NewClient(config)
+`,
+		},
+		{
+			name: "compute_tpg.NewClient",
+			diff: `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -50,0 +51,1 @@
++	c, err := compute_tpg.NewClient(config)
+`,
+		},
+		{
+			name: "DEPRECATED_LegacyApiaryClient property",
+			diff: `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -50,0 +51,1 @@
++	client := config.DEPRECATED_LegacyApiaryClient
+`,
+		},
+		{
+			name: "tpgcompute.DEPRECATED_LegacyApiaryClient func",
+			diff: `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -50,0 +51,1 @@
++	client := tpgcompute.DEPRECATED_LegacyApiaryClient(config)
+`,
+		},
+		{
+			name: "compute_tpg.DEPRECATED_LegacyApiaryClient func",
+			diff: `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -50,0 +51,1 @@
++	client := compute_tpg.DEPRECATED_LegacyApiaryClient(config)
+`,
+		},
+		{
+			name: "DEPRECATED_LegacyApiaryClient in template .tmpl file",
+			diff: `diff --git a/mmv1/templates/terraform/custom_expand/route_instance.tmpl b/mmv1/templates/terraform/custom_expand/route_instance.tmpl
+--- a/mmv1/templates/terraform/custom_expand/route_instance.tmpl
++++ b/mmv1/templates/terraform/custom_expand/route_instance.tmpl
+@@ -15,0 +16,1 @@
++		nextInstance, err := DEPRECATED_LegacyApiaryClient(config, userAgent).Instances.Get(val.Project, val.Zone, val.Name).Do()
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches, err := CheckLegacyApiaryDiff(strings.NewReader(tc.diff))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(matches) != 1 {
+				t.Fatalf("expected 1 match, got %d", len(matches))
+			}
+			if matches[0].Pattern != "legacy compute invocation" {
+				t.Errorf("expected pattern 'legacy compute invocation', got %s", matches[0].Pattern)
+			}
+		})
+	}
+}
+
+func TestCheckLegacyApiaryDiff_AllowedChanges(t *testing.T) {
+	diff := `diff --git a/mmv1/third_party/terraform/services/compute/resource_instance.go b/mmv1/third_party/terraform/services/compute/resource_instance.go
+--- a/mmv1/third_party/terraform/services/compute/resource_instance.go
++++ b/mmv1/third_party/terraform/services/compute/resource_instance.go
+@@ -10,3 +10,3 @@
+-	"google.golang.org/api/compute/v1"
+-	c, err := tpgcompute.NewClient(config)
+ 	existingContextLine := config.DEPRECATED_LegacyApiaryClient
++	// Modern replacement
++	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
++		Config: config,
++		Method: "GET",
++		RawURL: url,
++	})
++	"google.golang.org/api/container/v1"
+diff --git a/mmv1/third_party/terraform/services/compute/DEPRECATED_LegacyApiaryClient.go b/mmv1/third_party/terraform/services/compute/DEPRECATED_LegacyApiaryClient.go
+--- a/mmv1/third_party/terraform/services/compute/DEPRECATED_LegacyApiaryClient.go
++++ b/mmv1/third_party/terraform/services/compute/DEPRECATED_LegacyApiaryClient.go
+@@ -1,1 +1,1 @@
+-old
++new
+`
+
+	matches, err := CheckLegacyApiaryDiff(strings.NewReader(diff))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected 0 matches, got %d: %+v", len(matches), matches)
+	}
+}
+
+func TestCheckedPathspecs(t *testing.T) {
+	expected := []string{
+		"mmv1/templates/terraform/**.tmpl",
+		"mmv1/third_party/terraform/**.go",
+		"mmv1/third_party/terraform/**.go.tmpl",
+		"mmv1/third_party/cai2hcl/**.go",
+		"mmv1/third_party/tgc*/**.go",
+		"mmv1/third_party/tgc*/**.go.tmpl",
+	}
+
+	if len(checkedPathspecs) != len(expected) {
+		t.Fatalf("expected %d pathspecs, got %d", len(expected), len(checkedPathspecs))
+	}
+	for i, p := range expected {
+		if checkedPathspecs[i] != p {
+			t.Errorf("expected pathspec %d to be %q, got %q", i, p, checkedPathspecs[i])
+		}
+	}
+}

--- a/tools/template-check/cmd/root.go
+++ b/tools/template-check/cmd/root.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const rootCmdDesc = "Utilities for template checks."
+const rootCmdDesc = "Utilities for repository and template checks."
 
 type rootOptions struct {
 }
@@ -23,6 +23,7 @@ func newRootCmd() (*cobra.Command, *rootOptions, error) {
 	}
 	cmd.AddCommand(newversionGuardCmd(o))
 	cmd.AddCommand(newUnusedTmplCmd(o))
+	cmd.AddCommand(newDisallowLegacyApiaryCmd(o))
 	return cmd, o, nil
 }
 


### PR DESCRIPTION
### Summary
Add an automated `disallow-legacy-apiary` presubmit job to `.github/workflows/basic-pr-checks.yml` to prevent PRs from introducing new imports of the legacy Apiary client (`google.golang.org/api/compute/*`) or calls to deprecated client factories in handwritten overrides and templates.
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
