### PR TITLE
networkconnectivity: add auto_accept_hub to google_network_connectivity_spoke

### DIFF
--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -41,6 +41,19 @@ async:
     resource_inside_response: false
 legacy_long_form_project: true
 custom_code:
+  constants: templates/terraform/constants/network_connectivity_spoke.go.tmpl
+  post_create: templates/terraform/post_create/network_connectivity_spoke.go.tmpl
+  post_update: templates/terraform/post_update/network_connectivity_spoke.go.tmpl
+virtual_fields:
+  - name: autoAcceptHub
+    type: Boolean
+    default_value: false
+    description: |
+      If true, after this spoke is created the provider calls `hubs.acceptSpoke` when the spoke
+      is still `INACTIVE`. After an update that needs hub approval, it calls `hubs.acceptSpokeUpdate`.
+      Requires `networkconnectivity.groups.acceptSpoke` on the hub. Same-project spokes are
+      accepted by the API already. Use this for a cross-project spoke when these credentials
+      can accept on the hub. Otherwise leave unset and accept from the hub project.
 samples:
   - name: network_connectivity_spoke_linked_vpc_network_basic
     primary_resource_id: primary
@@ -57,6 +70,23 @@ samples:
           hub_name: '"hub1" + randomSuffix'
           # for backward compatible
           spoke_name: '"spoke1" + randomSuffix'
+  - name: network_connectivity_spoke_accept
+    primary_resource_id: primary
+    steps:
+      - name: network_connectivity_spoke_accept
+        resource_id_vars:
+          network_name: net
+          hub_name: hub1
+          spoke_name: spoke-accept
+        ignore_read_extra:
+          - auto_accept_hub
+      - name: network_connectivity_spoke_accept_update
+        resource_id_vars:
+          network_name: net
+          hub_name: hub1
+          spoke_name: spoke-accept
+        ignore_read_extra:
+          - auto_accept_hub
   - name: network_connectivity_spoke_linked_vpc_network_group
     primary_resource_id: primary
     steps:

--- a/mmv1/templates/terraform/constants/network_connectivity_spoke.go.tmpl
+++ b/mmv1/templates/terraform/constants/network_connectivity_spoke.go.tmpl
@@ -1,0 +1,110 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+var networkConnectivityHubPathRe = regexp.MustCompile(`projects/([^/]+)/locations/global/hubs/([^/]+)$`)
+
+func networkConnectivityParseHub(hub, defaultProject string) (string, string) {
+	if m := networkConnectivityHubPathRe.FindStringSubmatch(hub); len(m) == 3 {
+		return m[1], m[2]
+	}
+	return tpgresource.GetResourceNameFromSelfLink(strings.TrimPrefix(defaultProject, "projects/")), tpgresource.GetResourceNameFromSelfLink(hub)
+}
+
+func networkConnectivitySpokeUpdatePending(spoke map[string]interface{}) bool {
+	if spoke == nil {
+		return false
+	}
+	if paths, ok := spoke["fieldPathsPendingUpdate"].([]interface{}); ok && len(paths) > 0 {
+		return true
+	}
+	reasons, _ := spoke["reasons"].([]interface{})
+	for _, raw := range reasons {
+		reason, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if code, _ := reason["code"].(string); code == "UPDATE_PENDING_REVIEW" {
+			return true
+		}
+	}
+	return false
+}
+
+func networkConnectivitySpokeAcceptIfNeeded(d *schema.ResourceData, config *transport_tpg.Config, userAgent string, timeout time.Duration) error {
+	if !d.Get("auto_accept_hub").(bool) {
+		return nil
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+	billingProject := strings.TrimPrefix(project, "projects/")
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	getURL, err := tpgresource.ReplaceVarsForId(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/spokes/{{"{{"}}name{{"}}"}}")
+	if err != nil {
+		return err
+	}
+
+	spoke, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    getURL,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return fmt.Errorf("Error reading Spoke before accept: %s", err)
+	}
+
+	state, _ := spoke["state"].(string)
+	spokeURI, _ := spoke["name"].(string)
+	if spokeURI == "" {
+		spokeURI = d.Id()
+	}
+
+	hubProject, hubName := networkConnectivityParseHub(d.Get("hub").(string), project)
+	acceptBase := transport_tpg.BaseUrl(Product, config) + "projects/" + hubProject + "/locations/global/hubs/" + hubName
+
+	obj := map[string]interface{}{
+		"spokeUri": spokeURI,
+	}
+	var url string
+	if state == "INACTIVE" {
+		url = acceptBase + ":acceptSpoke"
+	} else if networkConnectivitySpokeUpdatePending(spoke) {
+		url = acceptBase + ":acceptSpokeUpdate"
+		if etag, ok := spoke["etag"].(string); ok && etag != "" {
+			obj["spokeEtag"] = etag
+		}
+	} else {
+		return nil
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   hubProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   timeout,
+	})
+	if err != nil {
+		return fmt.Errorf("Error accepting Spoke %q: %s", d.Id(), err)
+	}
+
+	return NetworkConnectivityOperationWaitTime(config, res, hubProject, "Accepting Spoke", userAgent, timeout)
+}

