### PR TITLE
remove deprecated interconnect_attachment_group.attachment

### DIFF
--- a/mmv1/products/compute/InterconnectAttachmentGroup.yaml
+++ b/mmv1/products/compute/InterconnectAttachmentGroup.yaml
@@ -171,16 +171,6 @@ properties:
                                   in, in the given facilities.  This is inherited from their
                                   Interconnects.
                                 output: true
-                              - name: 'attachment'
-                                type: Array
-                                description: |
-                                  URLs of Attachments in the given zone, to the given
-                                  region, on Interconnects in the given facility and metro. Every
-                                  Attachment in the AG has such an entry.
-                                output: true
-                                deprecation_message: '`attachment` is deprecated and will be removed in a future major release. Use `attachments` instead.'
-                                item_type:
-                                  type: String
                               - name: 'attachments'
                                 type: Array
                                 description: |

--- a/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
@@ -192,6 +192,12 @@ The default value of `load_balancing_scheme` for `google_compute_global_forwardi
 Configurations that do not set `load_balancing_scheme` will now default to `EXTERNAL_MANAGED` instead of `EXTERNAL`.
 To maintain the previous behavior (Classic Application Load Balancer), set `load_balancing_scheme = "EXTERNAL"` explicitly.
 
+## Resource: `google_compute_interconnect_attachment_group`
+
+### `logical_structure.*.zones.attachment` is now removed
+
+The deprecated `attachment` attribute within `logical_structure.regions.metros.facilities.zones` has been removed. Use `attachments` instead.
+
 ## Resource: `google_compute_service_attachment`
 
 ### `nat_subnets` is now a set


### PR DESCRIPTION
Removes the deprecated `attachment` attribute from `google_compute_interconnect_attachment_group` (replaced by `attachments`).

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27532

```release-note:breaking-change
compute: removed deprecated `attachment` from `google_compute_interconnect_attachment_group`
```