### PR TITLE
Feat/add network connectivity hub spoke acceptance

### DIFF
--- a/mmv1/products/networkconnectivity/HubSpokeAcceptance.yaml
+++ b/mmv1/products/networkconnectivity/HubSpokeAcceptance.yaml
@@ -27,7 +27,9 @@ description: |
 references:
   guides:
     Official Documentation: https://cloud.google.com/network-connectivity/docs/network-connectivity-center/how-to/vpc-review-proposed-spokes
-  api: https://docs.cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1/projects.locations.global.hubs/acceptSpokeUpdate
+    Accept a spoke: https://docs.cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1/projects.locations.global.hubs/acceptSpoke
+    Accept a spoke update: https://docs.cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1/projects.locations.global.hubs/acceptSpokeUpdate
+  api: https://docs.cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1/projects.locations.global.hubs/acceptSpoke
 docs:
   note: |
     Destroying this resource rejects the spoke (`rejectSpoke`), which disconnects it from the hub.
@@ -124,6 +126,7 @@ parameters:
     required: true
     immutable: true
     url_param_only: true
+    # listSpokes returns a Spoke object; hub is only used to build the method URL.
     ignore_read: true
     diff_suppress_func: tpgresource.CompareSelfLinkOrResourceName
 properties:
@@ -143,6 +146,7 @@ properties:
       Set this to `google_network_connectivity_spoke.this.etag` so Terraform accepts proposed
       filter changes (for example `include_export_ranges`) after the spoke is already attached.
     url_param_only: true
+    # Input for acceptSpokeUpdate. The spoke etag changes after accept, so it cannot be read back.
     ignore_read: true
   - name: state
     type: String