--- a/mmv1/templates/terraform/constants/network_connectivity_spoke.go.tmpl
+++ b/mmv1/templates/terraform/constants/network_connectivity_spoke.go.tmpl
@@ -10,6 +10,7 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 */ -}}
+{{- if not (contains $.ProductMetadata.Compiler "terraformgoogleconversion") }}
 var networkConnectivityHubPathRe = regexp.MustCompile(`projects/([^/]+)/locations/global/hubs/([^/]+)$`)
 
 func networkConnectivityParseHub(hub, defaultProject string) (string, string) {
@@ -108,3 +109,4 @@ func networkConnectivitySpokeAcceptIfNeeded(d *schema.ResourceData, config *tran
 
 	return NetworkConnectivityOperationWaitTime(config, res, hubProject, "Accepting Spoke", userAgent, timeout)
 }
+{{- end }}

--- a/mmv1/templates/terraform/post_create/network_connectivity_spoke.go.tmpl
+++ b/mmv1/templates/terraform/post_create/network_connectivity_spoke.go.tmpl
@@ -10,6 +10,8 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 */ -}}
+{{- if not (contains $.ProductMetadata.Compiler "terraformgoogleconversion") }}
 if err := networkConnectivitySpokeAcceptIfNeeded(d, config, userAgent, d.Timeout(schema.TimeoutCreate)); err != nil {
 	return err
 }
+{{- end }}

--- a/mmv1/templates/terraform/post_create/network_connectivity_spoke.go.tmpl
+++ b/mmv1/templates/terraform/post_create/network_connectivity_spoke.go.tmpl
@@ -1,0 +1,15 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+if err := networkConnectivitySpokeAcceptIfNeeded(d, config, userAgent, d.Timeout(schema.TimeoutCreate)); err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/post_update/network_connectivity_spoke.go.tmpl
+++ b/mmv1/templates/terraform/post_update/network_connectivity_spoke.go.tmpl
@@ -10,6 +10,8 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 */ -}}
+{{- if not (contains $.ProductMetadata.Compiler "terraformgoogleconversion") }}
 if err := networkConnectivitySpokeAcceptIfNeeded(d, config, userAgent, d.Timeout(schema.TimeoutUpdate)); err != nil {
 	return err
 }
+{{- end }}

