### PR TITLE
Add google_iam_workload_identity_pool_jwks data source

### DIFF
--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks.go
@@ -1,6 +1,7 @@
 package iambeta
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -18,11 +20,15 @@ import (
 func DataSourceIAMBetaWorkloadIdentityPoolJwks() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceIAMBetaWorkloadIdentityPoolJwksRead,
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(transport_tpg.DefaultRequestTimeout),
+		},
 		Schema: map[string]*schema.Schema{
 			"resource_name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The JWKS URI to retrieve the public keys from (e.g. from google_iam_workload_identity_pool_openid_config.jwks_uri).",
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+				Description:  "The JWKS URI to retrieve the public keys from (e.g. from google_iam_workload_identity_pool_openid_config.jwks_uri).",
 			},
 			"jwks_json": {
 				Type:        schema.TypeString,
@@ -81,18 +87,21 @@ func dataSourceIAMBetaWorkloadIdentityPoolJwksRead(d *schema.ResourceData, meta 
 
 	url := d.Get("resource_name").(string)
 
+	ctx, cancel := context.WithTimeout(config.Context, d.Timeout(schema.TimeoutRead))
+	defer cancel()
+
 	// We cannot use standard provider transport (transport_tpg.SendRequest) here because
 	// the JWKS endpoint (/openid/jwks) is a public, unauthenticated API.
 	// If the provider transport is used, it attaches an OAuth Bearer token to the request which
 	// causes public STS to reject the request with HTTP 400 Bad Request.
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error creating request: %s", err)
 	}
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error fetching JWKS: %s", err)

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks.go
@@ -13,6 +13,8 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
+// DataSourceIAMBetaWorkloadIdentityPoolJwks retrieves the JSON Web Key Set (JWKS)
+// public keys for a Workload Identity Pool from Google Cloud Security Token Service (STS) per RFC 7517.
 func DataSourceIAMBetaWorkloadIdentityPoolJwks() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceIAMBetaWorkloadIdentityPoolJwksRead,
@@ -27,6 +29,7 @@ func DataSourceIAMBetaWorkloadIdentityPoolJwks() *schema.Resource {
 				Computed:    true,
 				Description: "The raw JSON string representation of the JWKS response.",
 			},
+			// Schema follows the Google Cloud Security Token Service (STS) JWKS response.
 			"keys": {
 				Type:        schema.TypeList,
 				Computed:    true,

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks.go
@@ -1,0 +1,150 @@
+package iambeta
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceIAMBetaWorkloadIdentityPoolJwks() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIAMBetaWorkloadIdentityPoolJwksRead,
+		Schema: map[string]*schema.Schema{
+			"resource_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The JWKS URI to retrieve the public keys from (e.g. from google_iam_workload_identity_pool_openid_config.jwks_uri).",
+			},
+			"jwks_json": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The raw JSON string representation of the JWKS response.",
+			},
+			"keys": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The list of public keys in the JSON Web Key Set.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kty": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The key type.",
+						},
+						"use": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The intended use of the public key.",
+						},
+						"kid": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for the key.",
+						},
+						"n": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The modulus for the RSA public key.",
+						},
+						"e": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The exponent for the RSA public key.",
+						},
+						"alg": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The algorithm intended for use with the key.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIAMBetaWorkloadIdentityPoolJwksRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	url := d.Get("resource_name").(string)
+
+	// We cannot use standard provider transport (transport_tpg.SendRequest) here because
+	// the JWKS endpoint (/openid/jwks) is a public, unauthenticated API.
+	// If the provider transport is used, it attaches an OAuth Bearer token to the request which
+	// causes Google STS to reject the request with HTTP 400 Bad Request during cross-org testing (e.g. VCR).
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("Error creating request: %s", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("Error fetching JWKS: %s", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Error fetching JWKS: HTTP %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Error reading JWKS response: %s", err)
+	}
+
+	var res map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &res); err != nil {
+		return fmt.Errorf("Error parsing JWKS response: %s", err)
+	}
+
+	if err := d.Set("jwks_json", string(bodyBytes)); err != nil {
+		return fmt.Errorf("Error setting jwks_json: %s", err)
+	}
+
+	if keysRaw, ok := res["keys"].([]interface{}); ok {
+		keysList := make([]map[string]interface{}, 0, len(keysRaw))
+		for _, keyRaw := range keysRaw {
+			if keyMap, ok := keyRaw.(map[string]interface{}); ok {
+				k := map[string]interface{}{
+					"kty": keyMap["kty"],
+					"use": keyMap["use"],
+					"kid": keyMap["kid"],
+					"n":   keyMap["n"],
+					"e":   keyMap["e"],
+					"alg": keyMap["alg"],
+				}
+				keysList = append(keysList, k)
+			}
+		}
+		if err := d.Set("keys", keysList); err != nil {
+			return fmt.Errorf("Error setting keys: %s", err)
+		}
+	}
+
+	d.SetId(url)
+
+	return nil
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_iam_workload_identity_pool_jwks",
+		ProductName: "iambeta",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceIAMBetaWorkloadIdentityPoolJwks(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks.go
@@ -14,7 +14,7 @@ import (
 )
 
 // DataSourceIAMBetaWorkloadIdentityPoolJwks retrieves the JSON Web Key Set (JWKS)
-// public keys for a Workload Identity Pool from Google Cloud Security Token Service (STS) per RFC 7517.
+// public keys for a Workload Identity Pool per RFC 7517 (https://datatracker.ietf.org/doc/html/rfc7517#section-4).
 func DataSourceIAMBetaWorkloadIdentityPoolJwks() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceIAMBetaWorkloadIdentityPoolJwksRead,
@@ -29,7 +29,6 @@ func DataSourceIAMBetaWorkloadIdentityPoolJwks() *schema.Resource {
 				Computed:    true,
 				Description: "The raw JSON string representation of the JWKS response.",
 			},
-			// Schema follows the Google Cloud Security Token Service (STS) JWKS response.
 			"keys": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -85,7 +84,7 @@ func dataSourceIAMBetaWorkloadIdentityPoolJwksRead(d *schema.ResourceData, meta 
 	// We cannot use standard provider transport (transport_tpg.SendRequest) here because
 	// the JWKS endpoint (/openid/jwks) is a public, unauthenticated API.
 	// If the provider transport is used, it attaches an OAuth Bearer token to the request which
-	// causes Google STS to reject the request with HTTP 400 Bad Request during cross-org testing (e.g. VCR).
+	// causes public STS to reject the request with HTTP 400 Bad Request.
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error creating request: %s", err)

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks_test.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceIAMBetaWorkloadIdentityPoolJwks_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceIAMBetaWorkloadIdentityPoolJwksBasic(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "jwks_json", regexp.MustCompile(`^{\"keys\":\[.*\]}$`)),
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "jwks_json", regexp.MustCompile(`(?s)^\{\s*"keys":\s*\[.*\]\s*\}\s*$`)),
 					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.kty", regexp.MustCompile(`^RSA$`)),
 					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.use", regexp.MustCompile(`^sig$`)),
 					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.alg", regexp.MustCompile(`^RS256$`)),

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks_test.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks_test.go
@@ -27,7 +27,7 @@ func TestAccDataSourceIAMBetaWorkloadIdentityPoolJwks_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceIAMBetaWorkloadIdentityPoolJwksBasic(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "jwks_json", regexp.MustCompile(`(?s)^\{\s*"keys":\s*\[.*\]\s*\}$`)),
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "jwks_json", regexp.MustCompile(`(?s)"keys":\s*\[`)),
 					testAccCheckJWKSKeys("data.google_iam_workload_identity_pool_jwks.example"),
 				),
 			},

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks_test.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks_test.go
@@ -12,20 +12,38 @@ import (
 	_ "github.com/hashicorp/terraform-provider-google/google/services/iambeta"
 )
 
