### PR TITLE
fix(sql): set resource identity before early-return in resourceSqlUserRead for stopped instances

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -453,6 +453,15 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project":  project,
+		"instance": instance,
+		"host":     host,
+		"name":     name,
+	}); err != nil {
+		return err
+	}
+
 	if databaseInstance.Settings.ActivationPolicy != "ALWAYS" {
 		return nil
 	}

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
@@ -461,9 +461,21 @@ func TestAccSqlUser_instanceWithActivationPolicy(t *testing.T) {
 			{
 				Config: testGoogleSqlUser_instanceWithActivationPolicy(instance, "NEVER"),
 			},
-			// Step 3: Refresh to verify no errors
+			// Step 3: Refresh with instance stopped — identity attributes must still be set
 			{
 				Config: testGoogleSqlUser_instanceWithActivationPolicy(instance, "NEVER"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_sql_user.user", "project"),
+					resource.TestCheckResourceAttr("google_sql_user.user", "instance", instance),
+					resource.TestCheckResourceAttr("google_sql_user.user", "name", "admin"),
+				),
+			},
+			// Step 3a: ImportState with instance stopped — verifies identity survives a round-trip
+			{
+				ResourceName:      "google_sql_user.user",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"password", "deletion_policy"},
 			},
 			// Step 4: Update activation_policy to ALWAYS so that post-test destroy code is able to delete the google_sql_user resource
 			{

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
@@ -472,9 +472,9 @@ func TestAccSqlUser_instanceWithActivationPolicy(t *testing.T) {
 			},
 			// Step 3a: ImportState with instance stopped — verifies identity survives a round-trip
 			{
-				ResourceName:      "google_sql_user.user",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_sql_user.user",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"password", "deletion_policy"},
 			},
 			// Step 4: Update activation_policy to ALWAYS so that post-test destroy code is able to delete the google_sql_user resource


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#28571

When a Cloud SQL instance has `ActivationPolicy != ALWAYS` (stopped/paused), `resourceSqlUserRead` returns early before `SetResourceIdentityAttributes` is called. Users upgrading to provider ≥7.42 with existing state see `Missing Resource Identity After Read` on every plan.

### Fix
Call `SetResourceIdentityAttributes` using `project`, `instance`, `host`, and `name` (already in scope from `d.Get` above) immediately before the early-return. The existing call later in the function is untouched.

### Test
Strengthened `TestAccSqlUser_instanceWithActivationPolicy` to assert identity attributes survive a read and import round-trip while the instance is stopped.

```release-note:bug
sql: fixed `google_sql_user` returning `Missing Resource Identity After Read` when the parent Cloud SQL instance is stopped
```