--- a/mmv1/products/networkconnectivity/HubSpokeAcceptance.yaml
+++ b/mmv1/products/networkconnectivity/HubSpokeAcceptance.yaml
@@ -1,0 +1,150 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: HubSpokeAcceptance
+description: |
+  Accepts a Network Connectivity Center spoke that was proposed to a hub from another project,
+  and accepts later proposals to update that spoke.
+
+  When a spoke is created against a hub in a different project, it stays `INACTIVE` until the hub
+  administrator accepts it. This resource calls `hubs.acceptSpoke` on create. Set `spoke_etag` to
+  the spoke's current etag to call `hubs.acceptSpokeUpdate` when the spoke administrator proposes
+  a change (for example export range filters). Destroy calls `hubs.rejectSpoke`. Same-project
+  spokes are accepted automatically and do not need this resource.
+
+  Accept one spoke per resource. Use `for_each` to accept multiple spokes.
+references:
+  guides:
+    Official Documentation: https://cloud.google.com/network-connectivity/docs/network-connectivity-center/how-to/vpc-review-proposed-spokes
+  api: https://docs.cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1/projects.locations.global.hubs/acceptSpokeUpdate
+docs:
+  note: |
+    Destroying this resource rejects the spoke (`rejectSpoke`), which disconnects it from the hub.
+    Use `deletion_policy = "ABANDON"` to remove the resource from Terraform state without rejecting
+    the spoke.
+
+    To accept a pending spoke update, set `spoke_etag` to `google_network_connectivity_spoke.this.etag`
+    (or the etag from `hubs.listSpokes`). The provider calls `acceptSpokeUpdate` only when that
+    spoke has a pending update.
+
+    Import this resource using
+    `projects/{project}/locations/global/hubs/{hub}/spokeAcceptances/{spoke_uri}`.
+    The spoke URI contains slashes, so shorter import IDs are not supported.
+base_url: projects/{{project}}/locations/global/hubs
+self_link: projects/{{project}}/locations/global/hubs/{{hub}}:listSpokes
+create_url: projects/{{project}}/locations/global/hubs/{{hub}}:acceptSpoke
+delete_url: projects/{{project}}/locations/global/hubs/{{hub}}:rejectSpoke
+delete_verb: POST
+read_query_params: '?pageSize=500'
+id_format: projects/{{project}}/locations/global/hubs/{{hub}}/spokeAcceptances/{{spoke}}
+import_format:
+  - projects/{{project}}/locations/global/hubs/{{hub}}/spokeAcceptances/{{spoke}}
+identity:
+  - hub
+  - spoke
+exclude_identity_generation: true
+exclude_sweeper: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  type: OpAsync
+  operation:
+    base_url: '{{op_id}}'
+  actions: [create, delete, update]
+  result:
+    resource_inside_response: false
+legacy_long_form_project: true
+mutex: networkconnectivity/hub/{{hub}}
+custom_code:
+  encoder: templates/terraform/encoders/network_connectivity_hub_spoke_acceptance.go.tmpl
+  decoder: templates/terraform/decoders/network_connectivity_hub_spoke_acceptance.go.tmpl
+  constants: templates/terraform/constants/network_connectivity_hub_spoke_acceptance.go.tmpl
+  custom_update: templates/terraform/custom_update/network_connectivity_hub_spoke_acceptance.go.tmpl
+  pre_delete: templates/terraform/pre_delete/network_connectivity_hub_spoke_acceptance.go.tmpl
+  post_create: templates/terraform/post_create/network_connectivity_hub_spoke_acceptance.go.tmpl
+  custom_import: templates/terraform/custom_import/network_connectivity_hub_spoke_acceptance.go.tmpl
+  test_check_destroy: templates/terraform/custom_check_destroy/network_connectivity_hub_spoke_acceptance.go.tmpl
+samples:
+  - name: network_connectivity_hub_spoke_acceptance_basic
+    primary_resource_id: acceptance
+    exclude_test: true
+    steps:
+      - name: network_connectivity_hub_spoke_acceptance_basic
+  - name: network_connectivity_hub_spoke_acceptance_full
+    primary_resource_id: acceptance
+    exclude_basic_doc: true
+    skip_vcr: true
+    external_providers: [time]
+    steps:
+      - name: network_connectivity_hub_spoke_acceptance_full
+        resource_id_vars:
+          spoke_project_id: nccspk
+          hub_name: hub
+          spoke_name: spoke
+          network_name: net
+        vars:
+          include_export_range: 10.0.0.0/8
+        test_env_vars:
+          org_id: ORG_ID
+          billing_account: BILLING_ACCT
+        ignore_read_extra:
+          - deletion_policy
+      - name: network_connectivity_hub_spoke_acceptance_full
+        resource_id_vars:
+          spoke_project_id: nccspk
+          hub_name: hub
+          spoke_name: spoke
+          network_name: net
+        vars:
+          include_export_range: 10.1.0.0/16
+        test_env_vars:
+          org_id: ORG_ID
+          billing_account: BILLING_ACCT
+        ignore_read_extra:
+          - deletion_policy
+parameters:
+  - name: hub
+    type: String
+    description: |
+      The hub that will accept the spoke. This can be the hub ID or the full hub URI
+      (`projects/{project}/locations/global/hubs/{hub}`).
+    required: true
+    immutable: true
+    url_param_only: true
+    ignore_read: true
+    diff_suppress_func: tpgresource.CompareSelfLinkOrResourceName
+properties:
+  - name: spoke
+    type: String
+    api_name: spokeUri
+    description: |
+      The URI of the spoke to accept, for example
+      `projects/{project}/locations/{location}/spokes/{spoke}`.
+    required: true
+    immutable: true
+    diff_suppress_func: tpgresource.CompareSelfLinkRelativePathsIgnoreProjectId
+  - name: spokeEtag
+    type: String
+    description: |
+      The etag of the spoke. Required to accept a pending spoke update (`acceptSpokeUpdate`).
+      Set this to `google_network_connectivity_spoke.this.etag` so Terraform accepts proposed
+      filter changes (for example `include_export_ranges`) after the spoke is already attached.
+    url_param_only: true
+    ignore_read: true
+  - name: state
+    type: String
+    description: Output only. The current lifecycle state of the accepted spoke.
+    output: true

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -470,6 +470,12 @@ properties:
     type: String
     description: Output only. The Google-generated UUID for the spoke. This value is unique across all spoke resources. If a spoke is deleted and another with the same name is created, the new spoke is assigned a different unique_id.
     output: true
