### PR TITLE
fix(vertexai): pass a project ID to project_allowlist in the PSC tests

### DIFF
--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_deploy_psc_endpoint_automated.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_deploy_psc_endpoint_automated.tf.tmpl
@@ -9,10 +9,10 @@ resource "google_vertex_ai_endpoint_with_model_garden_deployment" "{{$.PrimaryRe
   endpoint_config {
     private_service_connect_config {
       enable_private_service_connect = true
-      project_allowlist              = [data.google_project.project.id]
+      project_allowlist              = [data.google_project.project.project_id]
 
       psc_automation_configs {
-        project_id = data.google_project.project.id
+        project_id = data.google_project.project.project_id
         network    = google_compute_network.network.id
       }
     }

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_endpoint_with_model_garden_deployment_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_endpoint_with_model_garden_deployment_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/compute"
+	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 	"github.com/hashicorp/terraform-provider-google/google/services/vertexai"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -220,7 +220,7 @@ resource "google_vertex_ai_endpoint_with_model_garden_deployment" "test" {
   endpoint_config {
     private_service_connect_config {
       enable_private_service_connect = true
-      project_allowlist              = [data.google_project.project.id]
+      project_allowlist              = [data.google_project.project.project_id]
     }
   }
 }
@@ -231,7 +231,16 @@ data "google_project" "project" {}
 
 func TestAccVertexAIEndpointWithModelGardenDeployment_pscEndpointAutomated(t *testing.T) {
 	t.Parallel()
-	context := map[string]interface{}{"random_suffix": acctest.RandString(t, 10)}
+	// PSC service automation attaches its own firewall rules to the network and
+	// removes them asynchronously when the deployment is deleted, so a network
+	// managed by this test cannot be destroyed reliably. Use the shared
+	// bootstrapped network, which is never torn down.
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "vertex-mg-psc")
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"network_name":  networkName,
+		"subnetwork":    tpgcompute.BootstrapSubnet(t, "vertex-mg-psc", networkName),
+	}
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -257,26 +266,18 @@ resource "google_vertex_ai_endpoint_with_model_garden_deployment" "test" {
   endpoint_config {
     private_service_connect_config {
       enable_private_service_connect = true
-      project_allowlist              = [data.google_project.project.id]
+      project_allowlist              = [data.google_project.project.project_id]
 
       psc_automation_configs {
-		    project_id = data.google_project.project.id
-		    network    = google_compute_network.network.id
+		    project_id = data.google_project.project.project_id
+		    network    = data.google_compute_network.network.id
 		  }
     }
   }
 }
 
-resource "google_compute_subnetwork" "subnetwork" {
-  name          = "subnetwork"
-  ip_cidr_range = "192.168.0.0/24"
-  region        = "us-central1"
-  network       = google_compute_network.network.id
-}
-
-resource "google_compute_network" "network" {
-  name                    = "network"
-  auto_create_subnetworks = false
+data "google_compute_network" "network" {
+  name = "%{network_name}"
 }
 
 data "google_project" "project" {}


### PR DESCRIPTION
`project_allowlist` takes a bare project ID. The two PSC acceptance tests and the published `psc_endpoint_automated` sample pass `data.google_project.project.id`, which renders as `projects/<project-id>`.

That used to work. The committed cassettes, recorded 2026-05-14, show a successful deploy sending `projects/<project-id>`, so `EndpointService.CreateEndpoint` accepted the resource-path form at the time and has since tightened validation. The underlying rejection is an `INVALID_ARGUMENT` naming `private_service_connect_config.project_allowlist`, but the deploy pipeline reports it to callers as a bare `code 13 INTERNAL` with an empty detail, so nothing about the offending field reaches the user. Anyone who copied the sample hits the same dead end.

These tests only reach the real API when their cassettes are invalidated, which is why the change in API behaviour went unnoticed for months — the last recording was in May.

`_pscEndpointAutomated` also managed its own network. PSC service automation attaches firewall rules to that network and removes them asynchronously when the deployment is deleted, so Terraform's network delete races them and destroy fails. It now uses the shared bootstrapped network, which also drops the hardcoded `network` and `subnetwork` names that let a failed run poison the next one.

```release-note:bug
vertexai: fixed the `google_vertex_ai_endpoint_with_model_garden_deployment` Private Service Connect sample passing a resource path to `project_allowlist`, which the API rejects; the field takes a project ID
```

### Testing

Both tests pass against a real project in us-central1, with an empty plan after apply:

* `TestAccVertexAIEndpointWithModelGardenDeployment_pscEndpoint` — 585s
* `TestAccVertexAIEndpointWithModelGardenDeployment_pscEndpointAutomated` — 1386s

Before this change both failed at create in every environment tried: four CI runs, plus us-west1 and us-central1 locally.

Split out of #18547 so it can land on its own — the breakage is an API behaviour change rather than part of the Read work in that PR, and #18547's PSC tests cannot go green until this merges.
