### PR TITLE
Revert "Migrate resource_compute_instance to new API (#18442)"

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -1058,75 +1058,6 @@ func resourceInstanceTags(d tpgresource.TerraformResourceData) map[string]interf
 	}
 }
 
-func resourceInstanceTagsOmitEmpty(d tpgresource.TerraformResourceData) map[string]interface{} {
-	tags := map[string]interface{}{}
-	v := d.Get("tags")
-	if v == nil {
-		return tags
-	}
-	vs := v.(*schema.Set)
-	if vs.Len() > 0 {
-		items := make([]string, vs.Len())
-		for i, v := range vs.List() {
-			items[i] = v.(string)
-		}
-		tags["items"] = items
-	}
-	if fingerprint := d.Get("tags_fingerprint").(string); fingerprint != "" {
-		tags["fingerprint"] = fingerprint
-	}
-	return tags
-}
-
-func schedulingOmitEmpty(scheduling map[string]interface{}) map[string]interface{} {
-	if scheduling == nil {
-		return nil
-	}
-	result := map[string]interface{}{}
-	for k, v := range scheduling {
-		if k == "automaticRestart" {
-			result[k] = v
-			continue
-		}
-		if v == nil {
-			continue
-		}
-		switch val := v.(type) {
-		case bool:
-			if val {
-				result[k] = v
-			}
-		case string:
-			if val != "" {
-				result[k] = v
-			}
-		case int:
-			if val != 0 {
-				result[k] = v
-			}
-		case int64:
-			if val != 0 {
-				result[k] = v
-			}
-		case float64:
-			if val != 0 {
-				result[k] = v
-			}
-		case map[string]interface{}:
-			if val != nil {
-				result[k] = v
-			}
-		case []interface{}:
-			if len(val) > 0 {
-				result[k] = v
-			}
-		default:
-			result[k] = v
-		}
-	}
-	return result
-}
-
 func expandShieldedVmConfigs(d tpgresource.TerraformResourceData) map[string]interface{} {
 	if _, ok := d.GetOk("shielded_instance_config"); !ok {
 		return nil
@@ -1583,23 +1514,13 @@ func expandComputeInstanceSourceEncryptionKey(d tpgresource.TerraformResourceDat
 	}
 
 	cekRes := cek.([]interface{})[0].(map[string]interface{})
-	result := map[string]interface{}{}
-	if v, _ := cekRes["rsa_encrypted_key"].(string); v != "" {
-		result["rsaEncryptedKey"] = v
+	return map[string]interface{}{
+		"rsaEncryptedKey":      cekRes["rsa_encrypted_key"].(string),
+		"rawKey":               cekRes["raw_key"].(string),
+		"kmsKeyName":           cekRes["kms_key_self_link"].(string),
+		"sha256":               cekRes["sha256"].(string),
+		"kmsKeyServiceAccount": cekRes["kms_key_service_account"].(string),
 	}
-	if v, _ := cekRes["raw_key"].(string); v != "" {
-		result["rawKey"] = v
-	}
-	if v, _ := cekRes["kms_key_self_link"].(string); v != "" {
-		result["kmsKeyName"] = v
-	}
-	if v, _ := cekRes["sha256"].(string); v != "" {
-		result["sha256"] = v
-	}
-	if v, _ := cekRes["kms_key_service_account"].(string); v != "" {
-		result["kmsKeyServiceAccount"] = v
-	}
-	return result
 }
 
 func flattenComputeInstanceSourceEncryptionKey(v map[string]interface{}) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance.go
@@ -36,42 +36,38 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 
 	id := fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, name)
 
-	baseURL, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}")
-	if err != nil {
-		return err
-	}
-	url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s", baseURL, project, zone, name)
-	instance, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "GET",
-		Project:   project,
-		RawURL:    url,
-		UserAgent: userAgent,
-	})
+	instance, err := NewClient(config, userAgent).Instances.Get(project, zone, name).Do()
 	if err != nil {
 		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Instance %s", name), id)
 	}
 
-	metadataMap, _ := instance["metadata"].(map[string]interface{})
+	var metadataMap map[string]interface{}
+	if instance.Metadata != nil {
+		if metadataMap, err = tpgresource.ConvertToMap(instance.Metadata); err != nil {
+			return fmt.Errorf("error converting metadata: %s", err)
+		}
+	}
 	md := flattenMetadataBeta(metadataMap)
 	if err = d.Set("metadata", md); err != nil {
 		return fmt.Errorf("error setting metadata: %s", err)
 	}
 
