### PR TITLE
Improve SQL user password policy handling and prevent state inconsist…

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -454,6 +454,14 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	if databaseInstance.Settings.ActivationPolicy != "ALWAYS" {
+		if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+			"project":  project,
+			"instance": instance,
+			"host":     host,
+			"name":     name,
+		}); err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -616,6 +624,13 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if hasPasswordChange {
 			user.Password = password
+			if d.HasChange("password_policy") {
+				if v, ok := d.GetOk("password_policy"); ok {
+					user.PasswordPolicy = expandPasswordPolicy(v)
+				} else {
+					user.NullFields = append(user.NullFields, "PasswordPolicy")
+				}
+			}
 		}
 
 		transport_tpg.MutexStore.Lock(instanceMutexKey(project, instance))

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
@@ -429,6 +429,14 @@ func TestAccSqlUser_mysqlPasswordPolicy(t *testing.T) {
 				),
 			},
 			{
+				// Remove password policy
+				Config: testGoogleSqlUser_mysqlPasswordPolicy_removed(instance, "new_password"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user1"),
+					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user2"),
+				),
+			},
+			{
 				ResourceName:            "google_sql_user.user2",
 				ImportStateId:           fmt.Sprintf("%s/%s/gmail.com/admin", envvar.GetTestProjectFromEnv(), instance),
 				ImportState:             true,
@@ -1009,6 +1017,34 @@ resource "google_sql_user" "user2" {
     allowed_failed_attempts  = 6
     enable_failed_attempts_check = true
   }
+}
+`, instance, password)
+}
+
+func testGoogleSqlUser_mysqlPasswordPolicy_removed(instance, password string) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "MYSQL_8_0"
+  deletion_protection = false
+  settings {
+    tier = "db-f1-micro"
+  }
+}
+
+resource "google_sql_user" "user1" {
+  name     = "admin"
+  instance = google_sql_database_instance.instance.name
+  host     = "google.com"
+  password = "%s"
+}
+
+resource "google_sql_user" "user2" {
+  name     = "admin"
+  instance = google_sql_database_instance.instance.name
+  host     = "gmail.com"
+  password = "hunter2"
 }
 `, instance, password)
 }


### PR DESCRIPTION
…encies on inactive instances

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
sql: fixed state inconsistencies for `google_sql_user` when instances are inactive and improved password policy updates
```
