### PR TITLE
add fields to create vmcluster for storage

### DIFF
--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -327,6 +327,23 @@ properties:
           ASM
           EXASCALE
         output: true
+      - name: vmFileSystemStorageType
+        type: String
+        description: |-
+          Specifies whether VM file system storage / VM images are stored on local DB server storage or Exascale storage.
+          Possible values:
+          VM_FILE_SYSTEM_STORAGE_TYPE_UNSPECIFIED
+          VM_FILE_SYSTEM_STORAGE_TYPE_LOCAL
+          VM_FILE_SYSTEM_STORAGE_TYPE_EXASCALE
+      - name: vmBackupStorageType
+        type: String
+        description: |-
+          Specifies whether VM backups are stored on local DB server storage or Exascale storage.
+          Possible values:
+          VM_BACKUP_STORAGE_TYPE_UNSPECIFIED
+          VM_BACKUP_STORAGE_TYPE_LOCAL
+          VM_BACKUP_STORAGE_TYPE_EXASCALE
+
   - name: labels
     type: KeyValueLabels
     description: 'Labels or tags associated with the VM Cluster. '

--- a/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_cloud_vmcluster_exascale.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_cloud_vmcluster_exascale.tf.tmpl
@@ -16,8 +16,8 @@ resource "google_oracle_database_cloud_vm_cluster" "{{$.PrimaryResourceId}}" {
     cpu_core_count  = "4"
     gi_version      = "23.0.0.0"
     hostname_prefix = "hostname1"
-    vm_file_system_storage_type = "VM_FILE_SYSTEM_STORAGE_TYPE_EXASCALE"
-    vm_backup_storage_type = "VM_BACKUP_STORAGE_TYPE_EXASCALE"
+    vm_file_system_storage_type = "VM_FILE_SYSTEM_STORAGE_TYPE_LOCAL"
+    vm_backup_storage_type = "VM_BACKUP_STORAGE_TYPE_LOCAL"
 
 
     # Required fields for Exascale-based VM Clusters:

--- a/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_cloud_vmcluster_exascale.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_cloud_vmcluster_exascale.tf.tmpl
@@ -16,6 +16,9 @@ resource "google_oracle_database_cloud_vm_cluster" "{{$.PrimaryResourceId}}" {
     cpu_core_count  = "4"
     gi_version      = "23.0.0.0"
     hostname_prefix = "hostname1"
+    vm_file_system_storage_type = "VM_FILE_SYSTEM_STORAGE_TYPE_EXASCALE"
+    vm_backup_storage_type = "VM_BACKUP_STORAGE_TYPE_EXASCALE"
+
 
     # Required fields for Exascale-based VM Clusters:
     memory_size_gb          = 60


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.
-->

This PR adds `vmFileSystemStorageType` and `vmBackupStorageType` fields to the `google_oracle_database_cloud_vm_cluster` resource to support advanced storage configurations (Local vs Exascale).

It also updates the `oracledatabase_cloud_vmcluster_exascale` sample to demonstrate usage of these fields with Exascale storage.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28793

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
oracledatabase: added `vm_file_system_storage_type` and `vm_backup_storage_type` fields to`google_oracle_database_cloud_vm_cluster`
```
