### PR TITLE
Mark backup_plan_association_id immutable

### DIFF
--- a/mmv1/products/backupdr/BackupPlanAssociation.yaml
+++ b/mmv1/products/backupdr/BackupPlanAssociation.yaml
@@ -60,13 +60,16 @@ parameters:
     type: String
     required: true
     url_param_only: true
+    immutable: true
     description: |
       The location for the backupplan association
   - name: backup_plan_association_id
     type: String
     required: true
     url_param_only: true
-    description: The id of backupplan association
+    immutable: true
+    description: |-
+      The id of backupplan association
 properties:
   - name: resource
     type: String


### PR DESCRIPTION
This change marks the backup_plan_association_id parameter as immutable so Terraform will force replacement instead of in-place updates.

manual runs

```release-note:bug
backupdr: mark backup plan association id immutable
```