### PR TITLE
migrationcenter: add list resources

### DIFF
--- a/mmv1/products/migrationcenter/AssetsExportJob.yaml
+++ b/mmv1/products/migrationcenter/AssetsExportJob.yaml
@@ -16,6 +16,7 @@ name: AssetsExportJob
 description: AssetsExportJob represents a batch job that exports Migration Center assets to external destinations such as Cloud Storage.
 base_url: projects/{{project}}/locations/{{location}}/assetsExportJobs
 immutable: true
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/assetsExportJobs/{{assets_export_job_id}}
 create_url: projects/{{project}}/locations/{{location}}/assetsExportJobs?assetsExportJobId={{assets_export_job_id}}
 import_format:

--- a/mmv1/products/migrationcenter/DiscoveryClient.yaml
+++ b/mmv1/products/migrationcenter/DiscoveryClient.yaml
@@ -15,6 +15,7 @@
 name: DiscoveryClient
 description: DiscoveryClient represents an on-premise discovery agent that scans infrastructure and uploads discovery data to Migration Center.
 base_url: projects/{{project}}/locations/{{location}}/discoveryClients
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/discoveryClients/{{discovery_client_id}}
 create_url: projects/{{project}}/locations/{{location}}/discoveryClients?discoveryClientId={{discovery_client_id}}
 update_mask: true

--- a/mmv1/products/migrationcenter/Group.yaml
+++ b/mmv1/products/migrationcenter/Group.yaml
@@ -16,6 +16,7 @@ name: Group
 description: A resource that represents an asset group. The purpose of an asset group is to bundle a set of assets that have something in common, while allowing users to add annotations to the group.
 docs:
 base_url: projects/{{project}}/locations/{{location}}/groups
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/groups/{{group_id}}
 create_url: projects/{{project}}/locations/{{location}}/groups?groupId={{group_id}}
 update_mask: true

--- a/mmv1/products/migrationcenter/ImportJob.yaml
+++ b/mmv1/products/migrationcenter/ImportJob.yaml
@@ -15,6 +15,7 @@
 name: ImportJob
 description: ImportJob represents a batch data import task that processes uploaded data files and populates Migration Center assets.
 base_url: projects/{{project}}/locations/{{location}}/importJobs
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/importJobs/{{import_job_id}}
 create_url: projects/{{project}}/locations/{{location}}/importJobs?importJobId={{import_job_id}}
 update_mask: true

--- a/mmv1/products/migrationcenter/PreferenceSet.yaml
+++ b/mmv1/products/migrationcenter/PreferenceSet.yaml
@@ -19,6 +19,7 @@ references:
     Managing Migration Preferences: https://cloud.google.com/migration-center/docs/migration-preferences
   api: https://cloud.google.com/migration-center/docs/reference/rest/v1
 base_url: projects/{{project}}/locations/{{location}}/preferenceSets
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/preferenceSets/{{preference_set_id}}
 create_url: projects/{{project}}/locations/{{location}}/preferenceSets?preferenceSetId={{preference_set_id}}
 update_mask: true

--- a/mmv1/products/migrationcenter/ReportConfig.yaml
+++ b/mmv1/products/migrationcenter/ReportConfig.yaml
@@ -16,6 +16,7 @@ name: ReportConfig
 description: ReportConfig defines the configuration and criteria used to generate Migration Center reports.
 base_url: projects/{{project}}/locations/{{location}}/reportConfigs
 immutable: true
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/reportConfigs/{{report_config_id}}
 create_url: projects/{{project}}/locations/{{location}}/reportConfigs?reportConfigId={{report_config_id}}
 import_format:

--- a/mmv1/products/migrationcenter/Source.yaml
+++ b/mmv1/products/migrationcenter/Source.yaml
@@ -15,6 +15,7 @@
 name: Source
 description: Source represents a data source from which asset discovery data is ingested into Migration Center.
 base_url: projects/{{project}}/locations/{{location}}/sources
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/sources/{{source_id}}
 create_url: projects/{{project}}/locations/{{location}}/sources?sourceId={{source_id}}
 update_mask: true


### PR DESCRIPTION
Adds list-resource generation for the following migrationcenter resources:

- `google_migrationcenter_assets_export_job`
- `google_migrationcenter_discovery_client`
- `google_migrationcenter_group`
- `google_migrationcenter_import_job`
- `google_migrationcenter_preference_set`
- `google_migrationcenter_report_config`
- `google_migrationcenter_source`

```release-note:new-list-resource
`google_migrationcenter_assets_export_job`
```

```release-note:new-list-resource
`google_migrationcenter_discovery_client`
```

```release-note:new-list-resource
`google_migrationcenter_group`
```

```release-note:new-list-resource
`google_migrationcenter_import_job`
```

```release-note:new-list-resource
`google_migrationcenter_preference_set`
```

```release-note:new-list-resource
`google_migrationcenter_report_config`
```

```release-note:new-list-resource
`google_migrationcenter_source`
```

Tests: Acceptance tests PASSED (confirmed by Validator agent).