### PR TITLE
deprecate google_beyondcorp_app_* resources and data sources

### DIFF
--- a/mmv1/products/beyondcorp/AppConnection.yaml
+++ b/mmv1/products/beyondcorp/AppConnection.yaml
@@ -19,6 +19,7 @@ references:
     Official Documentation: https://cloud.google.com/beyondcorp-enterprise/docs/enable-app-connector
   api: https://cloud.google.com/beyondcorp/docs/reference/rest#rest-resource:-v1.projects.locations.appconnections
 docs:
+deprecation_message: '`google_beyondcorp_app_connection` is deprecated. App Connector is being deprecated and creation of new App Connectors is no longer permitted. Use `google_beyondcorp_security_gateway` and `google_beyondcorp_security_gateway_application` instead.'
 base_url: projects/{{project}}/locations/{{region}}/appConnections
 self_link: projects/{{project}}/locations/{{region}}/appConnections/{{name}}
 create_url: projects/{{project}}/locations/{{region}}/appConnections?app_connection_id={{name}}

--- a/mmv1/products/beyondcorp/AppConnector.yaml
+++ b/mmv1/products/beyondcorp/AppConnector.yaml
@@ -19,6 +19,7 @@ references:
     Official Documentation: https://cloud.google.com/beyondcorp-enterprise/docs/enable-app-connector
   api: https://cloud.google.com/beyondcorp/docs/reference/rest#rest-resource:-v1.projects.locations.appconnectors
 docs:
+deprecation_message: '`google_beyondcorp_app_connector` is deprecated. App Connector is being deprecated and creation of new App Connectors is no longer permitted. Use `google_beyondcorp_security_gateway` and `google_beyondcorp_security_gateway_application` instead.'
 base_url: projects/{{project}}/locations/{{region}}/appConnectors
 self_link: projects/{{project}}/locations/{{region}}/appConnectors/{{name}}
 create_url: projects/{{project}}/locations/{{region}}/appConnectors?app_connector_id={{name}}

--- a/mmv1/products/beyondcorp/AppGateway.yaml
+++ b/mmv1/products/beyondcorp/AppGateway.yaml
@@ -19,6 +19,7 @@ references:
     Official Documentation: https://cloud.google.com/beyondcorp-enterprise/docs/enable-app-connector
   api: https://cloud.google.com/beyondcorp/docs/reference/rest#rest-resource:-v1.projects.locations.appgateways
 docs:
+deprecation_message: '`google_beyondcorp_app_gateway` is deprecated. App Connector is being deprecated and creation of new App Connectors is no longer permitted. Use `google_beyondcorp_security_gateway` instead.'
 base_url: projects/{{project}}/locations/{{region}}/appGateways
 # This resources is not updatable
 immutable: true

--- a/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_connection.go
+++ b/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_connection.go
@@ -19,8 +19,9 @@ func DataSourceGoogleBeyondcorpAppConnection() *schema.Resource {
 	tpgresource.AddOptionalFieldsToSchema(dsSchema, "region")
 
 	return &schema.Resource{
-		Read:   dataSourceGoogleBeyondcorpAppConnectionRead,
-		Schema: dsSchema,
+		Read:               dataSourceGoogleBeyondcorpAppConnectionRead,
+		Schema:             dsSchema,
+		DeprecationMessage: "`google_beyondcorp_app_connection` is deprecated. App Connector is being deprecated and creation of new App Connectors is no longer permitted. Use `google_beyondcorp_security_gateway` and `google_beyondcorp_security_gateway_application` instead.",
 	}
 }
 

--- a/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_connector.go
+++ b/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_connector.go
@@ -19,8 +19,9 @@ func DataSourceGoogleBeyondcorpAppConnector() *schema.Resource {
 	tpgresource.AddOptionalFieldsToSchema(dsSchema, "region")
 
 	return &schema.Resource{
-		Read:   dataSourceGoogleBeyondcorpAppConnectorRead,
-		Schema: dsSchema,
+		Read:               dataSourceGoogleBeyondcorpAppConnectorRead,
+		Schema:             dsSchema,
+		DeprecationMessage: "`google_beyondcorp_app_connector` is deprecated. App Connector is being deprecated and creation of new App Connectors is no longer permitted. Use `google_beyondcorp_security_gateway` and `google_beyondcorp_security_gateway_application` instead.",
 	}
 }
 

--- a/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_gateway.go
+++ b/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_gateway.go
@@ -19,8 +19,9 @@ func DataSourceGoogleBeyondcorpAppGateway() *schema.Resource {
 	tpgresource.AddOptionalFieldsToSchema(dsSchema, "region")
 
 	return &schema.Resource{
-		Read:   dataSourceGoogleBeyondcorpAppGatewayRead,
-		Schema: dsSchema,
+		Read:               dataSourceGoogleBeyondcorpAppGatewayRead,
+		Schema:             dsSchema,
+		DeprecationMessage: "`google_beyondcorp_app_gateway` is deprecated. App Connector is being deprecated and creation of new App Connectors is no longer permitted. Use `google_beyondcorp_security_gateway` instead.",
 	}
 }
 

--- a/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connection.html.markdown
@@ -6,6 +6,8 @@ description: |-
 
 # google_beyondcorp_app_connection
 
+!> **Warning:** `google_beyondcorp_app_connection` is deprecated. App Connector is being deprecated and creation of new App Connectors is no longer permitted. Use `google_beyondcorp_security_gateway` and `google_beyondcorp_security_gateway_application` instead.
+
 Get information about a Google BeyondCorp App Connection.
 
 ## Example Usage

--- a/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connector.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connector.html.markdown
@@ -6,6 +6,8 @@ description: |-
 
 # google_beyondcorp_app_connector
 
+!> **Warning:** `google_beyondcorp_app_connector` is deprecated. App Connector is being deprecated and creation of new App Connectors is no longer permitted. Use `google_beyondcorp_security_gateway` and `google_beyondcorp_security_gateway_application` instead.
+
 Get information about a Google BeyondCorp App Connector.
 
 ## Example Usage

--- a/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_gateway.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_gateway.html.markdown
@@ -6,6 +6,8 @@ description: |-
 
 # google_beyondcorp_app_gateway
 
+!> **Warning:** `google_beyondcorp_app_gateway` is deprecated. App Connector is being deprecated and creation of new App Connectors is no longer permitted. Use `google_beyondcorp_security_gateway` instead.
+
 Get information about a Google BeyondCorp App Gateway.
 
 ## Example Usage


### PR DESCRIPTION
Deprecate `google_beyondcorp_app_*` resources and data sources (`google_beyondcorp_app_connection`, `google_beyondcorp_app_connector`, `google_beyondcorp_app_gateway`) as App Connector is being deprecated and creation of new App Connectors is no longer permitted.

Reference: https://github.com/hashicorp/terraform-provider-google/issues/27729
Reference: https://github.com/hashicorp/terraform-provider-google/issues/27730

```release-note:deprecation
beyondcorp: deprecated `google_beyondcorp_app_connection`, `google_beyondcorp_app_connector`, and `google_beyondcorp_app_gateway` resources and data sources. Use `google_beyondcorp_security_gateway` and `google_beyondcorp_security_gateway_application` instead.
```