+var jwksTestContext = map[string]interface{}{
+	// Pre-existing Google-owned organization (google.com) with Agent System Pool
+	"org_id": "433637338589",
+}
+
 func TestAccDataSourceIAMBetaWorkloadIdentityPoolJwks_basic(t *testing.T) {
 	t.Parallel()
-
-	context := map[string]interface{}{
-		// Pre-existing Google-owned organization (google.com) with Agent System Pool
-		"org_id": "433637338589",
-	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceIAMBetaWorkloadIdentityPoolJwksBasic(context),
+				Config: testAccDataSourceIAMBetaWorkloadIdentityPoolJwksBasic(jwksTestContext),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "jwks_json", regexp.MustCompile(`(?s)"keys":\s*\[`)),
+					testAccCheckJWKSKeys("data.google_iam_workload_identity_pool_jwks.example"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceIAMBetaWorkloadIdentityPoolJwks_integration(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceIAMBetaWorkloadIdentityPoolJwksIntegration(jwksTestContext),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "jwks_json", regexp.MustCompile(`(?s)"keys":\s*\[`)),
 					testAccCheckJWKSKeys("data.google_iam_workload_identity_pool_jwks.example"),
@@ -68,6 +86,14 @@ func testAccCheckJWKSKeys(n string) resource.TestCheckFunc {
 }
 
 func testAccDataSourceIAMBetaWorkloadIdentityPoolJwksBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_iam_workload_identity_pool_jwks" "example" {
+	resource_name = "https://sts.googleapis.com/v1/organizations/%{org_id}/locations/global/workloadIdentityPools/agents.global.org-%{org_id}.system.id.goog/openid/jwks"
+}
+`, context)
+}
+
+func testAccDataSourceIAMBetaWorkloadIdentityPoolJwksIntegration(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_iam_workload_identity_pool_openid_config" "oidc" {
 	resource_name = "https://sts.googleapis.com/v1/organizations/%{org_id}/locations/global/workloadIdentityPools/agents.global.org-%{org_id}.system.id.goog/.well-known/openid-configuration"

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks_test.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks_test.go
@@ -1,0 +1,51 @@
+package iambeta_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/iambeta"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDataSourceIAMBetaWorkloadIdentityPoolJwks_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		// Pre-existing Google-owned organization (google.com) with Agent System Pool
+		"org_id": "433637338589",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceIAMBetaWorkloadIdentityPoolJwksBasic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "jwks_json", regexp.MustCompile(`^{\"keys\":\[.*\]}$`)),
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.kty", regexp.MustCompile(`^RSA$`)),
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.use", regexp.MustCompile(`^sig$`)),
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.alg", regexp.MustCompile(`^RS256$`)),
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.kid", regexp.MustCompile(`.+`)),
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.n", regexp.MustCompile(`.+`)),
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.e", regexp.MustCompile(`^AQAB$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceIAMBetaWorkloadIdentityPoolJwksBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_iam_workload_identity_pool_openid_config" "oidc" {
+	resource_name = "https://sts.googleapis.com/v1/organizations/%{org_id}/locations/global/workloadIdentityPools/agents.global.org-%{org_id}.system.id.goog/.well-known/openid-configuration"
+}
+
+data "google_iam_workload_identity_pool_jwks" "example" {
+	resource_name = data.google_iam_workload_identity_pool_openid_config.oidc.jwks_uri
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks_test.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_jwks_test.go
@@ -1,13 +1,15 @@
 package iambeta_test
 
 import (
+	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/iambeta"
-
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccDataSourceIAMBetaWorkloadIdentityPoolJwks_basic(t *testing.T) {
@@ -25,17 +27,44 @@ func TestAccDataSourceIAMBetaWorkloadIdentityPoolJwks_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceIAMBetaWorkloadIdentityPoolJwksBasic(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "jwks_json", regexp.MustCompile(`(?s)^\{\s*"keys":\s*\[.*\]\s*\}\s*$`)),
-					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.kty", regexp.MustCompile(`^RSA$`)),
-					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.use", regexp.MustCompile(`^sig$`)),
-					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.alg", regexp.MustCompile(`^RS256$`)),
-					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.kid", regexp.MustCompile(`.+`)),
-					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.n", regexp.MustCompile(`.+`)),
-					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "keys.0.e", regexp.MustCompile(`^AQAB$`)),
+					resource.TestMatchResourceAttr("data.google_iam_workload_identity_pool_jwks.example", "jwks_json", regexp.MustCompile(`(?s)^\{\s*"keys":\s*\[.*\]\s*\}$`)),
+					testAccCheckJWKSKeys("data.google_iam_workload_identity_pool_jwks.example"),
 				),
 			},
 		},
 	})