--- a/mmv1/templates/terraform/post_update/network_connectivity_spoke.go.tmpl
+++ b/mmv1/templates/terraform/post_update/network_connectivity_spoke.go.tmpl
@@ -1,0 +1,15 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+if err := networkConnectivitySpokeAcceptIfNeeded(d, config, userAgent, d.Timeout(schema.TimeoutUpdate)); err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/samples/services/networkconnectivity/network_connectivity_spoke_accept.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkconnectivity/network_connectivity_spoke_accept.tf.tmpl
@@ -1,0 +1,20 @@
+resource "google_compute_network" "network" {
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_connectivity_hub" "basic_hub" {
+  name        = "{{index $.ResourceIdVars "hub_name"}}"
+  description = "A sample hub"
+}
+
+resource "google_network_connectivity_spoke" "{{$.PrimaryResourceId}}" {
+  name     = "{{index $.ResourceIdVars "spoke_name"}}"
+  location = "global"
+  hub      = google_network_connectivity_hub.basic_hub.id
+  auto_accept_hub = true
+
+  linked_vpc_network {
+    uri = google_compute_network.network.self_link
+  }
+}

--- a/mmv1/templates/terraform/samples/services/networkconnectivity/network_connectivity_spoke_accept_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkconnectivity/network_connectivity_spoke_accept_update.tf.tmpl
@@ -1,0 +1,21 @@
+resource "google_compute_network" "network" {
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_connectivity_hub" "basic_hub" {
+  name        = "{{index $.ResourceIdVars "hub_name"}}"
+  description = "A sample hub"
+}
+
+resource "google_network_connectivity_spoke" "{{$.PrimaryResourceId}}" {
+  name        = "{{index $.ResourceIdVars "spoke_name"}}"
+  location    = "global"
+  description = "Updated spoke"
+  hub         = google_network_connectivity_hub.basic_hub.id
+  auto_accept_hub = true
+
+  linked_vpc_network {
+    uri = google_compute_network.network.self_link
+  }
+}

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_internal_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_internal_test.go
@@ -1,0 +1,54 @@
+package networkconnectivity
+
+import (
+	"testing"
+)
+
+func TestNetworkConnectivityParseHub(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		hub     string
+		project string
+		wantP   string
+		wantN   string
+	}{
+		"full uri": {
+			hub:     "projects/hub-proj/locations/global/hubs/my-hub",
+			project: "spoke-proj",
+			wantP:   "hub-proj",
+			wantN:   "my-hub",
+		},
+		"name only": {
+			hub:     "my-hub",
+			project: "spoke-proj",
+			wantP:   "spoke-proj",
+			wantN:   "my-hub",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			gotP, gotN := networkConnectivityParseHub(tc.hub, tc.project)
+			if gotP != tc.wantP || gotN != tc.wantN {
+				t.Errorf("networkConnectivityParseHub(%q, %q) = (%q, %q), want (%q, %q)", tc.hub, tc.project, gotP, gotN, tc.wantP, tc.wantN)
+			}
+		})
+	}
+}
+
+func TestNetworkConnectivitySpokeUpdatePending(t *testing.T) {
+	t.Parallel()
+
+	if networkConnectivitySpokeUpdatePending(nil) {
+		t.Fatal("nil spoke should not be pending")
+	}
+	if networkConnectivitySpokeUpdatePending(map[string]interface{}{"state": "ACTIVE"}) {
+		t.Fatal("active spoke should not be pending")
+	}
+	if !networkConnectivitySpokeUpdatePending(map[string]interface{}{
+		"reasons": []interface{}{map[string]interface{}{"code": "UPDATE_PENDING_REVIEW"}},
+	}) {
+		t.Fatal("UPDATE_PENDING_REVIEW should be pending")
+	}
+}


### PR DESCRIPTION
Adds `auto_accept_hub` to `google_network_connectivity_spoke`.

When true, after the spoke is created the provider calls `hubs.acceptSpoke` if the spoke is still `INACTIVE`. After an update that needs hub approval, it calls `hubs.acceptSpokeUpdate`. This is for cross-project spokes when the same credentials can accept on the hub.

Same-project spokes are already accepted by the API. If the spoke apply cannot accept on the hub, leave this unset and accept from the hub project (`google_network_connectivity_hub_spoke_acceptance`).

```release-note:enhancement
networkconnectivity: added `auto_accept_hub` field to `google_network_connectivity_spoke` resource
```
