### PR TITLE
fix: mark google_network_services_gateway name as immutable

### DIFF
--- a/mmv1/products/networkservices/Gateway.yaml
+++ b/mmv1/products/networkservices/Gateway.yaml
@@ -115,6 +115,7 @@ parameters:
     description: |
       Name of the Gateway resource.
     url_param_only: true
+    immutable: true
     required: true
   - name: location
     type: String


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#27894

Marks `name` as `immutable: true` in `Gateway.yaml` so Terraform correctly plans a destroy+recreate when the gateway name changes. Previously, renaming the gateway showed as an in-place update, then 404'd on apply since the API resource URL is name-based and cannot be PATCHed.

### Details
* Adds `immutable: true` to the `name` parameter in `mmv1/products/networkservices/Gateway.yaml`
* Generates `ForceNew: true` on the `name` field in `google_network_services_gateway` schema

### Release Note Template for Downstream PRs (will be copied)
```release-note:bug
networkservices: fixed `google_network_services_gateway` to correctly plan destroy+recreate when `name` is changed
```