+  - name: etag
+    type: String
+    description: |
+      This checksum is computed by the server based on the value of other fields, and may be sent
+      on update and delete requests to ensure the client has an up-to-date value before proceeding.
+    output: true
   - name: state
     type: String
     description: Output only. The current lifecycle state of this spoke.

--- a/mmv1/templates/terraform/constants/network_connectivity_hub_spoke_acceptance.go.tmpl
+++ b/mmv1/templates/terraform/constants/network_connectivity_hub_spoke_acceptance.go.tmpl
@@ -1,0 +1,47 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func NetworkConnectivitySpokeIsAccepted(state string) bool {
+	switch state {
+	case "ACTIVE", "UPDATING", "UPDATE_FAILED", "UPDATE_REJECTED":
+		return true
+	default:
+		return false
+	}
+}
+
+func NetworkConnectivitySpokeHasPendingUpdate(spoke map[string]interface{}) bool {
+	if spoke == nil {
+		return false
+	}
+	if paths, ok := spoke["fieldPathsPendingUpdate"].([]interface{}); ok && len(paths) > 0 {
+		return true
+	}
+	reasons, _ := spoke["reasons"].([]interface{})
+	for _, raw := range reasons {
+		reason, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		code, _ := reason["code"].(string)
+		if code == "UPDATE_PENDING_REVIEW" {
+			return true
+		}
+	}
+	return false
+}
+
+func networkConnectivityHubSpokeAcceptanceId(project, hub, spoke string) string {
+	project = tpgresource.GetResourceNameFromSelfLink(strings.TrimPrefix(project, "projects/"))
+	hub = tpgresource.GetResourceNameFromSelfLink(hub)
+	return fmt.Sprintf("projects/%s/locations/global/hubs/%s/spokeAcceptances/%s", project, hub, spoke)
+}

--- a/mmv1/templates/terraform/custom_check_destroy/network_connectivity_hub_spoke_acceptance.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/network_connectivity_hub_spoke_acceptance.go.tmpl
@@ -1,0 +1,53 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+config := acctest.GoogleProviderConfig(t)
+url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(networkconnectivity.Product, config)+"projects/{{"{{"}}project{{"}}"}}/locations/global/hubs/{{"{{"}}hub{{"}}"}}:listSpokes")
+if err != nil {
+	return err
+}
+
+billingProject := ""
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: config.UserAgent,
+})
+if err != nil {
+	if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+		continue
+	}
+	return err
+}
+
+spoke := rs.Primary.Attributes["spoke"]
+spokes, _ := res["spokes"].([]interface{})
+for _, raw := range spokes {
+	if raw == nil {
+		continue
+	}
+	item, ok := raw.(map[string]interface{})
+	if !ok {
+		continue
+	}
+	name, _ := item["name"].(string)
+	state, _ := item["state"].(string)
+	if tpgresource.CompareSelfLinkRelativePathsIgnoreProjectId("", spoke, name, nil) && networkconnectivity.NetworkConnectivitySpokeIsAccepted(state) {
+		return fmt.Errorf("HubSpokeAcceptance still exists at %s (spoke %s is %s)", url, name, state)
+	}
+}