+}
+
+func testAccCheckJWKSKeys(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		keysCountStr, ok := rs.Primary.Attributes["keys.#"]
+		if !ok {
+			return fmt.Errorf("Attribute 'keys.#' not found")
+		}
+
+		keysCount, err := strconv.Atoi(keysCountStr)
+		if err != nil {
+			return fmt.Errorf("Error parsing keys count: %s", err)
+		}
+
+		// Only check that key attributes are present when keys list is not empty
+		if keysCount > 0 {
+			fields := []string{"kty", "use", "kid", "n", "e", "alg"}
+			for _, field := range fields {
+				attrKey := fmt.Sprintf("keys.0.%s", field)
+				if val, exists := rs.Primary.Attributes[attrKey]; !exists || val == "" {
+					return fmt.Errorf("Expected %s to be present and non-empty in keys.0", attrKey)
+				}
+			}
+		}
+
+		return nil
+	}
 }
 
 func testAccDataSourceIAMBetaWorkloadIdentityPoolJwksBasic(context map[string]interface{}) string {

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_openid_config.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_openid_config.go
@@ -73,8 +73,8 @@ func dataSourceIAMBetaWorkloadIdentityPoolOpenIdConfigRead(d *schema.ResourceDat
 	url := d.Get("resource_name").(string)
 	// We cannot use standard provider transport (transport_tpg.SendRequest) here because
 	// the OIDC discovery endpoint (/.well-known/openid-configuration) is a public, unauthenticated API.
-	// If the provider transport is used, additional headers are attached to the request which
-	// causes Google STS to reject the request with HTTP 400 Bad Request during VCR testing.
+	// If the provider transport is used, it attaches an OAuth Bearer token to the request which
+	// causes Google STS to reject the request with HTTP 400 Bad Request during cross-org testing (e.g. VCR).
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error creating request: %s", err)

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_openid_config.go
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_openid_config.go
@@ -73,8 +73,8 @@ func dataSourceIAMBetaWorkloadIdentityPoolOpenIdConfigRead(d *schema.ResourceDat
 	url := d.Get("resource_name").(string)
 	// We cannot use standard provider transport (transport_tpg.SendRequest) here because
 	// the OIDC discovery endpoint (/.well-known/openid-configuration) is a public, unauthenticated API.
-	// If the provider transport is used, it attaches an OAuth Bearer token to the request which
-	// causes Google STS to reject the request with HTTP 400 Bad Request during cross-org testing (e.g. VCR).
+	// If the provider transport is used, additional headers are attached to the request which
+	// causes Google STS to reject the request with HTTP 400 Bad Request during VCR testing.
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error creating request: %s", err)

--- a/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool_jwks.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool_jwks.html.markdown
@@ -36,7 +36,7 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `keys` - The list of public keys in the JSON Web Key Set. Structure is [documented below](#nested_keys).
 
-<aByName name="nested_keys"></a>The `keys` block contains:
+<a name="nested_keys"></a>The `keys` block contains:
 
 * `kty` - The key type (e.g. `RSA`).
 

--- a/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool_jwks.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool_jwks.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "Cloud IAM"
+description: |-
+  Get JSON Web Key Set (JWKS) public keys for a Workload Identity Pool from Google Cloud.
+---
+
+# google_iam_workload_identity_pool_jwks
+
+Get the JSON Web Key Set (JWKS) public keys (`/openid/jwks`) for an Agent Workload Identity Pool from Google Cloud.
+
+## Example Usage
+
+```tf
+data "google_iam_workload_identity_pool_openid_config" "oidc" {
+  resource_name = "https://sts.googleapis.com/v1/organizations/433637338589/locations/global/workloadIdentityPools/agents.global.org-433637338589.system.id.goog/.well-known/openid-configuration"
+}
+
+data "google_iam_workload_identity_pool_jwks" "example" {
+  resource_name = data.google_iam_workload_identity_pool_openid_config.oidc.jwks_uri
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_name` - (Required) The JWKS URI to retrieve the public keys from (e.g. from `google_iam_workload_identity_pool_openid_config.jwks_uri`).
+
+- - -
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `jwks_json` - The raw JSON string representation of the JWKS response.
+
+* `keys` - The list of public keys in the JSON Web Key Set. Structure is [documented below](#nested_keys).
+
+<aByName name="nested_keys"></a>The `keys` block contains:
+
+* `kty` - The key type (e.g. `RSA`).
+
+* `use` - The intended use of the public key (e.g. `sig`).
+
+* `kid` - The unique identifier for the key.
+
+* `n` - The modulus for the RSA public key.
+
+* `e` - The exponent for the RSA public key.
+
+* `alg` - The algorithm intended for use with the key (e.g. `RS256`).

--- a/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool_jwks.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool_jwks.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "Cloud IAM"
 description: |-
-  Get JSON Web Key Set (JWKS) public keys for a Workload Identity Pool from Google Cloud.
+  Get JSON Web Key Set (JWKS) public keys for a Workload Identity Pool from GCP.
 ---
 
 # google_iam_workload_identity_pool_jwks
 
-Get the JSON Web Key Set (JWKS) public keys (`/openid/jwks`) for an Agent Workload Identity Pool from Google Cloud.
+Get the JSON Web Key Set (JWKS) public keys (`/openid/jwks`) for an Agent Workload Identity Pool from GCP.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

Part of https://github.com/hashicorp/terraform-provider-google/issues/28792

Adds a read-only data source google_iam_workload_identity_pool_jwks to get public keys for Workload Identity Pools.



```release-note:new-datasource
`google_iam_workload_identity_pool_jwks`
```
