### PR TITLE
Migrate `data_source_google_compute_images.go` data source to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_images.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_images.go
@@ -101,26 +101,79 @@ func dataSourceGoogleComputeImagesRead(d *schema.ResourceData, meta interface{})
 
 	images := make([]map[string]interface{}, 0)
 
-	imageList, err := NewClient(config, userAgent).Images.List(project).Filter(filter).Do()
-	if err != nil {
-		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Images : %s", project), fmt.Sprintf("Images : %s", project))
-	}
+	baseURL := fmt.Sprintf("%sprojects/%s/global/images", transport_tpg.BaseUrl(Product, config), project)
+	pageToken := ""
+	for {
+		// Always send filter, even when empty, to match the request shape of the
+		// previous typed-client call (and its recorded VCR cassettes).
+		params := map[string]string{"filter": filter}
+		if pageToken != "" {
+			params["pageToken"] = pageToken
+		}
+		url, err := transport_tpg.AddQueryParams(baseURL, params)
+		if err != nil {
+			return err
+		}
 
-	for _, image := range imageList.Items {
-		images = append(images, map[string]interface{}{
-			"name":               image.Name,
-			"family":             image.Family,
-			"self_link":          image.SelfLink,
-			"archive_size_bytes": image.ArchiveSizeBytes,
-			"creation_timestamp": image.CreationTimestamp,
-			"description":        image.Description,
-			"disk_size_gb":       image.DiskSizeGb,
-			"image_id":           image.Id,
-			"labels":             image.Labels,
-			"source_disk":        image.SourceDisk,
-			"source_disk_id":     image.SourceDiskId,
-			"source_image_id":    image.SourceImageId,
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
 		})
+		if err != nil {
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Images : %s", project), fmt.Sprintf("Images : %s", project))
+		}
+
+		if items, ok := res["items"].([]interface{}); ok {
+			for _, raw := range items {
+				image, ok := raw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				m := map[string]interface{}{
+					"name":               image["name"],
+					"family":             image["family"],
+					"self_link":          image["selfLink"],
+					"creation_timestamp": image["creationTimestamp"],
+					"description":        image["description"],
+					"labels":             image["labels"],
+					"source_disk":        image["sourceDisk"],
+					"source_disk_id":     image["sourceDiskId"],
+					"source_image_id":    image["sourceImageId"],
+				}
+				// The REST API returns int64/uint64 fields as JSON strings to
+				// avoid float64 precision loss.
+				if v, ok := image["archiveSizeBytes"].(string); ok {
+					n, err := tpgresource.StringToFixed64(v)
+					if err != nil {
+						return fmt.Errorf("Error parsing archive_size_bytes: %s", err)
+					}
+					m["archive_size_bytes"] = n
+				}
+				if v, ok := image["diskSizeGb"].(string); ok {
+					n, err := tpgresource.StringToFixed64(v)
+					if err != nil {
+						return fmt.Errorf("Error parsing disk_size_gb: %s", err)
+					}
+					m["disk_size_gb"] = n
+				}
+				if v, ok := image["id"].(string); ok {
+					n, err := tpgresource.StringToFixed64(v)
+					if err != nil {
+						return fmt.Errorf("Error parsing image_id: %s", err)
+					}
+					m["image_id"] = n
+				}
+				images = append(images, m)
+			}
+		}
+
+		pageToken, _ = res["nextPageToken"].(string)
+		if pageToken == "" {
+			break
+		}
 	}
 
 	if err := d.Set("images", images); err != nil {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Resubmit of #18466, which was reverted in #18643 because of a CodeQL "incorrect conversion between integer types" alert. Only the id parsing differs from the reverted version; the rest is unchanged from the branch that was approved by @WentaoNi and @c2thorn.

Part of the ongoing migration of handwritten compute files from the Apiary client library to direct HTTP calls (`transport_tpg.SendRequest`). Same pattern as #18444 and the merged data source migrations #17090 / #17117.

- Replaces `NewClient(...).Images.List(project).Filter(filter).Do()` with `GET projects/{project}/global/images` via `transport_tpg.SendRequest` + `transport_tpg.AddQueryParams`.
- Adds `pageToken` pagination. The previous code issued a single `Do()` call, which returns only the first page (server default 500 items) and silently truncated larger projects.
- The `filter` query parameter is sent unconditionally (even when empty) to keep the request shape identical to the typed client, so the recorded VCR cassette stays replay-compatible. `pageToken` is only sent when non-empty for the same reason.
- **What changed since the revert.** The REST API serializes int64/uint64 fields as JSON strings; `archiveSizeBytes`, `diskSizeGb` and `id` are now all parsed with `tpgresource.StringToFixed64`, which returns an `int64` directly, so the file contains no integer conversion at all and no longer imports `strconv`. The reverted version parsed `id` with `strconv.ParseUint(v, 10, 64)` and cast the result to `int64`; `go/incorrect-integer-conversion` flags that because a 64-bit unsigned value does not fit in `int64`. `image_id` is a `schema.TypeInt`, so such a value could never be stored anyway - the cast silently produced a negative number, and the parse now returns an explicit error instead. `tpgresource.StringToFixed64` is also the helper MMv1 generates for `type: Integer` properties in this format.
- No schema, test, or documentation changes.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_images` data source to use direct HTTP rather than a client library
```

```release-note:bug
compute: fixed truncation of results at 500 images in `google_compute_images` data source
```