--- a/mmv1/templates/terraform/custom_import/network_connectivity_hub_spoke_acceptance.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/network_connectivity_hub_spoke_acceptance.go.tmpl
@@ -1,0 +1,52 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+config := meta.(*transport_tpg.Config)
+
+const marker = "/spokeAcceptances/"
+importId := d.Id()
+idx := strings.Index(importId, marker)
+if idx == -1 {
+	return nil, fmt.Errorf("expected import id projects/{{"{{"}}project{{"}}"}}/locations/global/hubs/{{"{{"}}hub{{"}}"}}/spokeAcceptances/{{"{{"}}spoke{{"}}"}}, got %q", importId)
+}
+
+hubPart := importId[:idx]
+spoke := importId[idx+len(marker):]
+if spoke == "" {
+	return nil, fmt.Errorf("import id %q is missing the spoke URI after %s", importId, marker)
+}
+
+d.SetId(hubPart)
+if err := tpgresource.ParseImportId([]string{
+	"projects/(?P<project>[^/]+)/locations/global/hubs/(?P<hub>[^/]+)",
+	"(?P<project>[^/]+)/(?P<hub>[^/]+)",
+	"(?P<hub>[^/]+)",
+}, d, config); err != nil {
+	return nil, err
+}
+
+if err := d.Set("spoke", spoke); err != nil {
+	return nil, fmt.Errorf("Error setting spoke: %s", err)
+}
+
+project, err := tpgresource.GetProject(d, config)
+if err != nil {
+	return nil, fmt.Errorf("Error fetching project for HubSpokeAcceptance: %s", err)
+}
+if err := d.Set("hub", tpgresource.GetResourceNameFromSelfLink(d.Get("hub").(string))); err != nil {
+	return nil, fmt.Errorf("Error setting hub: %s", err)
+}
+
+id := networkConnectivityHubSpokeAcceptanceId(project, d.Get("hub").(string), spoke)
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/custom_update/network_connectivity_hub_spoke_acceptance.go.tmpl
+++ b/mmv1/templates/terraform/custom_update/network_connectivity_hub_spoke_acceptance.go.tmpl
@@ -1,0 +1,106 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+if err != nil {
+	return err
+}
+
+project, err := tpgresource.GetProject(d, config)
+if err != nil {
+	return fmt.Errorf("Error fetching project for HubSpokeAcceptance: %s", err)
+}
+billingProject := strings.TrimPrefix(project, "projects/")
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+	billingProject = bp
+}
+
+spokeEtag, _ := d.Get("spoke_etag").(string)
+if !d.HasChange("spoke_etag") || spokeEtag == "" {
+	log.Printf("[DEBUG] No spoke_etag change for HubSpokeAcceptance %q; skipping acceptSpokeUpdate", d.Id())
+	return resourceNetworkConnectivityHubSpokeAcceptanceRead(d, meta)
+}
+
+lockName, err := tpgresource.ReplaceVars(d, config, "networkconnectivity/hub/{{"{{"}}hub{{"}}"}}")
+if err != nil {
+	return err
+}
+transport_tpg.MutexStore.Lock(lockName)
+defer transport_tpg.MutexStore.Unlock(lockName)
+
+listURL, err := tpgresource.ReplaceVarsForId(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{"{{"}}project{{"}}"}}/locations/global/hubs/{{"{{"}}hub{{"}}"}}:listSpokes?pageSize=500")
+if err != nil {
+	return err
+}
+
+listRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    listURL,
+	UserAgent: userAgent,
+})
+if err != nil {
+	return fmt.Errorf("Error listing spokes while accepting HubSpokeAcceptance update: %s", err)
+}
+
+spokeObj, err := resourceNetworkConnectivityHubSpokeAcceptanceDecoder(d, meta, listRes)
+if err != nil {
+	return err
+}
+if spokeObj == nil {
+	return fmt.Errorf("cannot accept spoke update: spoke %q is not accepted on hub %q", d.Get("spoke"), d.Get("hub"))
+}
+
+if !NetworkConnectivitySpokeHasPendingUpdate(spokeObj) {
+	log.Printf("[DEBUG] Spoke %q has no pending update; skipping acceptSpokeUpdate", d.Get("spoke"))
+	return resourceNetworkConnectivityHubSpokeAcceptanceRead(d, meta)
+}
+
+if apiEtag, ok := spokeObj["etag"].(string); ok && apiEtag != "" {
+	if spokeEtag == "" {
+		spokeEtag = apiEtag
+	}
+}
+
+url, err := tpgresource.ReplaceVarsForId(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{"{{"}}project{{"}}"}}/locations/global/hubs/{{"{{"}}hub{{"}}"}}:acceptSpokeUpdate")
+if err != nil {
+	return err
+}
+
+obj := map[string]interface{}{
+	"spokeUri":  d.Get("spoke"),
+	"spokeEtag": spokeEtag,
+}
+
+log.Printf("[DEBUG] Accepting spoke update for HubSpokeAcceptance %q: %#v", d.Id(), obj)
+res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "POST",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: userAgent,
+	Body:      obj,
+	Timeout:   d.Timeout(schema.TimeoutUpdate),
+})
+if err != nil {
+	return fmt.Errorf("Error accepting spoke update for HubSpokeAcceptance %q: %s", d.Id(), err)
+}
+
+err = NetworkConnectivityOperationWaitTime(
+	config, res, tpgresource.GetResourceNameFromSelfLink(project), "Accepting HubSpokeAcceptance update", userAgent,
+	d.Timeout(schema.TimeoutUpdate))
+if err != nil {
+	return fmt.Errorf("Error waiting to accept spoke update for HubSpokeAcceptance: %s", err)
+}
+
+return resourceNetworkConnectivityHubSpokeAcceptanceRead(d, meta)