-	if err := d.Set("can_ip_forward", instance["canIpForward"]); err != nil {
+	if err := d.Set("can_ip_forward", instance.CanIpForward); err != nil {
 		return fmt.Errorf("Error setting can_ip_forward: %s", err)
 	}
-	machineType, _ := instance["machineType"].(string)
-	if err := d.Set("machine_type", tpgresource.GetResourceNameFromSelfLink(machineType)); err != nil {
+	if err := d.Set("machine_type", tpgresource.GetResourceNameFromSelfLink(instance.MachineType)); err != nil {
 		return fmt.Errorf("Error setting machine_type: %s", err)
 	}
-	if err := d.Set("hostname", instance["hostname"]); err != nil {
+	if err := d.Set("hostname", instance.Hostname); err != nil {
 		return fmt.Errorf("Error setting hostname: %s", err)
 	}
 
 	// Set the networks
 	// Use the first external IP found for the default connection info.
-	networkInterfacesRaw, _ := instance["networkInterfaces"].([]interface{})
+	networkInterfacesRaw, err := networkInterfacesToInterface(instance.NetworkInterfaces)
+	if err != nil {
+		return err
+	}
 	networkInterfaces, _, internalIP, externalIP, err := flattenNetworkInterfaces(d, config, networkInterfacesRaw)
 	if err != nil {
 		return err
@@ -95,63 +91,55 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 	})
 
 	// Set the metadata fingerprint if there is one.
-	if metadataMap != nil {
-		if err := d.Set("metadata_fingerprint", metadataMap["fingerprint"]); err != nil {
+	if instance.Metadata != nil {
+		if err := d.Set("metadata_fingerprint", instance.Metadata.Fingerprint); err != nil {
 			return fmt.Errorf("Error setting metadata_fingerprint: %s", err)
 		}
 	}
 
 	// Set the tags fingerprint if there is one.
-	if tags, ok := instance["tags"].(map[string]interface{}); ok {
-		if err := d.Set("tags_fingerprint", tags["fingerprint"]); err != nil {
+	if instance.Tags != nil {
+		if err := d.Set("tags_fingerprint", instance.Tags.Fingerprint); err != nil {
 			return fmt.Errorf("Error setting tags_fingerprint: %s", err)
 		}
-		items, _ := tags["items"].([]interface{})
-		if err := d.Set("tags", items); err != nil {
+		if err := d.Set("tags", tpgresource.ConvertStringArrToInterface(instance.Tags.Items)); err != nil {
 			return fmt.Errorf("Error setting tags: %s", err)
 		}
 	}
 
-	instanceLabels, _ := instance["labels"].(map[string]interface{})
-	if err := d.Set("labels", instanceLabels); err != nil {
+	if err := d.Set("labels", instance.Labels); err != nil {
 		return err
 	}
 
-	if err := d.Set("terraform_labels", instanceLabels); err != nil {
+	if err := d.Set("terraform_labels", instance.Labels); err != nil {
 		return err
 	}
 
-	if labelFingerprint, _ := instance["labelFingerprint"].(string); labelFingerprint != "" {
-		if err := d.Set("label_fingerprint", labelFingerprint); err != nil {
+	if instance.LabelFingerprint != "" {
+		if err := d.Set("label_fingerprint", instance.LabelFingerprint); err != nil {
 			return fmt.Errorf("Error setting label_fingerprint: %s", err)
 		}
 	}
 
 	attachedDisks := []map[string]interface{}{}
 	scratchDisks := []map[string]interface{}{}
-	instanceDisks, _ := instance["disks"].([]interface{})
-	for _, rawDisk := range instanceDisks {
-		disk, ok := rawDisk.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if isBoot, _ := disk["boot"].(bool); isBoot {
+	for _, disk := range instance.Disks {
+		if disk.Boot {
 			err = d.Set("boot_disk", flattenBootDisk(d, disk, config))
 			if err != nil {
 				return err
 			}
-		} else if diskType, _ := disk["type"].(string); diskType == "SCRATCH" {
+		} else if disk.Type == "SCRATCH" {
 			scratchDisks = append(scratchDisks, flattenScratchDisk(disk))
 		} else {
-			diskSource, _ := disk["source"].(string)
 			di := map[string]interface{}{
-				"source":      tpgresource.ConvertSelfLinkToV1(diskSource),
-				"device_name": disk["deviceName"],
-				"mode":        disk["mode"],
+				"source":      tpgresource.ConvertSelfLinkToV1(disk.Source),
+				"device_name": disk.DeviceName,
+				"mode":        disk.Mode,
 			}
-			if key, ok := disk["diskEncryptionKey"].(map[string]interface{}); ok {
-				di["disk_encryption_key_sha256"] = key["sha256"]
-				di["kms_key_self_link"] = key["kmsKeyName"]
+			if key := disk.DiskEncryptionKey; key != nil {
+				di["disk_encryption_key_sha256"] = key.Sha256
+				di["kms_key_self_link"] = key.KmsKeyName
 			}
 			attachedDisks = append(attachedDisks, di)
 		}
@@ -165,20 +153,21 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	instanceServiceAccounts, _ := instance["serviceAccounts"].([]interface{})
-	err = d.Set("service_account", flattenServiceAccounts(instanceServiceAccounts))
+	err = d.Set("service_account", flattenServiceAccounts(serviceAccountsToInterface(instance.ServiceAccounts)))
 	if err != nil {
 		return err
 	}
 
-	schedulingMap, _ := instance["scheduling"].(map[string]interface{})
+	schedulingMap, err := tpgresource.ConvertToMap(instance.Scheduling)
+	if err != nil {
+		return fmt.Errorf("Error converting scheduling: %s", err)
+	}
 	err = d.Set("scheduling", flattenScheduling(schedulingMap))
 	if err != nil {
 		return err
 	}
 
-	instanceGuestAccelerators, _ := instance["guestAccelerators"].([]interface{})
-	err = d.Set("guest_accelerator", flattenGuestAccelerators(instanceGuestAccelerators))
+	err = d.Set("guest_accelerator", flattenGuestAccelerators(guestAcceleratorsToInterface(instance.GuestAccelerators)))
 	if err != nil {
 		return err
 	}
@@ -188,13 +177,23 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	shieldedVmConfigMap, _ := instance["shieldedInstanceConfig"].(map[string]interface{})
+	var shieldedVmConfigMap map[string]interface{}
+	if sic := instance.ShieldedInstanceConfig; sic != nil {
+		shieldedVmConfigMap = map[string]interface{}{
+			"enableSecureBoot":          sic.EnableSecureBoot,
+			"enableVtpm":                sic.EnableVtpm,
+			"enableIntegrityMonitoring": sic.EnableIntegrityMonitoring,
+		}
+	}
 	err = d.Set("shielded_instance_config", flattenShieldedVmConfig(shieldedVmConfigMap))
 	if err != nil {
 		return err
 	}
 
-	displayDeviceMap, _ := instance["displayDevice"].(map[string]interface{})
+	var displayDeviceMap map[string]interface{}
+	if instance.DisplayDevice != nil {
+		displayDeviceMap = map[string]interface{}{"enableDisplay": instance.DisplayDevice.EnableDisplay}
+	}
 	err = d.Set("enable_display", flattenEnableDisplay(displayDeviceMap))
 	if err != nil {
 		return err
@@ -203,44 +202,41 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 	if err := d.Set("attached_disk", ads); err != nil {
 		return fmt.Errorf("Error setting attached_disk: %s", err)
 	}
-	if err := d.Set("cpu_platform", instance["cpuPlatform"]); err != nil {
+	if err := d.Set("cpu_platform", instance.CpuPlatform); err != nil {
 		return fmt.Errorf("Error setting cpu_platform: %s", err)
 	}
-	if err := d.Set("min_cpu_platform", instance["minCpuPlatform"]); err != nil {
+	if err := d.Set("min_cpu_platform", instance.MinCpuPlatform); err != nil {
 		return fmt.Errorf("Error setting min_cpu_platform: %s", err)
 	}
-	if err := d.Set("deletion_protection", instance["deletionProtection"]); err != nil {
+	if err := d.Set("deletion_protection", instance.DeletionProtection); err != nil {
 		return fmt.Errorf("Error setting deletion_protection: %s", err)
 	}
-	selfLink, _ := instance["selfLink"].(string)
-	if err := d.Set("self_link", tpgresource.ConvertSelfLinkToV1(selfLink)); err != nil {
+	if err := d.Set("self_link", tpgresource.ConvertSelfLinkToV1(instance.SelfLink)); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
-	if err := d.Set("instance_id", fmt.Sprintf("%d", getInt(instance["id"]))); err != nil {
+	if err := d.Set("instance_id", fmt.Sprintf("%d", instance.Id)); err != nil {
 		return fmt.Errorf("Error setting instance_id: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-	instanceZone, _ := instance["zone"].(string)
-	if err := d.Set("zone", tpgresource.GetResourceNameFromSelfLink(instanceZone)); err != nil {
+	if err := d.Set("zone", tpgresource.GetResourceNameFromSelfLink(instance.Zone)); err != nil {
 		return fmt.Errorf("Error setting zone: %s", err)
 	}
-	if err := d.Set("current_status", instance["status"]); err != nil {
+	if err := d.Set("current_status", instance.Status); err != nil {
 		return fmt.Errorf("Error setting current_status: %s", err)
 	}
-	instanceName, _ := instance["name"].(string)
-	if err := d.Set("name", instanceName); err != nil {
+	if err := d.Set("name", instance.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	if err := d.Set("key_revocation_action_type", instance["keyRevocationActionType"]); err != nil {
+	if err := d.Set("key_revocation_action_type", instance.KeyRevocationActionType); err != nil {
 		return fmt.Errorf("Error setting key_revocation_action_type: %s", err)
 	}
-	if err := d.Set("creation_timestamp", instance["creationTimestamp"]); err != nil {
+	if err := d.Set("creation_timestamp", instance.CreationTimestamp); err != nil {
 		return fmt.Errorf("Error setting creation_timestamp: %s", err)
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, tpgresource.GetResourceNameFromSelfLink(instanceZone), instanceName))
+	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, tpgresource.GetResourceNameFromSelfLink(instance.Zone), instance.Name))
 	return nil
 }
 

--- a/mmv1/third_party/terraform/services/compute/list_google_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/list_google_compute_instance.go.tmpl
@@ -10,6 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+{{ if eq $.TargetVersionName `ga` }}
+	"google.golang.org/api/compute/v1"
+{{- else }}
+	compute "google.golang.org/api/compute/v0.beta"
+{{- end }}
 
 	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -86,16 +91,18 @@ func (listR *GoogleComputeInstanceListResource) List(ctx context.Context, listRe
 }
 
 func flattenComputeInstanceListItem(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config, project string) error {
-	instanceName, _ := res["name"].(string)
-	if instanceName == "" {
+	var instance compute.Instance
+	if err := tpgresource.Convert(res, &instance); err != nil {
+		return fmt.Errorf("error converting compute instance list response: %w", err)
+	}
+	if instance.Name == "" {
 		return fmt.Errorf("missing name in compute instance list response")
 	}
 
-	instanceZone, _ := res["zone"].(string)
-	zone := tpgresource.GetResourceNameFromSelfLink(instanceZone)
+	zone := tpgresource.GetResourceNameFromSelfLink(instance.Zone)
 
-	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instanceName))
-	return populateComputeInstanceResourceData(d, res, project, zone, config)
+	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instance.Name))
+	return populateComputeInstanceResourceData(d, &instance, project, zone, config)
 }
 
 func ListComputeInstances(config *transport_tpg.Config, project, zone string, callback func(rd *schema.ResourceData) error) error {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -22,6 +22,12 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
+
+{{ if eq $.TargetVersionName `ga` }}
+	"google.golang.org/api/compute/v1"
+{{- else }}
+	compute "google.golang.org/api/compute/v0.beta"
+{{- end }}
 )
 
 func IpCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
@@ -1783,7 +1789,7 @@ be from 0 to 999,999,999 inclusive.`,
 	}
 }
 
-func getInstance(config *transport_tpg.Config, d *schema.ResourceData) (map[string]interface{}, error) {
+func getInstance(config *transport_tpg.Config, d *schema.ResourceData) (*compute.Instance, error) {
 	project, err := tpgresource.GetProject(d, config)
 	if err != nil {
 		return nil, err
@@ -1812,10 +1818,14 @@ func getInstance(config *transport_tpg.Config, d *schema.ResourceData) (map[stri
 	if err != nil {
 		return nil, transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Instance %s", d.Get("name").(string)))
 	}
-	return res, nil
+	var instance compute.Instance
+	if err = tpgresource.Convert(res, &instance); err != nil {
+		return nil, fmt.Errorf("Error parsing instance response: %s", err)
+	}
+	return &instance, nil
 }
 
-func getDisk(diskUri string, d *schema.ResourceData, config *transport_tpg.Config) (map[string]interface{}, error) {
+func getDisk(diskUri string, d *schema.ResourceData, config *transport_tpg.Config) (*compute.Disk, error) {
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return nil, err
@@ -1848,10 +1858,14 @@ func getDisk(diskUri string, d *schema.ResourceData, config *transport_tpg.Confi
 		return nil, err
 	}
 
-	return res, nil
+	var disk compute.Disk
+	if err = tpgresource.Convert(res, &disk); err != nil {
+		return nil, fmt.Errorf("Error parsing disk response: %s", err)
+	}
+	return &disk, nil
 }
 
-func expandComputeInstance(project string, d *schema.ResourceData, config *transport_tpg.Config) (map[string]interface{}, error) {
+func expandComputeInstance(project string, d *schema.ResourceData, config *transport_tpg.Config) (*compute.Instance, error) {
 	// Get the machine type
 	var machineTypeUrl string
 	if mt, ok := d.GetOk("machine_type"); ok {
@@ -1865,9 +1879,10 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 	}
 
 	// Build up the list of disks
-	disks := []interface{}{}
+
+	disks := []*compute.AttachedDisk{}
 	if _, hasBootDisk := d.GetOk("boot_disk"); hasBootDisk {
-		bootDisk, err := expandBootDisk(d, config, project)
+		bootDisk, err := expandBootDiskTyped(d, config, project)
 		if err != nil {
 			return nil, err
 		}
@@ -1875,7 +1890,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 	}
 
 	if _, hasScratchDisk := d.GetOk("scratch_disk"); hasScratchDisk {
-		scratchDisks, err := expandScratchDisks(d, config, project)
+		scratchDisks, err := expandScratchDisksTyped(d, config, project)
 		if err != nil {
 			return nil, err
 		}
@@ -1886,7 +1901,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 
 	for i := 0; i < attachedDisksCount; i++ {
 		diskConfig := d.Get(fmt.Sprintf("attached_disk.%d", i)).(map[string]interface{})
-		disk, err := expandAttachedDisk(diskConfig, d, config)
+		disk, err := expandAttachedDiskTyped(diskConfig, d, config)
 		if err != nil {
 			return nil, err
 		}
@@ -1894,7 +1909,9 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		disks = append(disks, disk)
 	}
 
-	networkInterfaces, err := expandNetworkInterfaces(d, config)
+
+
+	networkInterfaces, err := expandNetworkInterfacesTyped(d, config)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating network interfaces: %s", err)
 	}
@@ -1902,89 +1919,99 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 	if err != nil {
 		return nil, fmt.Errorf("Error creating network performance config: %s", err)
 	}
-	accels, err := expandInstanceGuestAccelerators(d, config)
+	var networkPerformanceConfig *compute.NetworkPerformanceConfig
+	if npcMap != nil {
+		networkPerformanceConfig = &compute.NetworkPerformanceConfig{}
+		if err := tpgresource.Convert(npcMap, networkPerformanceConfig); err != nil {
+			return nil, fmt.Errorf("Error converting networkPerformanceConfig: %s", err)
+		}
+	}
+	accels, err := expandInstanceGuestAcceleratorsTyped(d, config)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating guest accelerators: %s", err)
 	}
-	reservationAffinity, err := expandReservationAffinity(d)
+
+	tagsMap := resourceInstanceTags(d)
+	var tags *compute.Tags
+	if tagsMap != nil {
+		tags = &compute.Tags{}
+		if err := tpgresource.Convert(tagsMap, tags); err != nil {
+			return nil, fmt.Errorf("Error converting tags: %s", err)
+		}
+	}
+
+	reservationAffinityMap, err := expandReservationAffinity(d)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
 	}
+	var reservationAffinity *compute.ReservationAffinity
+	if reservationAffinityMap != nil {
+		reservationAffinity = &compute.ReservationAffinity{}
+		if err := tpgresource.Convert(reservationAffinityMap, reservationAffinity); err != nil {
+			return nil, fmt.Errorf("Error converting reservationAffinity: %s", err)
+		}
+	}
+
+	instanceEncryptionKeyMap := expandComputeInstanceEncryptionKey(d)
+	var instanceEncryptionKey *compute.CustomerEncryptionKey
+	if instanceEncryptionKeyMap != nil {
+		instanceEncryptionKey = &compute.CustomerEncryptionKey{}
+		if err := tpgresource.Convert(instanceEncryptionKeyMap, instanceEncryptionKey); err != nil {
+			return nil, fmt.Errorf("Error converting instance_encryption_key: %s", err)
+		}
+	}
 
 	// Create the instance information
-	instance := map[string]interface{}{
-		"canIpForward":       d.Get("can_ip_forward").(bool),
-		"deletionProtection": d.Get("deletion_protection").(bool),
-		"name":               d.Get("name").(string),
+	instance := &compute.Instance{
+		CanIpForward:               d.Get("can_ip_forward").(bool),
+		Description:                d.Get("description").(string),
+		Disks:                      disks,
+		MachineType:                machineTypeUrl,
+		Name:                       d.Get("name").(string),
+		NetworkInterfaces:          networkInterfaces,
+		NetworkPerformanceConfig:   networkPerformanceConfig,
+		Tags:                       tags,
+		Labels:                     tpgresource.ExpandEffectiveLabels(d),
+		ServiceAccounts:            expandServiceAccountsTyped(d.Get("service_account").([]interface{})),
+		GuestAccelerators:          accels,
+		MinCpuPlatform:             d.Get("min_cpu_platform").(string),
+		DeletionProtection:         d.Get("deletion_protection").(bool),
+		Hostname:                   d.Get("hostname").(string),
+		ForceSendFields:            []string{"CanIpForward", "DeletionProtection"},
+		ResourcePolicies:           tpgresource.ConvertStringArr(d.Get("resource_policies").([]interface{})),
+		ReservationAffinity:        reservationAffinity,
+		KeyRevocationActionType:    d.Get("key_revocation_action_type").(string),
+		InstanceEncryptionKey:      instanceEncryptionKey,
+		{{- if ne $.TargetVersionName `ga` }}
+		EraseWindowsVssSignature:   d.Get("erase_windows_vss_signature").(bool),
+		{{- end }}
 	}
-	if v := d.Get("description").(string); v != "" {
-		instance["description"] = v
-	}
-	if len(disks) > 0 {
-		instance["disks"] = disks
-	}
-	if machineTypeUrl != "" {
-		instance["machineType"] = machineTypeUrl
-	}
-	if len(networkInterfaces) > 0 {
-		instance["networkInterfaces"] = networkInterfaces
-	}
-	if npcMap != nil {
-		instance["networkPerformanceConfig"] = npcMap
-	}
-	if tagsMap := resourceInstanceTagsOmitEmpty(d); tagsMap != nil {
-		instance["tags"] = tagsMap
-	}
-	if labels := tpgresource.ExpandEffectiveLabels(d); len(labels) > 0 {
-		instance["labels"] = labels
-	}
-	if sa := expandServiceAccounts(d.Get("service_account").([]interface{})); len(sa) > 0 {
-		instance["serviceAccounts"] = sa
-	}
-	if len(accels) > 0 {
-		instance["guestAccelerators"] = accels
-	}
-	if v := d.Get("min_cpu_platform").(string); v != "" {
-		instance["minCpuPlatform"] = v
-	}
-	if v := d.Get("hostname").(string); v != "" {
-		instance["hostname"] = v
-	}
-	if rp := tpgresource.ConvertStringArr(d.Get("resource_policies").([]interface{})); len(rp) > 0 {
-		instance["resourcePolicies"] = rp
-	}
-	if reservationAffinity != nil {
-		instance["reservationAffinity"] = reservationAffinity
-	}
-	if v := d.Get("key_revocation_action_type").(string); v != "" {
-		instance["keyRevocationActionType"] = v
-	}
-	if instanceEncryptionKey := expandComputeInstanceEncryptionKey(d); instanceEncryptionKey != nil {
-		instance["instanceEncryptionKey"] = instanceEncryptionKey
-	}
-	{{- if ne $.TargetVersionName `ga` }}
-	if v := d.Get("erase_windows_vss_signature").(bool); v {
-		instance["eraseWindowsVssSignature"] = v
-	}
-	{{- end }}
 	if wic := expandWorkloadIdentityConfig(d); wic != nil {
-		instance["workloadIdentityConfig"] = wic
+		instance.WorkloadIdentityConfig = &compute.WorkloadIdentityConfig{
+			Identity:                   wic["identity"].(string),
+			IdentityCertificateEnabled: wic["identityCertificateEnabled"].(bool),
+		}
 	}
 	if cic := expandConfidentialInstanceConfig(d); cic != nil {
-		confidential := map[string]interface{}{}
-		if b, _ := cic["enableConfidentialCompute"].(bool); b {
-			confidential["enableConfidentialCompute"] = b
+		instance.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{
+			EnableConfidentialCompute: cic["enableConfidentialCompute"].(bool),
+			ConfidentialInstanceType:  cic["confidentialInstanceType"].(string),
 		}
-		if t, _ := cic["confidentialInstanceType"].(string); t != "" {
-			confidential["confidentialInstanceType"] = t
-		}
-		instance["confidentialInstanceConfig"] = confidential
 	}
 	if sicMap := expandShieldedVmConfigs(d); sicMap != nil {
-		instance["shieldedInstanceConfig"] = sicMap
+		instance.ShieldedInstanceConfig = &compute.ShieldedInstanceConfig{
+			EnableSecureBoot:          sicMap["enableSecureBoot"].(bool),
+			EnableVtpm:                sicMap["enableVtpm"].(bool),
+			EnableIntegrityMonitoring: sicMap["enableIntegrityMonitoring"].(bool),
+			ForceSendFields:           []string{"EnableSecureBoot", "EnableVtpm", "EnableIntegrityMonitoring"},
+		}
 	}
 	if dd := expandDisplayDevice(d); dd != nil {
-		instance["displayDevice"] = dd
+		enabled, _ := dd["enableDisplay"].(bool)
+		instance.DisplayDevice = &compute.DisplayDevice{
+			EnableDisplay:   enabled,
+			ForceSendFields: []string{"EnableDisplay"},
+		}
 	}
 	return instance, nil
 }
@@ -2067,8 +2094,7 @@ func waitUntilInstanceHasDesiredStatus(config *transport_tpg.Config, d *schema.R
 				log.Printf("Error on InstanceStateRefresh: %s", err)
 				return nil, "", err
 			}
-			status, _ := instance["status"].(string)
-			return instance["id"], status, nil
+			return instance.Id, instance.Status, nil
 		}
 		stateChangeConf := retry.StateChangeConf{
 			Delay:      5 * time.Second,
@@ -2120,7 +2146,10 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	{{- end }}
 
 	log.Printf("[INFO] Requesting instance creation")
-	instanceBody := instance
+	instanceBody, err := tpgresource.ConvertToMap(instance)
+	if err != nil {
+		return fmt.Errorf("Error converting instance: %s", err)
+	}
 	schedulingBody, err := expandScheduling(d.Get("scheduling"))
 	if err != nil {
 		return fmt.Errorf("Error creating scheduling: %s", err)
@@ -2173,7 +2202,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// Store the ID now
-	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, d.Get("name").(string)))
+	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
 	waitErr := ComputeOperationWaitTime(config, res, project, "instance to create", userAgent, d.Timeout(schema.TimeoutCreate))
@@ -2184,7 +2213,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	{{ if ne $.TargetVersionName `ga` -}}
-	err = computeInstanceAddSecurityPolicy(d, config, securityPolicies, project, z, userAgent, d.Get("name").(string))
+	err = computeInstanceAddSecurityPolicy(d, config, securityPolicies, project, z, userAgent, instance.Name)
 	if err != nil {
 		return fmt.Errorf("Error creating instance while setting the security policies: %s", err)
 	}
@@ -2207,7 +2236,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
 		"project": project,
 		"zone":    z,
-		"name":    instance["name"],
+		"name":    instance.Name,
 	}); err != nil {
 		return err
 	}
@@ -2234,8 +2263,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	savedNanos, hadNanos := d.GetOk("scheduling.0.graceful_shutdown.0.max_duration.0.nanos")
 	{{- end }}
 
-	instanceZone, _ := instance["zone"].(string)
-	zone := tpgresource.GetResourceNameFromSelfLink(instanceZone)
+	zone := tpgresource.GetResourceNameFromSelfLink(instance.Zone)
 
 	if err := populateComputeInstanceResourceData(d, instance, project, zone, config); err != nil {
 		return err
@@ -2258,7 +2286,10 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	// Fall back on internal ip if there is no external ip.  This makes sense in the situation where
 	// terraform is being used on a cloud instance and can therefore access the instances it creates
 	// via their internal ips.
-	networkInterfacesRaw, _ := instance["networkInterfaces"].([]interface{})
+	networkInterfacesRaw, err := networkInterfacesToInterface(instance.NetworkInterfaces)
+	if err != nil {
+		return err
+	}
 	_, _, internalIP, externalIP, err := flattenNetworkInterfaces(d, config, networkInterfacesRaw)
 	if err != nil {
 		return err
@@ -2275,7 +2306,10 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	{{ if ne $.TargetVersionName `ga` -}}
 	// Workaround: restore nanos from state since the API doesn't persist it (see comment above).
 	if hadNanos {
-		schedulingMap, _ := instance["scheduling"].(map[string]interface{})
+		schedulingMap, err := tpgresource.ConvertToMap(instance.Scheduling)
+		if err != nil {
+			return fmt.Errorf("Error converting scheduling for nanos workaround: %s", err)
+		}
 		scheduling := flattenScheduling(schedulingMap)
 		graceful_shutdown := scheduling[0]["graceful_shutdown"].([]interface{})[0].(map[string]interface{})
 		max_duration := graceful_shutdown["max_duration"].([]interface{})[0].(map[string]interface{})
@@ -2289,8 +2323,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	}
 	{{- end }}
 
-	instanceName, _ := instance["name"].(string)
-	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instanceName))
+	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instance.Name))
 
 	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil {
 		return err
@@ -2299,7 +2332,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
 		"project": project,
 		"zone":    zone,
-		"name":    instance["name"],
+		"name":    instance.Name,
 	}); err != nil {
 		return err
 	}
@@ -2307,33 +2340,45 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func populateComputeInstanceResourceData(d *schema.ResourceData, instance map[string]interface{}, project, zone string, config *transport_tpg.Config) error {
-	metadataMap, _ := instance["metadata"].(map[string]interface{})
+func populateComputeInstanceResourceData(d *schema.ResourceData, instance *compute.Instance, project, zone string, config *transport_tpg.Config) error {
+	var metadataMap map[string]interface{}
+	if instance.Metadata != nil {
+		var err error
+		metadataMap, err = tpgresource.ConvertToMap(instance.Metadata)
+		if err != nil {
+			return fmt.Errorf("Error converting metadata: %s", err)
+		}
+	}
 	if err := d.Set("metadata", flattenMetadataBeta(metadataMap)); err != nil {
 		return fmt.Errorf("Error setting metadata: %s", err)
 	}
 
-	var metadataFingerprint string
-	if metadataMap != nil {
-		metadataFingerprint, _ = metadataMap["fingerprint"].(string)
-	}
-	if err := d.Set("metadata_fingerprint", metadataFingerprint); err != nil {
+	if err := d.Set("metadata_fingerprint", instance.Metadata.Fingerprint); err != nil {
 		return fmt.Errorf("Error setting metadata_fingerprint: %s", err)
 	}
 
-	if err := d.Set("can_ip_forward", instance["canIpForward"]); err != nil {
+	if err := d.Set("can_ip_forward", instance.CanIpForward); err != nil {
 		return fmt.Errorf("Error setting can_ip_forward: %s", err)
 	}
-	machineType, _ := instance["machineType"].(string)
-	if err := d.Set("machine_type", tpgresource.GetResourceNameFromSelfLink(machineType)); err != nil {
+	if err := d.Set("machine_type", tpgresource.GetResourceNameFromSelfLink(instance.MachineType)); err != nil {
 		return fmt.Errorf("Error setting machine_type: %s", err)
 	}
-	npcMap, _ := instance["networkPerformanceConfig"].(map[string]interface{})
+	var npcMap map[string]interface{}
+	if instance.NetworkPerformanceConfig != nil {
+		var err error
+		npcMap, err = tpgresource.ConvertToMap(instance.NetworkPerformanceConfig)
+		if err != nil {
+			return fmt.Errorf("Error converting network_performance_config: %s", err)
+		}
+	}
 	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(npcMap)); err != nil {
 		return err
 	}
 	// Set the networks
-	networkInterfacesRaw, _ := instance["networkInterfaces"].([]interface{})
+	networkInterfacesRaw, err := networkInterfacesToInterface(instance.NetworkInterfaces)
+	if err != nil {
+		return err
+	}
 	networkInterfaces, _, _, _, err := flattenNetworkInterfaces(d, config, networkInterfacesRaw)
 	if err != nil {
 		return err
@@ -2343,36 +2388,29 @@ func populateComputeInstanceResourceData(d *schema.ResourceData, instance map[st
 	}
 
 	// Set the tags fingerprint if there is one.
-	if tags, ok := instance["tags"].(map[string]interface{}); ok {
-		if err := d.Set("tags_fingerprint", tags["fingerprint"]); err != nil {
+	if instance.Tags != nil {
+		if err := d.Set("tags_fingerprint", instance.Tags.Fingerprint); err != nil {
 			return fmt.Errorf("Error setting tags_fingerprint: %s", err)
 		}
-		items, _ := tags["items"].([]interface{})
-		if err := d.Set("tags", items); err != nil {
+		if err := d.Set("tags", tpgresource.ConvertStringArrToInterface(instance.Tags.Items)); err != nil {
 			return fmt.Errorf("Error setting tags: %s", err)
 		}
 	}
 
-	labels := map[string]string{}
-	if raw, ok := instance["labels"].(map[string]interface{}); ok {
-		for k, v := range raw {
-			labels[k], _ = v.(string)
-		}
-	}
-	if err := tpgresource.SetLabels(labels, d, "labels"); err != nil {
+	if err := tpgresource.SetLabels(instance.Labels, d, "labels"); err != nil {
 		return err
 	}
 
-	if err := tpgresource.SetLabels(labels, d, "terraform_labels"); err != nil {
+	if err := tpgresource.SetLabels(instance.Labels, d, "terraform_labels"); err != nil {
 		return err
 	}
 
-	if err := d.Set("effective_labels", labels); err != nil {
+	if err := d.Set("effective_labels", instance.Labels); err != nil {
 		return err
 	}
 
-	if labelFingerprint, _ := instance["labelFingerprint"].(string); labelFingerprint != "" {
-		if err := d.Set("label_fingerprint", labelFingerprint); err != nil {
+	if instance.LabelFingerprint != "" {
+		if err := d.Set("label_fingerprint", instance.LabelFingerprint); err != nil {
 			return fmt.Errorf("Error setting label_fingerprint: %s", err)
 		}
 	}
@@ -2406,29 +2444,23 @@ func populateComputeInstanceResourceData(d *schema.ResourceData, instance map[st
 
 	attachedDisks := make([]map[string]interface{}, d.Get("attached_disk.#").(int))
 	scratchDisks := []map[string]interface{}{}
-	instanceDisks, _ := instance["disks"].([]interface{})
-	for _, rawDisk := range instanceDisks {
-		disk, ok := rawDisk.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		diskSource, _ := disk["source"].(string)
-		if isBoot, _ := disk["boot"].(bool); isBoot {
+	for _, disk := range instance.Disks {
+		if disk.Boot {
 			if err := d.Set("boot_disk", flattenBootDisk(d, disk, config)); err != nil {
 				return fmt.Errorf("Error setting boot_disk: %s", err)
 			}
-		} else if diskType, _ := disk["type"].(string); diskType == "SCRATCH" {
+		} else if disk.Type == "SCRATCH" {
 			scratchDisks = append(scratchDisks, flattenScratchDisk(disk))
 		} else {
 			var sourceLink string
-			if strings.Contains(diskSource, "regions/") {
-				source, err := tpgresource.ParseRegionDiskFieldValue(diskSource, d, config)
+			if strings.Contains(disk.Source, "regions/") {
+				source, err := tpgresource.ParseRegionDiskFieldValue(disk.Source, d, config)
 				if err != nil {
 					return err
 				}
 				sourceLink = source.RelativeLink()
 			} else {
-				source, err := tpgresource.ParseDiskFieldValue(diskSource, d, config)
+				source, err := tpgresource.ParseDiskFieldValue(disk.Source, d, config)
 				if err != nil {
 					return err
 				}
@@ -2436,11 +2468,11 @@ func populateComputeInstanceResourceData(d *schema.ResourceData, instance map[st
 			}
 			adIndex, inConfig := attachedDiskSources[sourceLink]
 			di := map[string]interface{}{
-				"source":      tpgresource.ConvertSelfLinkToV1(diskSource),
-				"device_name": disk["deviceName"],
-				"mode":        disk["mode"],
+				"source":      tpgresource.ConvertSelfLinkToV1(disk.Source),
+				"device_name": disk.DeviceName,
+				"mode":        disk.Mode,
 			}
-			if key, ok := disk["diskEncryptionKey"].(map[string]interface{}); ok {
+			if key := disk.DiskEncryptionKey; key != nil {
 				if inConfig {
 					rsaKey := d.Get(fmt.Sprintf("attached_disk.%d.disk_encryption_key_rsa", adIndex))
 					if rsaKey != "" {
@@ -2454,13 +2486,13 @@ func populateComputeInstanceResourceData(d *schema.ResourceData, instance map[st
 						di["disk_encryption_service_account"] = serviceAccount
 					}
 				}
-				if kmsKeyName, _ := key["kmsKeyName"].(string); kmsKeyName != "" {
+				if key.KmsKeyName != "" {
 					// The response for crypto keys often includes the version of the key which needs to be removed
 					// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
-					di["kms_key_self_link"] = strings.Split(kmsKeyName, "/cryptoKeyVersions")[0]
+					di["kms_key_self_link"] = strings.Split(disk.DiskEncryptionKey.KmsKeyName, "/cryptoKeyVersions")[0]
 				}
-				if sha256, _ := key["sha256"].(string); sha256 != "" {
-					di["disk_encryption_key_sha256"] = sha256
+				if key.Sha256 != "" {
+					di["disk_encryption_key_sha256"] = key.Sha256
 				}
 			}
 
@@ -2478,7 +2510,7 @@ func populateComputeInstanceResourceData(d *schema.ResourceData, instance map[st
 		}
 	}
 
-	if err := d.Set("resource_policies", instance["resourcePolicies"]); err != nil {
+	if err := d.Set("resource_policies", instance.ResourcePolicies); err != nil {
 		return fmt.Errorf("Error setting resource_policies: %s", err)
 	}
 
@@ -2490,8 +2522,7 @@ func populateComputeInstanceResourceData(d *schema.ResourceData, instance map[st
 			ads = append(ads, ad)
 		}
 	}
-	instanceServiceAccounts, _ := instance["serviceAccounts"].([]interface{})
-	if err := d.Set("service_account", flattenServiceAccounts(instanceServiceAccounts)); err != nil {
+	if err := d.Set("service_account", flattenServiceAccounts(serviceAccountsToInterface(instance.ServiceAccounts))); err != nil {
 		return fmt.Errorf("Error setting service_account: %s", err)
 	}
 	if err := d.Set("attached_disk", ads); err != nil {
@@ -2502,14 +2533,20 @@ func populateComputeInstanceResourceData(d *schema.ResourceData, instance map[st
 	}
 
 {{ if eq $.TargetVersionName `ga` -}}
-	schedulingMap, _ := instance["scheduling"].(map[string]interface{})
+	schedulingMap, err := tpgresource.ConvertToMap(instance.Scheduling)
+	if err != nil {
+		return fmt.Errorf("Error converting scheduling: %s", err)
+	}
 	if err := d.Set("scheduling", flattenScheduling(schedulingMap)); err != nil {
 		return fmt.Errorf("Error setting scheduling: %s", err)
 	}
 {{ else -}}
 	// Workaroud: API doesn't update the scheduling.graceful_shutdown.max_duration.nanos field.
 	// To avoid diff, we need to set the value from the state not from API response.
-	schedulingMap, _ := instance["scheduling"].(map[string]interface{})
+	schedulingMap, err := tpgresource.ConvertToMap(instance.Scheduling)
+	if err != nil {
+		return fmt.Errorf("Error converting scheduling: %s", err)
+	}
 	scheduling := flattenScheduling(schedulingMap)
 	if nanos, ok := d.GetOk("scheduling.0.graceful_shutdown.0.max_duration.0.nanos"); ok {
 		graceful_shutdown := scheduling[0]["graceful_shutdown"].([]interface{})[0].(map[string]interface{})
@@ -2524,35 +2561,43 @@ func populateComputeInstanceResourceData(d *schema.ResourceData, instance map[st
 	}
 {{- end }}
 
-	instanceGuestAccelerators, _ := instance["guestAccelerators"].([]interface{})
-	if err := d.Set("guest_accelerator", flattenGuestAccelerators(instanceGuestAccelerators)); err != nil {
+	if err := d.Set("guest_accelerator", flattenGuestAccelerators(guestAcceleratorsToInterface(instance.GuestAccelerators))); err != nil {
 		return fmt.Errorf("Error setting guest_accelerator: %s", err)
 	}
-	shieldedVmConfigMap, _ := instance["shieldedInstanceConfig"].(map[string]interface{})
+	var shieldedVmConfigMap map[string]interface{}
+	if sic := instance.ShieldedInstanceConfig; sic != nil {
+		shieldedVmConfigMap = map[string]interface{}{
+			"enableSecureBoot":          sic.EnableSecureBoot,
+			"enableVtpm":                sic.EnableVtpm,
+			"enableIntegrityMonitoring": sic.EnableIntegrityMonitoring,
+		}
+	}
 	if err := d.Set("shielded_instance_config", flattenShieldedVmConfig(shieldedVmConfigMap)); err != nil {
 		return fmt.Errorf("Error setting shielded_instance_config: %s", err)
 	}
-	displayDeviceMap, _ := instance["displayDevice"].(map[string]interface{})
+	var displayDeviceMap map[string]interface{}
+	if instance.DisplayDevice != nil {
+		displayDeviceMap = map[string]interface{}{"enableDisplay": instance.DisplayDevice.EnableDisplay}
+	}
 	if err := d.Set("enable_display", flattenEnableDisplay(displayDeviceMap)); err != nil {
 		return fmt.Errorf("Error setting enable_display: %s", err)
 	}
-	if err := d.Set("cpu_platform", instance["cpuPlatform"]); err != nil {
+	if err := d.Set("cpu_platform", instance.CpuPlatform); err != nil {
 		return fmt.Errorf("Error setting cpu_platform: %s", err)
 	}
-	if err := d.Set("min_cpu_platform", instance["minCpuPlatform"]); err != nil {
+	if err := d.Set("min_cpu_platform", instance.MinCpuPlatform); err != nil {
 		return fmt.Errorf("Error setting min_cpu_platform: %s", err)
 	}
-	if err := d.Set("deletion_protection", instance["deletionProtection"]); err != nil {
+	if err := d.Set("deletion_protection", instance.DeletionProtection); err != nil {
 		return fmt.Errorf("Error setting deletion_protection: %s", err)
 	}
-	selfLink, _ := instance["selfLink"].(string)
-	if err := d.Set("self_link", tpgresource.ConvertSelfLinkToV1(selfLink)); err != nil {
+	if err := d.Set("self_link", tpgresource.ConvertSelfLinkToV1(instance.SelfLink)); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
-	if err := d.Set("instance_id", fmt.Sprintf("%d", getInt(instance["id"]))); err != nil {
+	if err := d.Set("instance_id", fmt.Sprintf("%d", instance.Id)); err != nil {
 		return fmt.Errorf("Error setting instance_id: %s", err)
 	}
-	if err := d.Set("creation_timestamp", instance["creationTimestamp"]); err != nil {
+	if err := d.Set("creation_timestamp", instance.CreationTimestamp); err != nil {
 		return fmt.Errorf("Error setting creation_timestamp: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {
@@ -2561,46 +2606,71 @@ func populateComputeInstanceResourceData(d *schema.ResourceData, instance map[st
 	if err := d.Set("zone", zone); err != nil {
 		return fmt.Errorf("Error setting zone: %s", err)
 	}
-	if err := d.Set("name", instance["name"]); err != nil {
+	if err := d.Set("name", instance.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	if err := d.Set("description", instance["description"]); err != nil {
+	if err := d.Set("description", instance.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
-	if err := d.Set("hostname", instance["hostname"]); err != nil {
+	if err := d.Set("hostname", instance.Hostname); err != nil {
 		return fmt.Errorf("Error setting hostname: %s", err)
 	}
-	if err := d.Set("current_status", instance["status"]); err != nil {
+	if err := d.Set("current_status", instance.Status); err != nil {
 		return fmt.Errorf("Error setting current_status: %s", err)
 	}
-	if cicMap, ok := instance["confidentialInstanceConfig"].(map[string]interface{}); ok {
+	if instance.ConfidentialInstanceConfig != nil {
+		cicMap, err := tpgresource.ConvertToMap(instance.ConfidentialInstanceConfig)
+		if err != nil {
+			return fmt.Errorf("Error converting confidential_instance_config: %s", err)
+		}
 		if err := d.Set("confidential_instance_config", flattenConfidentialInstanceConfig(cicMap)); err != nil {
 			return fmt.Errorf("Error setting confidential_instance_config: %s", err)
 		}
 	}
-	amfMap, _ := instance["advancedMachineFeatures"].(map[string]interface{})
+	amfMap, err := tpgresource.ConvertToMap(instance.AdvancedMachineFeatures)
+	if err != nil {
+		return fmt.Errorf("Error converting advanced_machine_features: %s", err)
+	}
 	if err := d.Set("advanced_machine_features", flattenAdvancedMachineFeatures(amfMap)); err != nil {
 		return fmt.Errorf("Error setting advanced_machine_features: %s", err)
 	}
 	if d.Get("desired_status") != "" {
-		if err := d.Set("desired_status", instance["status"]); err != nil {
+		if err := d.Set("desired_status", instance.Status); err != nil {
 			return fmt.Errorf("Error setting desired_status: %s", err)
 		}
 	}
-	reservationAffinityMap, _ := instance["reservationAffinity"].(map[string]interface{})
+	var reservationAffinityMap map[string]interface{}
+	if instance.ReservationAffinity != nil {
+		var err error
+		reservationAffinityMap, err = tpgresource.ConvertToMap(instance.ReservationAffinity)
+		if err != nil {
+			return fmt.Errorf("Error converting reservation_affinity: %s", err)
+		}
+	}
 	if err := d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinityMap)); err != nil {
 		return fmt.Errorf("Error setting reservation_affinity: %s", err)
 	}
-	if err := d.Set("key_revocation_action_type", instance["keyRevocationActionType"]); err != nil {
+	if err := d.Set("key_revocation_action_type", instance.KeyRevocationActionType); err != nil {
 		return fmt.Errorf("Error setting key_revocation_action_type: %s", err)
 	}
-	instanceEncryptionKeyMap, _ := instance["instanceEncryptionKey"].(map[string]interface{})
+	var instanceEncryptionKeyMap map[string]interface{}
+	if instance.InstanceEncryptionKey != nil {
+		var err error
+		instanceEncryptionKeyMap, err = tpgresource.ConvertToMap(instance.InstanceEncryptionKey)
+		if err != nil {
+			return fmt.Errorf("Error converting instance_encryption_key: %s", err)
+		}
+	}
 	if err := d.Set("instance_encryption_key", flattenComputeInstanceEncryptionKey(instanceEncryptionKeyMap)); err != nil {
 		return fmt.Errorf("Error setting instance_encryption_key: %s", err)
 	}
 
 	{{- if ne $.TargetVersionName `ga` }}
-	if partnerMetadataMap, ok := instance["partnerMetadata"].(map[string]interface{}); ok {
+	if instance.PartnerMetadata != nil {
+		partnerMetadataMap, err := tpgresource.ConvertToMap(instance.PartnerMetadata)
+		if err != nil {
+			return fmt.Errorf("Error converting partner metadata: %s", err)
+		}
 		partnerMetadata, err := flattenPartnerMetadata(convertPartnerMetadataFromCompute(partnerMetadataMap))
 		if err != nil {
 			return fmt.Errorf("Error parsing partner metadata: %s", err)
@@ -2666,7 +2736,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Instance %s", d.Get("name").(string)))
 	}
-	instance := instanceMap
+	instance := &compute.Instance{}
+	if err := tpgresource.Convert(instanceMap, instance); err != nil {
+		return fmt.Errorf("Error parsing instance response: %s", err)
+	}
 
 	// Enable partial mode for the resource since it is possible
 	d.Partial(true)
@@ -2813,7 +2886,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 {{ end }}
 	if d.HasChange("tags") {
-		tagsBody := resourceInstanceTagsOmitEmpty(d)
+		tagsBody := resourceInstanceTags(d)
 		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setTags")
 		if err != nil {
 			return fmt.Errorf("Error generating URL: %s", err)
@@ -2839,12 +2912,11 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("effective_labels") {
 		labels := tpgresource.ExpandEffectiveLabels(d)
 		labelFingerprint := d.Get("label_fingerprint").(string)
-		labelsBody := map[string]interface{}{}
-		if len(labels) > 0 {
-			labelsBody["labels"] = labels
-		}
-		if labelFingerprint != "" {
-			labelsBody["labelFingerprint"] = labelFingerprint
+		req := compute.InstancesSetLabelsRequest{Labels: labels, LabelFingerprint: labelFingerprint}
+
+		labelsBody, err := tpgresource.ConvertToMap(&req)
+		if err != nil {
+			return fmt.Errorf("Error converting labels: %s", err)
 		}
 		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setLabels")
 		if err != nil {
@@ -2912,10 +2984,13 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("resource_policies") {
-		instanceResourcePolicies, _ := instance["resourcePolicies"].([]interface{})
-		if len(instanceResourcePolicies) > 0 {
-			body := map[string]interface{}{"resourcePolicies": instanceResourcePolicies}
+		if len(instance.ResourcePolicies) > 0 {
+			req := compute.InstancesRemoveResourcePoliciesRequest{ResourcePolicies: instance.ResourcePolicies}
 
+			body, err := tpgresource.ConvertToMap(&req)
+			if err != nil {
+				return fmt.Errorf("Error converting remove resource policies request: %s", err)
+			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/removeResourcePolicies")
 			if err != nil {
 				return fmt.Errorf("Error generating URL: %s", err)
@@ -2940,8 +3015,12 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 		resourcePolicies := tpgresource.ConvertStringArr(d.Get("resource_policies").([]interface{}))
 		if len(resourcePolicies) > 0 {
-			body := map[string]interface{}{"resourcePolicies": resourcePolicies}
+			req := compute.InstancesAddResourcePoliciesRequest{ResourcePolicies: resourcePolicies}
 
+			body, err := tpgresource.ConvertToMap(&req)
+			if err != nil {
+				return fmt.Errorf("Error converting add resource policies request: %s", err)
+			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/addResourcePolicies")
 			if err != nil {
 				return fmt.Errorf("Error generating URL: %s", err)
@@ -2996,25 +3075,24 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	networkInterfaces, err := expandNetworkInterfaces(d, config)
+	networkInterfaces, err := expandNetworkInterfacesTyped(d, config)
 	if err != nil {
 		return fmt.Errorf("Error getting network interface from config: %s", err)
 	}
-	instNics, _ := instance["networkInterfaces"].([]interface{})
 
 	// Sanity check
-	if len(networkInterfaces) != len(instNics) {
-		return fmt.Errorf("Instance had unexpected number of network interfaces: %d", len(instNics))
+	if len(networkInterfaces) != len(instance.NetworkInterfaces) {
+		return fmt.Errorf("Instance had unexpected number of network interfaces: %d", len(instance.NetworkInterfaces))
 	}
 
 	{{ if ne $.TargetVersionName `ga` -}}
 	updateSecurityPolicy := false
-	for i := 0; i < len(instNics); i++ {
+	for i := 0; i < len(instance.NetworkInterfaces); i++ {
 		prefix := fmt.Sprintf("network_interface.%d", i)
 		// check if sec policy has been changed
 		// check if access config has been changed because it may be deleted and needs to be re-created.
 		if d.HasChange(prefix+".security_policy") || d.HasChange(prefix+".access_config") || d.HasChange(prefix+".ipv6_access_config") {
-			if instStatus, _ := instance["status"].(string); instStatus != "RUNNING" {
+			if instance.Status != "RUNNING" {
 				return fmt.Errorf("Error to update security policy because the current instance status must be \"RUNNING\". The security policy or some access config may have changed which requires the security policy to be re-applied")
 			}
 			updateSecurityPolicy = true
@@ -3034,16 +3112,16 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	var updatesToNIWhileStopped []func(inst map[string]interface{}) error
 	for i := 0; i < len(networkInterfaces); i++ {
 		prefix := fmt.Sprintf("network_interface.%d", i)
-		networkInterface, _ := networkInterfaces[i].(map[string]interface{})
-		instNetworkInterface, _ := instNics[i].(map[string]interface{})
+		networkInterface := networkInterfaces[i]
+		instNetworkInterface := instance.NetworkInterfaces[i]
 
 		networkName := d.Get(prefix + ".name").(string)
-		subnetwork, _ := networkInterface["subnetwork"].(string)
+		subnetwork := networkInterface.Subnetwork
 		updateDuringStop := d.HasChange(prefix+".subnetwork") || d.HasChange(prefix+".network") || d.HasChange(prefix+".subnetwork_project")
 
 		// Sanity check
-		if instNiName, _ := instNetworkInterface["name"].(string); networkName != instNiName {
-			return fmt.Errorf("Instance networkInterface had unexpected name: %s", instNiName)
+		if networkName != instNetworkInterface.Name {
+			return fmt.Errorf("Instance networkInterface had unexpected name: %s", instNetworkInterface.Name)
 		}
 
 		// On creation the network is inferred if only subnetwork is given.
@@ -3077,7 +3155,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Cannot determine self_link for network %q: %s", networkSelfLink, err)
 				}
-				networkInterface["network"] = nf.RelativeLink()
+				networkInterface.Network = nf.RelativeLink()
 			}
 		}
 
@@ -3089,19 +3167,25 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			// necessary, and also add before removing.
 
 			// Delete current access configs
-			instNiMap := instNetworkInterface
-			err = computeInstanceDeleteAccessConfigs(d, config, instNiMap, project, zone, userAgent, d.Get("name").(string))
+			instNiMap, err := tpgresource.ConvertToMap(instNetworkInterface)
+			if err != nil {
+				return fmt.Errorf("Error converting network interface to map: %w", err)
+			}
+			err = computeInstanceDeleteAccessConfigs(d, config, instNiMap, project, zone, userAgent, instance.Name)
 			if err != nil {
 				return err
 			}
 
 			// Create new ones
-			accessConfigs, _ := networkInterface["accessConfigs"].([]interface{})
-			acMaps := make([]interface{}, len(accessConfigs))
-			for j, ac := range accessConfigs {
-				acMaps[j] = ac
+			acMaps := make([]interface{}, len(networkInterface.AccessConfigs))
+			for j, ac := range networkInterface.AccessConfigs {
+				acMap, err := tpgresource.ConvertToMap(ac)
+				if err != nil {
+					return fmt.Errorf("Error converting access config to map: %w", err)
+				}
+				acMaps[j] = acMap
 			}
-			err = computeInstanceAddAccessConfigs(d, config, instNiMap, acMaps, project, zone, userAgent, d.Get("name").(string))
+			err = computeInstanceAddAccessConfigs(d, config, instNiMap, acMaps, project, zone, userAgent, instance.Name)
 			if err != nil {
 				return err
 			}
@@ -3121,23 +3205,30 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			instance = freshMap
-			instNics, _ = instance["networkInterfaces"].([]interface{})
-			instNetworkInterface, _ = instNics[i].(map[string]interface{})
+			if err := tpgresource.Convert(freshMap, instance); err != nil {
+				return fmt.Errorf("Error parsing instance response: %s", err)
+			}
+			instNetworkInterface = instance.NetworkInterfaces[i]
 		}
 
 		if !updateDuringStop && d.HasChange(prefix+".alias_ip_range") {
 			// Alias IP ranges cannot be updated; they must be removed and then added
 			// unless you are changing subnetwork/network
-			if instAliasIpRanges, _ := instNetworkInterface["aliasIpRanges"].([]interface{}); len(instAliasIpRanges) > 0 {
-				oldNiMap := instNetworkInterface
-				newNiMap := networkInterface
+			if len(instNetworkInterface.AliasIpRanges) > 0 {
+				oldNiMap, err := tpgresource.ConvertToMap(instNetworkInterface)
+				if err != nil {
+					return fmt.Errorf("Error converting network interface to map: %w", err)
+				}
+				newNiMap, err := tpgresource.ConvertToMap(networkInterface)
+				if err != nil {
+					return fmt.Errorf("Error converting network interface to map: %w", err)
+				}
 				aliasRanges := []interface{}{}
 				if commonAliasIpRanges := CheckForCommonAliasIp(oldNiMap, newNiMap); len(commonAliasIpRanges) > 0 {
 					aliasRanges = commonAliasIpRanges
 				}
 				niBody := map[string]interface{}{
-					"fingerprint":   instNetworkInterface["fingerprint"],
+					"fingerprint":   instNetworkInterface.Fingerprint,
 					"aliasIpRanges": aliasRanges,
 				}
 				url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
@@ -3178,16 +3269,19 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return err
 				}
-				instance = freshMap
-				instNics, _ = instance["networkInterfaces"].([]interface{})
-				instNetworkInterface, _ = instNics[i].(map[string]interface{})
+				if err := tpgresource.Convert(freshMap, instance); err != nil {
+					return fmt.Errorf("Error parsing instance response: %s", err)
+				}
+				instNetworkInterface = instance.NetworkInterfaces[i]
 			}
 
-			niBody := map[string]interface{}{
-				"fingerprint": instNetworkInterface["fingerprint"],
+			networkInterfacePatchObj := &compute.NetworkInterface{
+				AliasIpRanges: networkInterface.AliasIpRanges,
+				Fingerprint:   instNetworkInterface.Fingerprint,
 			}
-			if air, ok := networkInterface["aliasIpRanges"].([]interface{}); ok && len(air) > 0 {
-				niBody["aliasIpRanges"] = air
+			niBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
 			if err != nil {
@@ -3218,110 +3312,61 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if !updateDuringStop && d.HasChange(prefix+".alias_ipv6_range") {
 			// Alias IPv6 ranges cannot be updated; they must be removed and then added
 			// unless you are changing subnetwork/network
-			if instAliasIpv6Ranges, _ := instNetworkInterface["aliasIpv6Ranges"].([]interface{}); len(instAliasIpv6Ranges) > 0 {
-				ni := map[string]interface{}{
-					"fingerprint":     instNetworkInterface["fingerprint"],
-					"aliasIpv6Ranges": []interface{}{},
+			if len(instNetworkInterface.AliasIpv6Ranges) > 0 {
+				ni := &compute.NetworkInterface{
+					Fingerprint:     instNetworkInterface.Fingerprint,
+					ForceSendFields: []string{"AliasIpv6Ranges"},
 				}
 				if commonAliasIpv6Ranges := CheckForCommonAliasIpv6(instNetworkInterface, networkInterface); len(commonAliasIpv6Ranges) > 0 {
-					ni["aliasIpv6Ranges"] = commonAliasIpv6Ranges
+					ni.AliasIpv6Ranges = commonAliasIpv6Ranges
 				}
-				url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
-				if err != nil {
-					return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
-				}
-				url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
-				if err != nil {
-					return err
-				}
-				res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-					Config:    config,
-					Method:    "PATCH",
-					Project:   project,
-					RawURL:    url,
-					UserAgent: userAgent,
-					Body:      ni,
-				})
+				op, err := NewClient(config, userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, ni).Do()
 				if err != nil {
 					return errwrap.Wrapf("Error removing alias_ipv6_range: {{"{{"}}err{{"}}"}}", err)
 				}
-				opErr := ComputeOperationWaitTime(config, res, project, "updating alias ipv6 ranges", userAgent, d.Timeout(schema.TimeoutUpdate))
+				opErr := ComputeOperationWaitTime(config, op, project, "updating alias ipv6 ranges", userAgent, d.Timeout(schema.TimeoutUpdate))
 				if opErr != nil {
 					return opErr
 				}
 				// re-read fingerprint
-				freshUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}")
+				instance, err = NewClient(config, userAgent).Instances.Get(project, zone, instance.Name).Do()
 				if err != nil {
 					return err
 				}
-				instance, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-					Config:    config,
-					Method:    "GET",
-					Project:   project,
-					RawURL:    freshUrl,
-					UserAgent: userAgent,
-				})
-				if err != nil {
-					return err
-				}
-				instNics, _ = instance["networkInterfaces"].([]interface{})
-				instNetworkInterface, _ = instNics[i].(map[string]interface{})
+				instNetworkInterface = instance.NetworkInterfaces[i]
 			}
 
-			niBody := map[string]interface{}{
-				"fingerprint": instNetworkInterface["fingerprint"],
+			networkInterfacePatchObj := &compute.NetworkInterface{
+				AliasIpv6Ranges: networkInterface.AliasIpv6Ranges,
+				Fingerprint:     instNetworkInterface.Fingerprint,
 			}
-			if air, ok := networkInterface["aliasIpv6Ranges"].([]interface{}); ok && len(air) > 0 {
-				niBody["aliasIpv6Ranges"] = air
-			}
-			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
-			if err != nil {
-				return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
-			}
-			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
-			if err != nil {
-				return err
-			}
-			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-				Config:    config,
-				Method:    "PATCH",
-				Project:   project,
-				RawURL:    url,
-				UserAgent: userAgent,
-				Body:      niBody,
-			})
+			updateCall := NewClient(config, userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, networkInterfacePatchObj).Do
+			op, err := updateCall()
 			if err != nil {
 				return errwrap.Wrapf("Error updating network interface: {{`{{`}}err{{`}}`}}", err)
 			}
-			opErr := ComputeOperationWaitTime(config, res, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, op, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
 			// re-read fingerprint
-			freshUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}")
+			instance, err = NewClient(config, userAgent).Instances.Get(project, zone, instance.Name).Do()
 			if err != nil {
 				return err
 			}
-			instance, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-				Config:    config,
-				Method:    "GET",
-				Project:   project,
-				RawURL:    freshUrl,
-				UserAgent: userAgent,
-			})
-			if err != nil {
-				return err
-			}
-			instNics, _ = instance["networkInterfaces"].([]interface{})
-			instNetworkInterface, _ = instNics[i].(map[string]interface{})
+			instNetworkInterface = instance.NetworkInterfaces[i]
 		}
 {{- end }}
 
 		if !updateDuringStop && d.HasChange(prefix+".stack_type") {
 
-			niBody := map[string]interface{}{
-				"stackType":   d.Get(prefix+".stack_type").(string),
-				"fingerprint": instNetworkInterface["fingerprint"],
+			networkInterfacePatchObj := &compute.NetworkInterface{
+				StackType: d.Get(prefix+".stack_type").(string),
+				Fingerprint:   instNetworkInterface.Fingerprint,
+			}
+			niBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
 			if err != nil {
@@ -3350,9 +3395,13 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 		if !updateDuringStop && d.HasChange(prefix+".igmp_query") {
 
-			niBody := map[string]interface{}{
-				"igmpQuery":   d.Get(prefix+".igmp_query").(string),
-				"fingerprint": instNetworkInterface["fingerprint"],
+			networkInterfacePatchObj := &compute.NetworkInterface{
+				IgmpQuery: d.Get(prefix+".igmp_query").(string),
+				Fingerprint:   instNetworkInterface.Fingerprint,
+			}
+			niBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
 			if err != nil {
@@ -3381,9 +3430,13 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 		if !updateDuringStop && d.HasChange(prefix+".ipv6_address") {
 
-			niBody := map[string]interface{}{
-				"ipv6Address": d.Get(prefix+".ipv6_address").(string),
-				"fingerprint": instNetworkInterface["fingerprint"],
+			networkInterfacePatchObj := &compute.NetworkInterface{
+				Ipv6Address: d.Get(prefix+".ipv6_address").(string),
+				Fingerprint:   instNetworkInterface.Fingerprint,
+			}
+			niBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
 			if err != nil {
@@ -3412,9 +3465,13 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 		if !updateDuringStop && d.HasChange(prefix+".internal_ipv6_prefix_length") {
 
-			niBody := map[string]interface{}{
-				"internalIpv6PrefixLength": d.Get(prefix+".internal_ipv6_prefix_length").(int64),
-				"fingerprint":              instNetworkInterface["fingerprint"],
+			networkInterfacePatchObj := &compute.NetworkInterface{
+				InternalIpv6PrefixLength: d.Get(prefix+".internal_ipv6_prefix_length").(int64),
+				Fingerprint:              instNetworkInterface.Fingerprint,
+			}
+			niBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
 			if err != nil {
@@ -3443,27 +3500,27 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 		if updateDuringStop {
 			// Lets be explicit about what we are changing in the patch call
-			niPatchMap := map[string]interface{}{
-				"network":       networkInterface["network"],
-				"subnetwork":    networkInterface["subnetwork"],
-				"aliasIpRanges": networkInterface["aliasIpRanges"],
-{{- if ne $.TargetVersionName "ga" }}
-				"aliasIpv6Ranges": networkInterface["aliasIpv6Ranges"],
+			networkInterfacePatchObj := &compute.NetworkInterface{
+				Network:       networkInterface.Network,
+				Subnetwork:    networkInterface.Subnetwork,
+				AliasIpRanges: networkInterface.AliasIpRanges,
+{{ if ne $.TargetVersionName `ga` -}}
+				AliasIpv6Ranges: networkInterface.AliasIpv6Ranges,
 {{- end }}
 			}
 
 			// network_ip can be inferred if not declared. Let's only patch if it's being changed by user
 			// otherwise this could fail if the network ip is not compatible with the new Subnetwork/Network.
 			if d.HasChange(prefix + ".network_ip") {
-				niPatchMap["networkIP"] = networkInterface["networkIP"]
+				networkInterfacePatchObj.NetworkIP = networkInterface.NetworkIP
 			}
 
 			if d.HasChange(prefix+".internal_ipv6_prefix_length") {
-				niPatchMap["ipv6Address"] = networkInterface["ipv6Address"]
+				networkInterfacePatchObj.Ipv6Address = networkInterface.Ipv6Address
 			}
 
 			if d.HasChange(prefix+".ipv6_address") {
-				niPatchMap["ipv6Address"] = networkInterface["ipv6Address"]
+				networkInterfacePatchObj.Ipv6Address = networkInterface.Ipv6Address
 			}
 
 			// Access config can run into some issues since we can't tell the difference between
@@ -3473,9 +3530,20 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			// configs if we notice the configuration (user intent) changes.
 			accessConfigsHaveChanged := d.HasChange(prefix + ".access_config")
 
-			acMaps, _ := networkInterface["accessConfigs"].([]interface{})
+			acMaps := make([]interface{}, len(networkInterface.AccessConfigs))
+			for j, ac := range networkInterface.AccessConfigs {
+				acMap, err := tpgresource.ConvertToMap(ac)
+				if err != nil {
+					return fmt.Errorf("Error converting access config to map: %w", err)
+				}
+				acMaps[j] = acMap
+			}
+			niPatchMap, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return fmt.Errorf("Error converting network interface patch object to map: %w", err)
+			}
 
-			updateCall := computeInstanceCreateUpdateWhileStoppedCall(d, config, niPatchMap, acMaps, accessConfigsHaveChanged, i, project, zone, userAgent, d.Get("name").(string))
+			updateCall := computeInstanceCreateUpdateWhileStoppedCall(d, config, niPatchMap, acMaps, accessConfigsHaveChanged, i, project, zone, userAgent, instance.Name)
 			updatesToNIWhileStopped = append(updatesToNIWhileStopped, updateCall)
 		}
 	}
@@ -3492,16 +3560,14 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 		if d.HasChange("boot_disk.0.initialize_params") {
 			var locationType, location string
-			if diskRegion, _ := disk["region"].(string); diskRegion != "" {
+			if disk.Region != "" {
 				locationType = "regions"
-				location = tpgresource.GetResourceNameFromSelfLink(diskRegion)
+				location = tpgresource.GetResourceNameFromSelfLink(disk.Region)
 			} else {
-				diskZone, _ := disk["zone"].(string)
 				locationType = "zones"
-				location = tpgresource.GetResourceNameFromSelfLink(diskZone)
+				location = tpgresource.GetResourceNameFromSelfLink(disk.Zone)
 			}
-			diskName, _ := disk["name"].(string)
-			urlBase := fmt.Sprintf("{{"{{"}}ComputeBasePath{{"}}"}}projects/%s/%s/%s/disks/%s", project, locationType, location, diskName)
+			urlBase := fmt.Sprintf("{{"{{"}}ComputeBasePath{{"}}"}}projects/%s/%s/%s/disks/%s", project, locationType, location, disk.Name)
 
 			if d.HasChange("boot_disk.0.initialize_params.0.size") {
 				obj["sizeGb"] = d.Get("boot_disk.0.initialize_params.0.size").(int)
@@ -3512,7 +3578,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			}
 			if d.HasChange("boot_disk.0.initialize_params.0.labels") {
 				obj["labels"] = tpgresource.ConvertStringMap(d.Get("boot_disk.0.initialize_params.0.labels").(map[string]interface{}))
-				obj["labelFingerprint"] = disk["labelFingerprint"]
+				obj["labelFingerprint"] = disk.LabelFingerprint
 				err := updateDisk(d, config, userAgent, project, urlBase+"/setLabels", obj)
 				if err != nil {
 					return err
@@ -3528,17 +3594,9 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		// can detach disks, it's possible that there are fewer disks currently attached than there
 		// were at the time we ran terraform plan.
 		currDisks := map[string]struct{}{}
-		instanceDisksRaw, _ := instance["disks"].([]interface{})
-		for _, diskRaw := range instanceDisksRaw {
-			disk, ok := diskRaw.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			isBoot, _ := disk["boot"].(bool)
-			diskType, _ := disk["type"].(string)
-			deviceName, _ := disk["deviceName"].(string)
-			if !isBoot && diskType != "SCRATCH" {
-				currDisks[deviceName] = struct{}{}
+		for _, disk := range instance.Disks {
+			if !disk.Boot && disk.Type != "SCRATCH" {
+				currDisks[disk.DeviceName] = struct{}{}
 			}
 		}
 
@@ -3548,17 +3606,16 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		oDisks := map[uint64]string{}
 		for _, disk := range o.([]interface{}) {
 			diskConfig := disk.(map[string]interface{})
-			computeDisk, err := expandAttachedDisk(diskConfig, d, config)
+			computeDisk, err := expandAttachedDiskTyped(diskConfig, d, config)
 			if err != nil {
 				return err
 			}
-			hash, err := hashstructure.Hash(computeDisk, nil)
+			hash, err := hashstructure.Hash(*computeDisk, nil)
 			if err != nil {
 				return err
 			}
-			computeDiskDeviceName, _ := computeDisk["deviceName"].(string)
-			if _, ok := currDisks[computeDiskDeviceName]; ok {
-				oDisks[hash] = computeDiskDeviceName
+			if _, ok := currDisks[computeDisk.DeviceName]; ok {
+				oDisks[hash] = computeDisk.DeviceName
 			}
 		}
 
@@ -3567,21 +3624,26 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		// keep track of the hash of the full disk.
 		// If a disk with a certain hash is only in the new config, it should be attached.
 		nDisks := map[uint64]struct{}{}
-		var attach []map[string]interface{}
+		var attach []*compute.AttachedDisk
 		for _, disk := range n.([]interface{}) {
 			diskConfig := disk.(map[string]interface{})
-			computeDisk, err := expandAttachedDisk(diskConfig, d, config)
+			computeDisk, err := expandAttachedDiskTyped(diskConfig, d, config)
 			if err != nil {
 				return err
 			}
-			hash, err := hashstructure.Hash(computeDisk, nil)
+			hash, err := hashstructure.Hash(*computeDisk, nil)
 			if err != nil {
 				return err
 			}
 			nDisks[hash] = struct{}{}
 
 			if _, ok := oDisks[hash]; !ok {
-				attach = append(attach, computeDisk)
+				computeDiskV1 := &compute.AttachedDisk{}
+				err = tpgresource.Convert(computeDisk, computeDiskV1)
+				if err != nil {
+					return err
+				}
+				attach = append(attach, computeDiskV1)
 			}
 		}
 
@@ -3617,7 +3679,11 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		// Attach the new disks
-		for _, diskBody := range attach {
+		for _, disk := range attach {
+			diskBody, err := tpgresource.ConvertToMap(disk)
+			if err != nil {
+				return fmt.Errorf("Error converting attached disk: %s", err)
+			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/attachDisk")
 			if err != nil {
 				return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
@@ -3638,7 +3704,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if opErr != nil {
 				return opErr
 			}
-			log.Printf("[DEBUG] Successfully attached disk %s", diskBody["source"])
+			log.Printf("[DEBUG] Successfully attached disk %s", disk.Source)
 		}
 	}
 
@@ -3829,7 +3895,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 	// Attributes which can only be changed if the instance is stopped
 	if needToStopInstanceBeforeUpdating {
-		statusBeforeUpdate, _ := instance["status"].(string)
+		statusBeforeUpdate := instance.Status
 		desiredStatus := d.Get("desired_status").(string)
 
 		if statusBeforeUpdate == "RUNNING" && desiredStatus != "TERMINATED" && !d.Get("allow_stopping_for_update").(bool) {
@@ -3862,8 +3928,13 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if d.HasChange("min_cpu_platform") {
-			body := map[string]interface{}{
-				"minCpuPlatform": d.Get("min_cpu_platform").(string),
+			minCpuPlatform := d.Get("min_cpu_platform")
+			req := &compute.InstancesSetMinCpuPlatformRequest{
+				MinCpuPlatform: minCpuPlatform.(string),
+			}
+			body, err := tpgresource.ConvertToMap(req)
+			if err != nil {
+				return fmt.Errorf("Error converting min cpu platform request: %s", err)
 			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setMinCpuPlatform")
 			if err != nil {
@@ -3891,8 +3962,12 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			body := map[string]interface{}{
-				"machineType": mt.RelativeLink(),
+			req := &compute.InstancesSetMachineTypeRequest{
+				MachineType: mt.RelativeLink(),
+			}
+			body, err := tpgresource.ConvertToMap(req)
+			if err != nil {
+				return fmt.Errorf("Error converting machine type request: %s", err)
 			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setMachineType")
 			if err != nil {
@@ -3917,11 +3992,15 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 		if d.HasChange("service_account.0.email") || scopesChange {
 			sa := d.Get("service_account").([]interface{})
-			body := map[string]interface{}{"email": ""}
+			req := &compute.InstancesSetServiceAccountRequest{ForceSendFields: []string{"email"}}
 			if !isEmptyServiceAccountBlock(d) && len(sa) > 0 && sa[0] != nil {
 				saMap := sa[0].(map[string]interface{})
-				body["email"] = saMap["email"].(string)
-				body["scopes"] = tpgresource.CanonicalizeServiceScopes(tpgresource.ConvertStringSet(saMap["scopes"].(*schema.Set)))
+				req.Email = saMap["email"].(string)
+				req.Scopes = tpgresource.CanonicalizeServiceScopes(tpgresource.ConvertStringSet(saMap["scopes"].(*schema.Set)))
+			}
+			body, err := tpgresource.ConvertToMap(req)
+			if err != nil {
+				return fmt.Errorf("Error converting service account request: %s", err)
 			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setServiceAccount")
 			if err != nil {
@@ -3945,8 +4024,13 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if d.HasChange("enable_display") {
-			body := map[string]interface{}{
-				"enableDisplay": d.Get("enable_display").(bool),
+			req := &compute.DisplayDevice{
+				EnableDisplay:   d.Get("enable_display").(bool),
+				ForceSendFields: []string{"EnableDisplay"},
+			}
+			body, err := tpgresource.ConvertToMap(req)
+			if err != nil {
+				return fmt.Errorf("Error converting display device request: %s", err)
 			}
 			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateDisplayDevice")
 			if err != nil {
@@ -4076,7 +4160,9 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			instance = freshInstMap
+			if err := tpgresource.Convert(freshInstMap, instance); err != nil {
+				return fmt.Errorf("Error parsing instance response: %s", err)
+			}
 		}
 		for _, patch := range updatesToNIWhileStopped {
 			instanceMap, err := tpgresource.ConvertToMap(instance)
@@ -4106,7 +4192,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 	{{ if ne $.TargetVersionName `ga` -}}
 	// The access config must be updated only if the machine is still RUNNING and after each access_config for each interface has been re-created.
-	err = computeInstanceAddSecurityPolicy(d, config, securityPolicies, project, zone, userAgent, d.Get("name").(string))
+	err = computeInstanceAddSecurityPolicy(d, config, securityPolicies, project, zone, userAgent, instance.Name)
 	if err != nil {
 		return fmt.Errorf("Error updating instance while setting the security policies: %s", err)
 	}
@@ -4118,7 +4204,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
 		"project": project,
 		"zone":    zone,
-		"name":    instance["name"],
+		"name":    instance.Name,
 	}); err != nil {
 		return err
 	}
@@ -4144,32 +4230,23 @@ func startInstanceOperation(d *schema.ResourceData, config *transport_tpg.Config
 	}
 
 	var encryptedDisks []map[string]interface{}
-	if disksRaw, ok := instanceFromConfig["disks"].([]interface{}); ok {
-		for _, raw := range disksRaw {
-			disk, ok := raw.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			dek, ok := disk["diskEncryptionKey"].(map[string]interface{})
-			if !ok {
-				continue
-			}
+	for _, disk := range instanceFromConfig.Disks {
+		if disk.DiskEncryptionKey != nil {
 			diskKey := map[string]interface{}{}
-			if v, _ := dek["rawKey"].(string); v != "" {
-				diskKey["rawKey"] = v
+			if disk.DiskEncryptionKey.RawKey != "" {
+				diskKey["rawKey"] = disk.DiskEncryptionKey.RawKey
 			}
-			if v, _ := dek["rsaEncryptedKey"].(string); v != "" {
-				diskKey["rsaEncryptedKey"] = v
+			if disk.DiskEncryptionKey.RsaEncryptedKey != "" {
+				diskKey["rsaEncryptedKey"] = disk.DiskEncryptionKey.RsaEncryptedKey
 			}
-			if v, _ := dek["kmsKeyName"].(string); v != "" {
-				diskKey["kmsKeyName"] = v
+			if disk.DiskEncryptionKey.KmsKeyName != "" {
+				diskKey["kmsKeyName"] = disk.DiskEncryptionKey.KmsKeyName
 			}
-			if v, _ := dek["kmsKeyServiceAccount"].(string); v != "" {
-				diskKey["kmsKeyServiceAccount"] = v
+			if disk.DiskEncryptionKey.KmsKeyServiceAccount != "" {
+				diskKey["kmsKeyServiceAccount"] = disk.DiskEncryptionKey.KmsKeyServiceAccount
 			}
-			source, _ := disk["source"].(string)
 			encryptedDisks = append(encryptedDisks, map[string]interface{}{
-				"source":            source,
+				"source":            disk.Source,
 				"diskEncryptionKey": diskKey,
 			})
 		}
@@ -4285,6 +4362,21 @@ func expandAttachedDisk(diskConfig map[string]interface{}, d *schema.ResourceDat
 	return disk, nil
 }
 
+// expandAttachedDiskTyped adapts the map-based expandAttachedDisk output to the
+// typed *compute.AttachedDisk still required by callers that build Apiary
+// request structs directly or read typed fields.
+func expandAttachedDiskTyped(diskConfig map[string]interface{}, d *schema.ResourceData, meta interface{}) (*compute.AttachedDisk, error) {
+	expanded, err := expandAttachedDisk(diskConfig, d, meta)
+	if err != nil {
+		return nil, err
+	}
+	disk := &compute.AttachedDisk{}
+	if err := convertViaJSON(expanded, disk); err != nil {
+		return nil, fmt.Errorf("Error converting attached disk: %s", err)
+	}
+	return disk, nil
+}
+
 // See comment on expandInstanceTemplateGuestAccelerators regarding why this
 // code is duplicated.
 func expandInstanceGuestAccelerators(d tpgresource.TerraformResourceData, config *transport_tpg.Config) ([]interface{}, error) {
@@ -4310,6 +4402,25 @@ func expandInstanceGuestAccelerators(d tpgresource.TerraformResourceData, config
 	}
 
 	return guestAccelerators, nil
+}
+
+// expandInstanceGuestAcceleratorsTyped adapts the map-based
+// expandInstanceGuestAccelerators output to the typed
+// []*compute.AcceleratorConfig still required by callers that build Apiary
+// request structs directly.
+func expandInstanceGuestAcceleratorsTyped(d tpgresource.TerraformResourceData, config *transport_tpg.Config) ([]*compute.AcceleratorConfig, error) {
+	expanded, err := expandInstanceGuestAccelerators(d, config)
+	if err != nil {
+		return nil, err
+	}
+	if expanded == nil {
+		return nil, nil
+	}
+	accels := make([]*compute.AcceleratorConfig, 0, len(expanded))
+	if err := convertViaJSON(expanded, &accels); err != nil {
+		return nil, fmt.Errorf("Error converting guest accelerators: %s", err)
+	}
+	return accels, nil
 }
 
 // suppressEmptyGuestAcceleratorDiff is used to work around perpetual diff
@@ -4513,6 +4624,21 @@ func expandParams(d *schema.ResourceData) (map[string]interface{}, error) {
 	return params, nil
 }
 
+// expandParamsTyped adapts the map-based expandParams output to the typed
+// *compute.InstanceParams still required by callers that build Apiary request
+// structs directly.
+func expandParamsTyped(d *schema.ResourceData) (*compute.InstanceParams, error) {
+	expanded, err := expandParams(d)
+	if err != nil {
+		return nil, err
+	}
+	params := &compute.InstanceParams{}
+	if err := convertViaJSON(expanded, params); err != nil {
+		return nil, fmt.Errorf("Error converting params: %s", err)
+	}
+	return params, nil
+}
+
 func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, project string) (map[string]interface{}, error) {
 	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
@@ -4699,25 +4825,33 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 	return disk, nil
 }
 
-func flattenBootDisk(d *schema.ResourceData, disk map[string]interface{}, config *transport_tpg.Config) []map[string]interface{} {
-	guestOsFeaturesSlice := make([]interface{}, 0)
-	if gof, ok := disk["guestOsFeatures"].([]interface{}); ok {
-		for _, raw := range gof {
-			f, ok := raw.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if t, _ := f["type"].(string); t != "" {
-				guestOsFeaturesSlice = append(guestOsFeaturesSlice, map[string]interface{}{"type": t})
-			}
+// expandBootDiskTyped adapts the map-based expandBootDisk output to the typed
+// *compute.AttachedDisk still required by callers that build Apiary request
+// structs directly.
+func expandBootDiskTyped(d *schema.ResourceData, config *transport_tpg.Config, project string) (*compute.AttachedDisk, error) {
+	expanded, err := expandBootDisk(d, config, project)
+	if err != nil {
+		return nil, err
+	}
+	disk := &compute.AttachedDisk{}
+	if err := convertViaJSON(expanded, disk); err != nil {
+		return nil, fmt.Errorf("Error converting boot disk: %s", err)
+	}
+	return disk, nil
+}
+
+func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config *transport_tpg.Config) []map[string]interface{} {
+	guestOsFeaturesSlice := make([]interface{}, 0, len(disk.GuestOsFeatures))
+	for _, f := range disk.GuestOsFeatures {
+		if f != nil && f.Type != "" {
+			guestOsFeaturesSlice = append(guestOsFeaturesSlice, map[string]interface{}{"type": f.Type})
 		}
 	}
-	diskSource, _ := disk["source"].(string)
 	result := map[string]interface{}{
-		"auto_delete": disk["autoDelete"],
-		"device_name": disk["deviceName"],
-		"mode":        disk["mode"],
-		"source":      tpgresource.ConvertSelfLinkToV1(diskSource),
+		"auto_delete": disk.AutoDelete,
+		"device_name": disk.DeviceName,
+		"mode":        disk.Mode,
+		"source":      tpgresource.ConvertSelfLinkToV1(disk.Source),
 		"guest_os_features":       flattenComputeInstanceGuestOsFeatures(guestOsFeaturesSlice),
 		"force_attach": d.Get("boot_disk.0.force_attach"),
 		// disk_encryption_key_raw is not returned from the API, so copy it from what the user
@@ -4726,20 +4860,18 @@ func flattenBootDisk(d *schema.ResourceData, disk map[string]interface{}, config
 		"disk_encryption_key_rsa": d.Get("boot_disk.0.disk_encryption_key_rsa"),
 	}
         if _,ok := d.GetOk("boot_disk.0.interface"); ok {
-               result["interface"] = disk["interface"]
+               result["interface"] = disk.Interface
         }
 	if v, ok := d.GetOk("boot_disk.0.force_attach"); ok {
 		result["force_attach"] = v.(bool)
 	}
 
-	diskDetails, err := getDisk(diskSource, d, config)
+	diskDetails, err := getDisk(disk.Source, d, config)
 
 	// Resource policies can get autofilled from the API and on this field and this will cause the instance to recreate
 	// This overrides any value set by the API not to cause a diff when the user didn't set this in their config.
-	if diskDetails != nil {
-		if d.Get("boot_disk.0.initialize_params.0.resource_policies.0") == nil || d.Get("boot_disk.0.initialize_params.0.resource_policies") == nil {
-			delete(diskDetails, "resourcePolicies")
-		}
+	if d.Get("boot_disk.0.initialize_params.0.resource_policies.0") == nil || d.Get("boot_disk.0.initialize_params.0.resource_policies") == nil {
+		diskDetails.ResourcePolicies = nil
 	}
 
 	if err != nil {
@@ -4752,45 +4884,35 @@ func flattenBootDisk(d *schema.ResourceData, disk map[string]interface{}, config
 			result["initialize_params"] = m
 		}
 	} else {
-		diskType, _ := diskDetails["type"].(string)
-		storagePool, _ := diskDetails["storagePool"].(string)
-		var replicaZones []string
-		if rz, ok := diskDetails["replicaZones"].([]interface{}); ok {
-			for _, z := range rz {
-				if s, ok := z.(string); ok {
-					replicaZones = append(replicaZones, s)
-				}
-			}
-		}
 		result["initialize_params"] = []map[string]interface{}{{"{{"}}
-			"type": tpgresource.GetResourceNameFromSelfLink(diskType),
+			"type": tpgresource.GetResourceNameFromSelfLink(diskDetails.Type),
 			// If the config specifies a family name that doesn't match the image name, then
 			// the diff won't be properly suppressed. See DiffSuppressFunc for this field.
-			"image":  diskDetails["sourceImage"],
+			"image":  diskDetails.SourceImage,
 			"source_image_encryption_key":    d.Get("boot_disk.0.initialize_params.0.source_image_encryption_key"),
 			"snapshot":                       d.Get("boot_disk.0.initialize_params.0.snapshot"),
 			"source_snapshot_encryption_key": d.Get("boot_disk.0.initialize_params.0.source_snapshot_encryption_key"),
-			"architecture": diskDetails["architecture"],
-			"size":   getInt(diskDetails["sizeGb"]),
-			"labels": diskDetails["labels"],
+			"architecture": diskDetails.Architecture,
+			"size":   diskDetails.SizeGb,
+			"labels": diskDetails.Labels,
 			"resource_manager_tags": d.Get("boot_disk.0.initialize_params.0.resource_manager_tags"),
-			"resource_policies": diskDetails["resourcePolicies"],
-			"provisioned_iops": getInt(diskDetails["provisionedIops"]),
-			"provisioned_throughput": getInt(diskDetails["provisionedThroughput"]),
-			"enable_confidential_compute": diskDetails["enableConfidentialCompute"],
-			"storage_pool": tpgresource.GetResourceNameFromSelfLink(storagePool),
-			"replica_zones": flattenReplicaZones(replicaZones),
+			"resource_policies": diskDetails.ResourcePolicies,
+			"provisioned_iops": diskDetails.ProvisionedIops,
+			"provisioned_throughput": diskDetails.ProvisionedThroughput,
+			"enable_confidential_compute": diskDetails.EnableConfidentialCompute,
+			"storage_pool": tpgresource.GetResourceNameFromSelfLink(diskDetails.StoragePool),
+			"replica_zones": flattenReplicaZones(diskDetails.ReplicaZones),
 		{{"}}"}}
 	}
 
-	if key, ok := disk["diskEncryptionKey"].(map[string]interface{}); ok {
-		if sha256, _ := key["sha256"].(string); sha256 != "" {
-			result["disk_encryption_key_sha256"] = sha256
+	if disk.DiskEncryptionKey != nil {
+		if disk.DiskEncryptionKey.Sha256 != "" {
+			result["disk_encryption_key_sha256"] = disk.DiskEncryptionKey.Sha256
 		}
-		if kmsKeyName, _ := key["kmsKeyName"].(string); kmsKeyName != "" {
+		if disk.DiskEncryptionKey.KmsKeyName != "" {
 			// The response for crypto keys often includes the version of the key which needs to be removed
 			// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
-			result["kms_key_self_link"] = strings.Split(kmsKeyName, "/cryptoKeyVersions")[0]
+			result["kms_key_self_link"] = strings.Split(disk.DiskEncryptionKey.KmsKeyName, "/cryptoKeyVersions")[0]
 		}
 		if v, ok := d.GetOk("boot_disk.0.disk_encryption_service_account"); ok {
 			result["disk_encryption_service_account"] = v.(string)
@@ -4809,29 +4931,41 @@ func expandScratchDisks(d *schema.ResourceData, config *transport_tpg.Config, pr
 	n := d.Get("scratch_disk.#").(int)
 	scratchDisks := make([]interface{}, 0, n)
 	for i := 0; i < n; i++ {
-		scratchDisk := map[string]interface{}{
+		scratchDisks = append(scratchDisks, map[string]interface{}{
 			"autoDelete": true,
 			"type":       "SCRATCH",
 			"deviceName": d.Get(fmt.Sprintf("scratch_disk.%d.device_name", i)).(string),
 			"interface":  d.Get(fmt.Sprintf("scratch_disk.%d.interface", i)).(string),
+			"diskSizeGb": strconv.Itoa(d.Get(fmt.Sprintf("scratch_disk.%d.size", i)).(int)),
 			"initializeParams": map[string]interface{}{
 				"diskType": diskType.RelativeLink(),
 			},
-		}
-		if size := d.Get(fmt.Sprintf("scratch_disk.%d.size", i)).(int); size > 0 {
-			scratchDisk["diskSizeGb"] = strconv.Itoa(size)
-		}
-		scratchDisks = append(scratchDisks, scratchDisk)
+		})
 	}
 
 	return scratchDisks, nil
 }
 
-func flattenScratchDisk(disk map[string]interface{}) map[string]interface{} {
+// expandScratchDisksTyped adapts the map-based expandScratchDisks output to the
+// typed []*compute.AttachedDisk still required by callers that build Apiary
+// request structs directly.
+func expandScratchDisksTyped(d *schema.ResourceData, config *transport_tpg.Config, project string) ([]*compute.AttachedDisk, error) {
+	expanded, err := expandScratchDisks(d, config, project)
+	if err != nil {
+		return nil, err
+	}
+	disks := make([]*compute.AttachedDisk, 0, len(expanded))
+	if err := convertViaJSON(expanded, &disks); err != nil {
+		return nil, fmt.Errorf("Error converting scratch disks: %s", err)
+	}
+	return disks, nil
+}
+
+func flattenScratchDisk(disk *compute.AttachedDisk) map[string]interface{} {
 	result := map[string]interface{}{
-		"device_name": disk["deviceName"],
-		"interface": disk["interface"],
-		"size": getInt(disk["diskSizeGb"]),
+		"device_name": disk.DeviceName,
+		"interface": disk.Interface,
+		"size": disk.DiskSizeGb,
 	}
 	return result
 }
@@ -4967,30 +5101,20 @@ func CheckForCommonAliasIp(old, new map[string]interface{}) []interface{} {
 }
 
 {{ if ne $.TargetVersionName `ga` -}}
-func CheckForCommonAliasIpv6(old, new map[string]interface{}) []interface{} {
+func CheckForCommonAliasIpv6(old, new *compute.NetworkInterface) []*compute.AliasIpRange {
+	return checkForCommonAliasIpRanges(old.AliasIpv6Ranges, new.AliasIpv6Ranges)
+}
+
+func checkForCommonAliasIpRanges(old, new []*compute.AliasIpRange) []*compute.AliasIpRange {
 	newAliasIpMap := make(map[string]bool)
-	if newRanges, ok := new["aliasIpv6Ranges"].([]interface{}); ok {
-		for _, raw := range newRanges {
-			ipRange, ok := raw.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			cidr, _ := ipRange["ipCidrRange"].(string)
-			newAliasIpMap[cidr] = true
-		}
+	for _, ipRange := range new {
+		newAliasIpMap[ipRange.IpCidrRange] = true
 	}
 
-	resultAliasIpRanges := make([]interface{}, 0)
-	if oldRanges, ok := old["aliasIpv6Ranges"].([]interface{}); ok {
-		for _, raw := range oldRanges {
-			ipRange, ok := raw.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			cidr, _ := ipRange["ipCidrRange"].(string)
-			if newAliasIpMap[cidr] {
-				resultAliasIpRanges = append(resultAliasIpRanges, ipRange)
-			}
+	resultAliasIpRanges := make([]*compute.AliasIpRange, 0)
+	for _, val := range old {
+		if newAliasIpMap[val.IpCidrRange] {
+			resultAliasIpRanges = append(resultAliasIpRanges, val)
 		}
 	}
 	return resultAliasIpRanges

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image.go.tmpl
@@ -2,6 +2,7 @@ package compute
 {{- if ne $.TargetVersionName "ga" }}
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -140,7 +141,30 @@ func resourceComputeInstanceFromMachineImageCreate(d *schema.ResourceData, meta 
 		return err
 	}
 
-	instanceBody := instance
+	// Force send all top-level fields that have been set in case they're overridden to zero values.
+	// Initialize ForceSendFields to empty so we don't get things that the instance resource
+	// always force-sends.
+	instance.ForceSendFields = []string{}
+	for f, s := range computeInstanceFromMachineImageSchema() {
+		// It seems that GetOkExists always returns true for sets.
+		// TODO: confirm this and file issue against Terraform core.
+		// In the meantime, don't force send sets.
+		if s.Type == schema.TypeSet {
+			continue
+		}
+
+		if _, exists := d.GetOkExists(f); exists {
+			// Assume for now that all fields are exact snake_case versions of the API fields.
+			// This won't necessarily always be true, but it serves as a good approximation and
+			// can be adjusted later as we discover issues.
+			instance.ForceSendFields = append(instance.ForceSendFields,  tpgresource.SnakeToPascalCase(f))
+		}
+	}
+
+	instanceBody, err := tpgresource.ConvertToMap(instance)
+	if err != nil {
+		return fmt.Errorf("Error converting instance: %s", err)
+	}
 
 	if paramsBody, err := expandParams(d); err != nil {
 		return fmt.Errorf("Error creating params: %s", err)
@@ -220,7 +244,17 @@ func resourceComputeInstanceFromMachineImageCreate(d *schema.ResourceData, meta 
 			return fmt.Errorf("Error expanding scheduling: %s", err)
 		}
 		if schedulingBody != nil {
-			instanceBody["scheduling"] = schedulingOmitEmpty(schedulingBody)
+			// Strip nil Duration fields so the source machine image values are inherited
+			// instead of being overridden with null. Use json.Marshal to detect typed nils
+			// (map[string]interface{}(nil)) that are not equal to untyped nil.
+			for _, k := range []string{"localSsdRecoveryTimeout", "maxRunDuration", "gracefulShutdown", "preemptionNoticeDuration"} {
+				if v, ok := schedulingBody[k]; ok {
+					if b, err := json.Marshal(v); err == nil && string(b) == "null" {
+						delete(schedulingBody, k)
+					}
+				}
+			}
+			instanceBody["scheduling"] = schedulingBody
 		}
 	} else if srcProps, ok := miRes["sourceInstanceProperties"].(map[string]interface{}); ok {
 		if schedulingRaw, ok := srcProps["scheduling"].(map[string]interface{}); ok {
@@ -254,35 +288,6 @@ func resourceComputeInstanceFromMachineImageCreate(d *schema.ResourceData, meta 
 		instanceBody["advancedMachineFeatures"] = amf
 	}
 
-	delete(instanceBody, "canIpForward")
-	delete(instanceBody, "deletionProtection")
-	forceableScalars := map[string]string{
-		"can_ip_forward":             "canIpForward",
-		"deletion_protection":        "deletionProtection",
-		"description":                "description",
-		"hostname":                   "hostname",
-		"machine_type":               "machineType",
-		"min_cpu_platform":           "minCpuPlatform",
-		"name":                       "name",
-		"key_revocation_action_type": "keyRevocationActionType",
-{{- if ne $.TargetVersionName "ga" }}
-		"erase_windows_vss_signature": "eraseWindowsVssSignature",
-{{- end }}
-	}
-	for field, key := range forceableScalars {
-		if _, exists := d.GetOkExists(field); !exists {
-			continue
-		}
-		if _, present := instanceBody[key]; !present {
-			instanceBody[key] = d.Get(field)
-		}
-	}
-	if _, exists := d.GetOkExists("zone"); exists {
-		if _, present := instanceBody["zone"]; !present {
-			instanceBody["zone"] = ""
-		}
-	}
-
 	log.Printf("[INFO] Requesting instance creation")
 	insertURL := fmt.Sprintf("%sprojects/%s/zones/%s/instances", transport_tpg.BaseUrl(Product, config), project, z)
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -298,7 +303,7 @@ func resourceComputeInstanceFromMachineImageCreate(d *schema.ResourceData, meta 
 	}
 
 	// Store the ID now
-	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, d.Get("name").(string)))
+	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
 	err = ComputeOperationWaitTime(config, res, project,
@@ -325,7 +330,7 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 	}
 
 	if _, hasBootDisk := d.GetOk("boot_disk"); hasBootDisk {
-		bootDisk, err := expandBootDisk(d, config, project)
+		bootDisk, err := expandBootDiskTyped(d, config, project)
 		if err != nil {
 			return nil, err
 		}
@@ -353,7 +358,7 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 	}
 
 	if _, hasScratchDisk := d.GetOk("scratch_disk"); hasScratchDisk {
-		scratchDisks, err := expandScratchDisks(d, config, project)
+		scratchDisks, err := expandScratchDisksTyped(d, config, project)
 		if err != nil {
 			return nil, err
 		}
@@ -385,7 +390,7 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 	if attachedDisksCount > 0 {
 		for i := 0; i < attachedDisksCount; i++ {
 			diskConfig := d.Get(fmt.Sprintf("attached_disk.%d", i)).(map[string]interface{})
-			disk, err := expandAttachedDisk(diskConfig, d, config)
+			disk, err := expandAttachedDiskTyped(diskConfig, d, config)
 			if err != nil {
 				return nil, err
 			}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.tmpl
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
@@ -12,6 +13,12 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+{{ if eq $.TargetVersionName `ga` }}
+	"google.golang.org/api/compute/v1"
+{{- else }}
+	compute "google.golang.org/api/compute/v0.beta"
+{{- end }}
 )
 
 func ResourceComputeInstanceFromTemplate() *schema.Resource {
@@ -103,21 +110,10 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 	log.Printf("[DEBUG] Loading zone: %s", z)
-	zoneUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}")
-	if err != nil {
-		return err
-	}
-	zone, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "GET",
-		Project:   project,
-		RawURL:    zoneUrl,
-		UserAgent: userAgent,
-	})
+	zone, err := NewClient(config, userAgent).Zones.Get(project, z).Do()
 	if err != nil {
 		return fmt.Errorf("Error loading zone '%s': %s", z, err)
 	}
-	zoneRegion, _ := zone["region"].(string)
 
 	instance, err := expandComputeInstance(project, d, config)
 	if err != nil {
@@ -129,7 +125,13 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error creating metadata: %s", err)
 	}
 	if len(metadataMap) > 0 {
-		instance["metadata"] = metadataMap
+		metadataBytes, err := json.Marshal(metadataMap)
+		if err != nil {
+			return fmt.Errorf("Error marshaling metadata: %s", err)
+		}
+		if err := json.Unmarshal(metadataBytes, &instance.Metadata); err != nil {
+			return fmt.Errorf("Error setting metadata: %s", err)
+		}
 	}
 {{- if ne $.TargetVersionName "ga" }}
 	partnerMetadataMap, err := resourceInstancePartnerMetadata(d)
@@ -141,8 +143,12 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 		if err != nil {
 			return fmt.Errorf("Error converting partner metadata: %s", err)
 		}
-		if len(partnerMetadataConverted) > 0 {
-			instance["partnerMetadata"] = partnerMetadataConverted
+		partnerMetadataBytes, err := json.Marshal(partnerMetadataConverted)
+		if err != nil {
+			return fmt.Errorf("Error marshaling partner metadata: %s", err)
+		}
+		if err := json.Unmarshal(partnerMetadataBytes, &instance.PartnerMetadata); err != nil {
+			return fmt.Errorf("Error setting partner metadata: %s", err)
 		}
 	}
 {{- end }}
@@ -153,12 +159,19 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
+	it := compute.InstanceTemplate{}
 	var relativeUrl string
-	var templateUrl string
-	isFromRegionalTemplate := !strings.Contains(sourceInstanceTemplate, "global/instanceTemplates")
-	if !isFromRegionalTemplate {
+
+	if strings.Contains(sourceInstanceTemplate, "global/instanceTemplates") {
+		instanceTemplate, err := NewClient(config, userAgent).InstanceTemplates.Get(project, tpl.Name).Do()
+		if err != nil {
+			return err
+		}
+
+		it = *instanceTemplate
 		relativeUrl = tpl.RelativeLink()
-		templateUrl, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/instanceTemplates/" + tpl.Name)
+
+		instance.Disks, err = adjustInstanceFromTemplateDisks(d, config, &it, zone, project, false)
 		if err != nil {
 			return err
 		}
@@ -168,37 +181,45 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 			return err
 		}
 
-		templateUrl, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/regions/{{"{{"}}region{{"}}"}}/instanceTemplates/" + tpl.Name)
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/regions/{{"{{"}}region{{"}}"}}/instanceTemplates/" + tpl.Name)
+		if err != nil {
+			return err
+		}
+
+		instanceTemplate, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config: config,
+			Method: "GET",
+			Project: project,
+			RawURL: url,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return err
+		}
+
+		instancePropertiesObj, err := json.Marshal(instanceTemplate)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		if err := json.Unmarshal(instancePropertiesObj, &it); err != nil {
+			fmt.Println(err)
+			return err
+		}
+
+		instance.Disks, err = adjustInstanceFromTemplateDisks(d, config, &it, zone, project, true)
 		if err != nil {
 			return err
 		}
 	}
 
-	it, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "GET",
-		Project:   project,
-		RawURL:    templateUrl,
-		UserAgent: userAgent,
-	})
-	if err != nil {
-		return err
-	}
-
-	instance["disks"], err = adjustInstanceFromTemplateDisks(d, config, it, z, zoneRegion, project, isFromRegionalTemplate)
-	if err != nil {
-		return err
-	}
-
 	// expandComputeInstance no longer sets Scheduling; handle it here so the user's
 	// scheduling overrides are applied. When no scheduling block is set, inherit from
-	// the instance template. When set, use the map-based result from expandScheduling.
+	// the instance template. When set, convert the map-based result from expandScheduling
+	// into the typed struct required by the API client.
 	if _, hasSchedule := d.GetOk("scheduling"); !hasSchedule {
-		if props, ok := it["properties"].(map[string]interface{}); ok {
-			if sched, ok := props["scheduling"]; ok {
-				instance["scheduling"] = sched
-			}
-		}
+		instance.Scheduling = it.Properties.Scheduling
 	} else {
 		schedulingMap, err := expandScheduling(d.Get("scheduling"))
 		if err != nil {
@@ -218,7 +239,15 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 				}
 			}
 		}
-		instance["scheduling"] = schedulingOmitEmpty(schedulingMap)
+		schedulingBytes, err := json.Marshal(schedulingMap)
+		if err != nil {
+			return fmt.Errorf("Error marshaling scheduling: %s", err)
+		}
+		schedulingTyped := &compute.Scheduling{}
+		if err := json.Unmarshal(schedulingBytes, schedulingTyped); err != nil {
+			return fmt.Errorf("Error setting scheduling: %s", err)
+		}
+		instance.Scheduling = schedulingTyped
 	}
 
 	{{- if ne $.TargetVersionName "ga" }}
@@ -232,66 +261,48 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 			return fmt.Errorf("Error converting partner_metadata: %s", err)
 		}
 		if len(partnerMetadataConverted) > 0 {
-			instance["partnerMetadata"] = partnerMetadataConverted
+			partnerMetadataBytes, err := json.Marshal(partnerMetadataConverted)
+			if err != nil {
+				return fmt.Errorf("Error marshaling partner_metadata: %s", err)
+			}
+			if err := json.Unmarshal(partnerMetadataBytes, &instance.PartnerMetadata); err != nil {
+				return fmt.Errorf("Error setting partner_metadata: %s", err)
+			}
 		}
 	}
 	{{- end }}
 
-	delete(instance, "canIpForward")
-	delete(instance, "deletionProtection")
-	forceableScalars := map[string]string{
-		"can_ip_forward":             "canIpForward",
-		"deletion_protection":        "deletionProtection",
-		"description":                "description",
-		"hostname":                   "hostname",
-		"machine_type":               "machineType",
-		"min_cpu_platform":           "minCpuPlatform",
-		"name":                       "name",
-		"key_revocation_action_type": "keyRevocationActionType",
-{{- if ne $.TargetVersionName "ga" }}
-		"erase_windows_vss_signature": "eraseWindowsVssSignature",
-{{- end }}
-	}
-	for field, key := range forceableScalars {
-		if _, exists := d.GetOkExists(field); !exists {
+	// Force send all top-level fields that have been set in case they're overridden to zero values.
+	// Initialize ForceSendFields to empty so we don't get things that the instance resource
+	// always force-sends.
+	instance.ForceSendFields = []string{}
+	for f, s := range computeInstanceFromTemplateSchema() {
+		// It seems that GetOkExists always returns true for sets.
+		// TODO: confirm this and file issue against Terraform core.
+		// In the meantime, don't force send sets.
+		if s.Type == schema.TypeSet {
 			continue
 		}
-		if _, present := instance[key]; !present {
-			instance[key] = d.Get(field)
-		}
-	}
-	if _, exists := d.GetOkExists("zone"); exists {
-		if _, present := instance["zone"]; !present {
-			instance["zone"] = ""
+
+		if _, exists := d.GetOkExists(f); exists {
+			// Assume for now that all fields are exact snake_case versions of the API fields.
+			// This won't necessarily always be true, but it serves as a good approximation and
+			// can be adjusted later as we discover issues.
+			instance.ForceSendFields = append(instance.ForceSendFields,  tpgresource.SnakeToPascalCase(f))
 		}
 	}
 
 	log.Printf("[INFO] Requesting instance creation")
-	insertUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances")
-	if err != nil {
-		return fmt.Errorf("Error generating URL: %s", err)
-	}
-	insertUrl, err = transport_tpg.AddQueryParams(insertUrl, map[string]string{"sourceInstanceTemplate": relativeUrl})
-	if err != nil {
-		return err
-	}
-	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "POST",
-		Project:   project,
-		RawURL:    insertUrl,
-		UserAgent: userAgent,
-		Body:      instance,
-	})
+	op, err := NewClient(config, userAgent).Instances.Insert(project, zone.Name, instance).SourceInstanceTemplate(relativeUrl).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating instance: %s", err)
 	}
 
 	// Store the ID now
-	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, d.Get("name").(string)))
+	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := ComputeOperationWaitTime(config, res, project,
+	waitErr := ComputeOperationWaitTime(config, op, project,
 		"instance to create", userAgent, d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		// The resource didn't actually create
@@ -304,50 +315,37 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 
 // Instances have disks spread across multiple schema properties. This function
 // ensures that overriding one of these properties does not override the others.
-func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_tpg.Config, it map[string]interface{}, zoneName, zoneRegion, project string, isFromRegionalTemplate bool) ([]interface{}, error) {
-	disks := []interface{}{}
+func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_tpg.Config, it *compute.InstanceTemplate, zone *compute.Zone, project string, isFromRegionalTemplate bool) ([]*compute.AttachedDisk, error) {
+	disks := []*compute.AttachedDisk{}
 	re := regexp.MustCompile(`projects/[^/]+/regions/[^/]+/disks/[^/]+$`)
-
-	var templateDisks []interface{}
-	if props, ok := it["properties"].(map[string]interface{}); ok {
-		if dl, ok := props["disks"].([]interface{}); ok {
-			templateDisks = dl
-		}
-	}
-
 	if _, hasBootDisk := d.GetOk("boot_disk"); hasBootDisk {
-		bootDisk, err := expandBootDisk(d, config, project)
+		bootDisk, err := expandBootDiskTyped(d, config, project)
 		if err != nil {
 			return nil, err
 		}
 		disks = append(disks, bootDisk)
 	} else {
 		// boot disk was not overridden, so use the one from the instance template
-		for _, rawDisk := range templateDisks {
-			disk, ok := rawDisk.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if isBoot, _ := disk["boot"].(bool); isBoot {
-				if source, _ := disk["source"].(string); source != "" && !isFromRegionalTemplate && !re.MatchString(source) {
+		for _, disk := range it.Properties.Disks {
+			if disk.Boot {
+				if disk.Source != "" && !isFromRegionalTemplate && !re.MatchString(disk.Source){
 					// Instances need a URL for the disk, but instance templates only have the name
-					disk["source"] = fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zoneName, source)
+					disk.Source = fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone.Name, disk.Source)
 				}
-				if ip, ok := disk["initializeParams"].(map[string]interface{}); ok {
-					if dt, _ := ip["diskType"].(string); dt != "" {
+				if disk.InitializeParams != nil {
+					if dt := disk.InitializeParams.DiskType; dt != "" {
 						// Instances need a URL for the disk type, but instance templates
 						// only have the name (since they're global).
-						ip["diskType"] = fmt.Sprintf("zones/%s/diskTypes/%s", zoneName, dt)
+						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
 					}
-					if rp, ok := ip["resourcePolicies"].([]interface{}); ok && len(rp) > 0 {
+					if rp := disk.InitializeParams.ResourcePolicies; len(rp) > 0 {
 						// Instances need a URL for the resource policy, but instance templates
 						// only have the name (since they're global).
 						for i := range rp {
-							name, _ := rp[i].(string)
-							name, _ = parseUniqueId(name) // in some cases the API translation doesn't work and returns entire url when only name is provided. And allows for id to be passed as well
-							rp[i] = fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", project, regionFromUrl(zoneRegion), name)
+							rp[i], _ = parseUniqueId(rp[i]) // in some cases the API translation doesn't work and returns entire url when only name is provided. And allows for id to be passed as well
+							rp[i] = fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", project, regionFromUrl(zone.Region), rp[i])
 						}
-						ip["resourcePolicies"] = rp
+						disk.InitializeParams.ResourcePolicies = rp
 					}
 				}
 				disks = append(disks, disk)
@@ -357,24 +355,20 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_t
 	}
 
 	if _, hasScratchDisk := d.GetOk("scratch_disk"); hasScratchDisk {
-		scratchDisks, err := expandScratchDisks(d, config, project)
+		scratchDisks, err := expandScratchDisksTyped(d, config, project)
 		if err != nil {
 			return nil, err
 		}
 		disks = append(disks, scratchDisks...)
 	} else {
 		// scratch disks were not overridden, so use the ones from the instance template
-		for _, rawDisk := range templateDisks {
-			disk, ok := rawDisk.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if dtype, _ := disk["type"].(string); dtype == "SCRATCH" {
-				if ip, ok := disk["initializeParams"].(map[string]interface{}); ok {
-					if dt, _ := ip["diskType"].(string); dt != "" {
+		for _, disk := range it.Properties.Disks {
+			if disk.Type == "SCRATCH" {
+				if disk.InitializeParams != nil {
+					if dt := disk.InitializeParams.DiskType; dt != "" {
 						// Instances need a URL for the disk type, but instance templates
 						// only have the name (since they're global).
-						ip["diskType"] = fmt.Sprintf("zones/%s/diskTypes/%s", zoneName, dt)
+						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
 					}
 				}
 				disks = append(disks, disk)
@@ -386,7 +380,7 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_t
 	if attachedDisksCount > 0 {
 		for i := 0; i < attachedDisksCount; i++ {
 			diskConfig := d.Get(fmt.Sprintf("attached_disk.%d", i)).(map[string]interface{})
-			disk, err := expandAttachedDisk(diskConfig, d, config)
+			disk, err := expandAttachedDiskTyped(diskConfig, d, config)
 			if err != nil {
 				return nil, err
 			}
@@ -395,24 +389,18 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_t
 		}
 	} else {
 		// attached disks were not overridden, so use the ones from the instance template
-		for _, rawDisk := range templateDisks {
-			disk, ok := rawDisk.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			isBoot, _ := disk["boot"].(bool)
-			dtype, _ := disk["type"].(string)
-			if !isBoot && dtype != "SCRATCH" {
-				if source, _ := disk["source"].(string); source != "" && !isFromRegionalTemplate && !re.MatchString(source) {
+		for _, disk := range it.Properties.Disks {
+			if !disk.Boot && disk.Type != "SCRATCH" {
+				if s := disk.Source; s != ""  && !isFromRegionalTemplate && !re.MatchString(disk.Source){
 					// Instances need a URL for the disk source, but instance templates
 					// only have the name (since they're global).
-					disk["source"] = fmt.Sprintf("zones/%s/disks/%s", zoneName, source)
+					disk.Source = fmt.Sprintf("zones/%s/disks/%s", zone.Name, s)
 				}
-				if ip, ok := disk["initializeParams"].(map[string]interface{}); ok {
-					if dt, _ := ip["diskType"].(string); dt != "" {
+				if disk.InitializeParams != nil {
+					if dt := disk.InitializeParams.DiskType; dt != "" {
 						// Instances need a URL for the disk type, but instance templates
 						// only have the name (since they're global).
-						ip["diskType"] = fmt.Sprintf("zones/%s/diskTypes/%s", zoneName, dt)
+						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
 					}
 				}
 				disks = append(disks, disk)


### PR DESCRIPTION
This reverts commit c2f292edbd14afa89a5f43c98a97be7497dcd831.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: migrate resource_compute_instance to REST (revert)
```
