### PR TITLE
fix(apigee): retry "the resource is locked by another operation"

### DIFF
--- a/mmv1/products/apigee/EndpointAttachment.yaml
+++ b/mmv1/products/apigee/EndpointAttachment.yaml
@@ -44,6 +44,8 @@ async:
     resource_inside_response: true
 custom_code:
   custom_import: 'templates/terraform/custom_import/apigee_endpoint_attachment.go.tmpl'
+error_retry_predicates:
+  - 'transport_tpg.IsApigeeRetryableError'
 exclude_sweeper: true
 samples:
   - name: 'apigee_endpoint_attachment_basic'

--- a/mmv1/products/apigee/Envgroup.yaml
+++ b/mmv1/products/apigee/Envgroup.yaml
@@ -42,6 +42,8 @@ async:
     resource_inside_response: true
 custom_code:
   custom_import: 'templates/terraform/custom_import/apigee_environment_group.go.tmpl'
+error_retry_predicates:
+  - 'transport_tpg.IsApigeeRetryableError'
 exclude_sweeper: true
 samples:
   - name: 'apigee_environment_group_basic'

--- a/mmv1/products/apigee/EnvgroupAttachment.yaml
+++ b/mmv1/products/apigee/EnvgroupAttachment.yaml
@@ -44,6 +44,8 @@ async:
 autogen_async: true
 custom_code:
   custom_import: templates/terraform/custom_import/apigee_environment_group_attachment.go.tmpl
+error_retry_predicates:
+  - 'transport_tpg.IsApigeeRetryableError'
 samples:
   - name: apigee_environment_group_attachment_basic
     exclude_test: true

--- a/mmv1/products/apigee/Environment.yaml
+++ b/mmv1/products/apigee/Environment.yaml
@@ -47,6 +47,8 @@ iam_policy:
     - '{{name}}'
 custom_code:
   custom_import: 'templates/terraform/custom_import/apigee_environment.go.tmpl'
+error_retry_predicates:
+  - 'transport_tpg.IsApigeeRetryableError'
 samples:
   - name: 'apigee_environment_basic'
     exclude_test: true

--- a/mmv1/products/apigee/InstanceAttachment.yaml
+++ b/mmv1/products/apigee/InstanceAttachment.yaml
@@ -45,6 +45,8 @@ async:
 autogen_async: true
 custom_code:
   custom_import: templates/terraform/custom_import/apigee_instance_attachment.go.tmpl
+error_retry_predicates:
+  - 'transport_tpg.IsApigeeRetryableError'
 samples:
   - name: apigee_instance_attachment_basic
     exclude_test: true

--- a/mmv1/products/apigee/NatAddress.yaml
+++ b/mmv1/products/apigee/NatAddress.yaml
@@ -48,6 +48,8 @@ custom_code:
   post_create: templates/terraform/post_create/apigee_nat_address.go.tmpl
   custom_update: templates/terraform/custom_update/apigee_nat_address.go.tmpl
   custom_import: templates/terraform/custom_import/apigee_nat_address.go.tmpl
+error_retry_predicates:
+  - 'transport_tpg.IsApigeeRetryableError'
 samples:
   - name: apigee_nat_address_basic
     exclude_test: true


### PR DESCRIPTION
Apigee serialises long-running operations per organization. A mutation issued while another operation is in flight against the same org is rejected immediately with HTTP 400 `the resource is locked by another operation` rather than being queued.

`google_apigee_instance` already retries this via `transport_tpg.IsApigeeRetryableError` (added for hashicorp/terraform-provider-google#10979), but every other org-scoped asynchronous Apigee resource can hit the same error and does not.

This is easy to reproduce with a `for_each` that creates two of them concurrently in a single apply — the first succeeds, the second fails outright:

```
google_apigee_endpoint_attachment.this["euw2"]: Creation complete after 1m5s
Error: Error creating EndpointAttachment: googleapi: Error 400: the resource is
locked by another operation where endpoint attachment swp-euw2 is currently being
created for organization <org> by operation: 1c83301f-195f-4d20-b6f4-7d5c8f6b66e8
```

There is no practical config-side workaround: Terraform builds dependency edges at the config-node level rather than per instance, so neither a `time_sleep` stagger nor a child-module-per-item stagger serialises a dynamic `for_each` — every instance still starts after the longest sleep. That leaves `-parallelism=1` for the whole apply, which also serialises the 30–45 minute `google_apigee_instance` creates.

This PR applies the existing predicate to the remaining org-scoped async Apigee resources: `EndpointAttachment`, `InstanceAttachment`, `EnvgroupAttachment`, `Environment`, `Envgroup` and `NatAddress`.

Note that `InstanceAttachment` already carries `mutex: apigeeInstanceAttachments`. That mutex only covers a single provider process and does not prevent collisions against the same org from a different resource type, so the predicate is complementary rather than redundant.

Contributes to hashicorp/terraform-provider-google#12369, hashicorp/terraform-provider-google#11445 and hashicorp/terraform-provider-google#10084.

```release-note:bug
apigee: fixed an issue where concurrently creating `google_apigee_endpoint_attachment`, `google_apigee_instance_attachment`, `google_apigee_envgroup_attachment`, `google_apigee_environment`, `google_apigee_envgroup` or `google_apigee_nat_address` resources could fail with a 400 error stating the resource is locked by another operation
```