--- a/mmv1/templates/terraform/decoders/network_connectivity_hub_spoke_acceptance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/network_connectivity_hub_spoke_acceptance.go.tmpl
@@ -1,0 +1,48 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+spokeUri, _ := d.Get("spoke").(string)
+
+spokes, hasSpokes := res["spokes"].([]interface{})
+if !hasSpokes {
+	if name, ok := res["name"].(string); ok && tpgresource.CompareSelfLinkRelativePathsIgnoreProjectId("", spokeUri, name, nil) {
+		state, _ := res["state"].(string)
+		if !NetworkConnectivitySpokeIsAccepted(state) {
+			return nil, nil
+		}
+		res["spokeUri"] = name
+		return res, nil
+	}
+	return nil, nil
+}
+
+for _, raw := range spokes {
+	if raw == nil {
+		continue
+	}
+	spoke, ok := raw.(map[string]interface{})
+	if !ok {
+		continue
+	}
+	name, _ := spoke["name"].(string)
+	if !tpgresource.CompareSelfLinkRelativePathsIgnoreProjectId("", spokeUri, name, nil) {
+		continue
+	}
+	state, _ := spoke["state"].(string)
+	if !NetworkConnectivitySpokeIsAccepted(state) {
+		return nil, nil
+	}
+	spoke["spokeUri"] = name
+	return spoke, nil
+}
+
+return nil, nil

--- a/mmv1/templates/terraform/encoders/network_connectivity_hub_spoke_acceptance.go.tmpl
+++ b/mmv1/templates/terraform/encoders/network_connectivity_hub_spoke_acceptance.go.tmpl
@@ -1,0 +1,19 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+if v, ok := d.GetOk("hub"); ok {
+	if err := d.Set("hub", tpgresource.GetResourceNameFromSelfLink(v.(string))); err != nil {
+		return nil, fmt.Errorf("Error normalizing hub: %s", err)
+	}
+}
+
+return obj, nil

--- a/mmv1/templates/terraform/post_create/network_connectivity_hub_spoke_acceptance.go.tmpl
+++ b/mmv1/templates/terraform/post_create/network_connectivity_hub_spoke_acceptance.go.tmpl
@@ -1,0 +1,14 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+id = networkConnectivityHubSpokeAcceptanceId(project, d.Get("hub").(string), d.Get("spoke").(string))
+d.SetId(id)

