### PR TITLE
Exascale storage configuration for Exadata Infrastructure.

### DIFF
--- a/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
+++ b/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
@@ -276,6 +276,28 @@ properties:
         type: String
         description: "The monthly software version of the database servers (dom0)\nin the Exadata Infrastructure. Example: 20.1.15 "
         output: true
+      - name: exascaleConfig
+        type: NestedObject
+        description: 'The Exascale configuration for the Exadata Infrastructure. '
+        output: true
+        properties:
+          - name: totalStorageSizeGb
+            type: Integer
+            description: 'Total storage size needed for Exascale in GBs. '
+            output: true
+          - name: availableStorageSizeGb
+            type: Integer
+            description: 'Available storage size for Exascale in GBs. '
+            output: true
+          - name: totalVmStorageSizeGb
+            type: Integer
+            description: 'Storage size needed for VM storage on Exascale in GBs. '
+            output: true
+          - name: availableVmStorageSizeGb
+            type: Integer
+            description: 'Available storage size for VM storage on Exascale in GBs. '
+            output: true
+
   - name: labels
     type: KeyValueLabels
     description: 'Labels or tags associated with the resource. '

--- a/mmv1/products/oracledatabase/CloudExadataInfrastructureExascaleConfig.yaml
+++ b/mmv1/products/oracledatabase/CloudExadataInfrastructureExascaleConfig.yaml
@@ -77,4 +77,3 @@ properties:
     required: false
     immutable: true
     description: Storage size needed for VM storage on Exascale in GBs.
-

--- a/mmv1/products/oracledatabase/CloudExadataInfrastructureExascaleConfig.yaml
+++ b/mmv1/products/oracledatabase/CloudExadataInfrastructureExascaleConfig.yaml
@@ -72,3 +72,9 @@ properties:
     required: true
     immutable: true
     description: The total storage to be allocated to Exascale in GBs.
+  - name: totalVmStorageSizeGb
+    type: Integer
+    required: false
+    immutable: true
+    description: Storage size needed for VM storage on Exascale in GBs.
+

--- a/mmv1/templates/terraform/decoders/oracledatabase_cloud_exadata_infrastructure_exascale_config.go.tmpl
+++ b/mmv1/templates/terraform/decoders/oracledatabase_cloud_exadata_infrastructure_exascale_config.go.tmpl
@@ -9,5 +9,7 @@ if !ok || exascaleConfig == nil {
 }
 
 res["totalStorageSizeGb"] = exascaleConfig["totalStorageSizeGb"]
+res["totalVmStorageSizeGb"] = exascaleConfig["totalVmStorageSizeGb"]
+
 
 return res, nil

--- a/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_cloud_exadata_infrastructure_exascale_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_cloud_exadata_infrastructure_exascale_config_basic.tf.tmpl
@@ -18,4 +18,6 @@ resource "google_oracle_database_cloud_exadata_infrastructure_exascale_config" "
   location                     = "us-east4"
   project                      = "{{index $.ResourceIdVars "project"}}"
   total_storage_size_gb        = 10240
+  total_vm_storage_size_gb     = 2048
+
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.
-->

This PR introduces enhancements to Exascale configuration and observability for Exadata Infrastructure.

### Key Changes:
1. **Exadata Infrastructure Observability**: Added the `exascaleConfig` read-only output object to `google_oracle_database_cloud_exadata_infrastructure` properties, providing visibility into total and available Exascale and VM storage sizes.
2. **Exascale Configuration**: Added support for the `total_vm_storage_size_gb` optional parameter in the `google_oracle_database_cloud_exadata_infrastructure_exascale_config` custom method resource, allowing users to configure VM storage size on Exascale.
3. **Custom Decoder & Tests**: Updated the custom decoder to map the new field and added it to the basic configuration sample template.

### Affected Resources
- `google_oracle_database_cloud_exadata_infrastructure`
- `google_oracle_database_cloud_exadata_infrastructure_exascale_config`

### References
- Internal API Source: `ConfigureExascaleCloudExadataInfrastructureRequest` in `exadata_infra.proto`
- Related: https://github.com/GoogleCloudPlatform/magic-modules/pull/18002

Fixes https://github.com/hashicorp/terraform-provider-google/issues/YOUR_ISSUE_ID_HERE

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
oracle_database: added `exascale_config` output block to `google_oracle_database_cloud_exadata_infrastructure`
```

```release-note:enhancement
oracle_database: added `total_vm_storage_size_gb` optional parameter to `google_oracle_database_cloud_exadata_infrastructure_exascale_config`
```