--- a/mmv1/templates/terraform/pre_delete/network_connectivity_hub_spoke_acceptance.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/network_connectivity_hub_spoke_acceptance.go.tmpl
@@ -1,0 +1,15 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+obj = map[string]interface{}{
+	"spokeUri": d.Get("spoke"),
+}

--- a/mmv1/templates/terraform/samples/services/networkconnectivity/network_connectivity_hub_spoke_acceptance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkconnectivity/network_connectivity_hub_spoke_acceptance_basic.tf.tmpl
@@ -1,0 +1,29 @@
+resource "google_network_connectivity_hub" "hub" {
+  name        = "my-hub"
+  description = "Hub that accepts cross-project spokes"
+}
+
+resource "google_compute_network" "spoke_network" {
+  project                 = "spoke-project-id"
+  name                    = "spoke-vpc"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_connectivity_spoke" "spoke" {
+  project     = "spoke-project-id"
+  name        = "workload-spoke"
+  location    = "global"
+  description = "Spoke proposed from a workload project"
+  hub         = google_network_connectivity_hub.hub.id
+
+  linked_vpc_network {
+    uri                   = google_compute_network.spoke_network.self_link
+    include_export_ranges = ["10.0.0.0/8"]
+  }
+}
+
+resource "google_network_connectivity_hub_spoke_acceptance" "{{$.PrimaryResourceId}}" {
+  hub        = google_network_connectivity_hub.hub.id
+  spoke      = google_network_connectivity_spoke.spoke.id
+  spoke_etag = google_network_connectivity_spoke.spoke.etag
+}

--- a/mmv1/templates/terraform/samples/services/networkconnectivity/network_connectivity_hub_spoke_acceptance_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkconnectivity/network_connectivity_hub_spoke_acceptance_full.tf.tmpl
@@ -1,0 +1,58 @@
+resource "google_project" "spoke" {
+  project_id      = "{{index $.ResourceIdVars "spoke_project_id"}}"
+  name            = "NCC spoke project"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "spoke_compute" {
+  project = google_project.spoke.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "spoke_ncc" {
+  project = google_project.spoke.project_id
+  service = "networkconnectivity.googleapis.com"
+}
+
+resource "time_sleep" "wait_for_spoke_apis" {
+  create_duration = "60s"
+  depends_on = [
+    google_project_service.spoke_compute,
+    google_project_service.spoke_ncc,
+  ]
+}
+
+resource "google_compute_network" "spoke_network" {
+  project                 = google_project.spoke.project_id
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
+  auto_create_subnetworks = false
+  depends_on              = [time_sleep.wait_for_spoke_apis]
+}
+
+resource "google_network_connectivity_hub" "hub" {
+  name        = "{{index $.ResourceIdVars "hub_name"}}"
+  description = "Hub that accepts cross-project spokes"
+}
+
+resource "google_network_connectivity_spoke" "spoke" {
+  project     = google_project.spoke.project_id
+  name        = "{{index $.ResourceIdVars "spoke_name"}}"
+  location    = "global"
+  description = "Spoke proposed from a workload project"
+  hub         = google_network_connectivity_hub.hub.id
+
+  linked_vpc_network {
+    uri                   = google_compute_network.spoke_network.self_link
+    include_export_ranges = ["{{index $.Vars "include_export_range"}}"]
+  }
+
+  depends_on = [time_sleep.wait_for_spoke_apis]
+}
+
+resource "google_network_connectivity_hub_spoke_acceptance" "{{$.PrimaryResourceId}}" {
+  hub        = google_network_connectivity_hub.hub.id
+  spoke      = google_network_connectivity_spoke.spoke.id
+  spoke_etag = google_network_connectivity_spoke.spoke.etag
+}

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_hub_spoke_acceptance_internal_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_hub_spoke_acceptance_internal_test.go
@@ -1,0 +1,85 @@
+package networkconnectivity
+
+import (
+	"testing"
+)
+
+func TestNetworkConnectivitySpokeIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{
+		"ACTIVE":          true,
+		"UPDATING":        true,
+		"UPDATE_FAILED":   true,
+		"UPDATE_REJECTED": true,
+		"INACTIVE":        false,
+		"CREATING":        false,
+		"OBSOLETE":        false,
+		"DELETING":        false,
+		"":                false,
+	}
+
+	for state, want := range cases {
+		if got := NetworkConnectivitySpokeIsAccepted(state); got != want {
+			t.Errorf("NetworkConnectivitySpokeIsAccepted(%q) = %v, want %v", state, got, want)
+		}
+	}
+}
+
+func TestNetworkConnectivitySpokeHasPendingUpdate(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		spoke map[string]interface{}
+		want  bool
+	}{
+		"nil": {},
+		"active with no reasons": {
+			spoke: map[string]interface{}{"state": "ACTIVE"},
+		},
+		"update pending review": {
+			spoke: map[string]interface{}{
+				"state": "ACTIVE",
+				"reasons": []interface{}{
+					map[string]interface{}{"code": "UPDATE_PENDING_REVIEW"},
+				},
+			},
+			want: true,
+		},
+		"field paths pending update": {
+			spoke: map[string]interface{}{
+				"fieldPathsPendingUpdate": []interface{}{"linkedVpcNetwork.includeExportRanges"},
+			},
+			want: true,
+		},
+		"other reason": {
+			spoke: map[string]interface{}{
+				"reasons": []interface{}{
+					map[string]interface{}{"code": "REJECTED"},
+				},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			if got := NetworkConnectivitySpokeHasPendingUpdate(tc.spoke); got != tc.want {
+				t.Errorf("NetworkConnectivitySpokeHasPendingUpdate(%v) = %v, want %v", tc.spoke, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNetworkConnectivityHubSpokeAcceptanceId(t *testing.T) {
+	t.Parallel()
+
+	got := networkConnectivityHubSpokeAcceptanceId(
+		"projects/hub-proj",
+		"projects/hub-proj/locations/global/hubs/my-hub",
+		"projects/spoke-proj/locations/global/spokes/my-spoke",
+	)
+	want := "projects/hub-proj/locations/global/hubs/my-hub/spokeAcceptances/projects/spoke-proj/locations/global/spokes/my-spoke"
+	if got != want {
+		t.Errorf("networkConnectivityHubSpokeAcceptanceId() = %q, want %q", got, want)
+	}
+}

--- a/tools/issue-labeler/labeler/enrolled_teams.yml
+++ b/tools/issue-labeler/labeler/enrolled_teams.yml
@@ -618,6 +618,7 @@ service/network-connectivity-center:
   resources:
   - google_network_connectivity_hub
   - google_network_connectivity_spoke
+  - google_network_connectivity_hub_spoke_acceptance
   - google_network_connectivity_gateway_advertised_route
   - google_network_connectivity_transport
   - google_network_security_sac_realm


### PR DESCRIPTION
---

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27458

Part of https://github.com/hashicorp/terraform-provider-google/issues/17109

Adds `google_network_connectivity_hub_spoke_acceptance` so a hub admin can accept a cross-project NCC spoke (`acceptSpoke`) and later accept spoke updates (`acceptSpokeUpdate`) without maintaining `auto_accept_projects`.

The issue sketched `spokes = [...]`. This is one spoke per resource; use `for_each` for several. Same-project spokes are still auto-accepted by the API.

Create calls `hubs.acceptSpoke`. Setting `spoke_etag` to the spoke's etag accepts a pending update. Destroy calls `hubs.rejectSpoke`. `google_network_connectivity_spoke` now exports `etag`.

The generated acceptance test creates a second project and is `skip_vcr`. It needs `GOOGLE_ORG` and `GOOGLE_BILLING_ACCOUNT` if run live.

```release-note:new-resource
`google_network_connectivity_hub_spoke_acceptance`
```

```release-note:enhancement
networkconnectivity: added `etag` field to `google_network_connectivity_spoke` resource
```
