### PR TITLE
Update etag type and output status in AgentGateway.yaml

### DIFF
--- a/mmv1/products/networkservices/AgentGateway.yaml
+++ b/mmv1/products/networkservices/AgentGateway.yaml
@@ -102,7 +102,8 @@ properties:
     description: |
       A free-text description of the resource. Max length 1024 characters.
   - name: etag
-    type: Fingerprint
+    type: String
+    output: true
     description: |
       Etag of the resource.
       If this is provided, it must match the server's etag. If the provided etag


### PR DESCRIPTION
Changed `etag` type from Fingerprint to String and marked it as output for `google_network_services_agent_gateway`.

### Description
In `AgentGateway.yaml`, `etag` was set to `type: Fingerprint`. In MMv1, `Fingerprint` fields are treated as settable during updates even if `output: true` is set. As a result, the generated provider included `etag` in PATCH payloads and `updateMask`.
After an `AgentGateway` is created, backend operations (like certificate provisioning on `agentGatewayCard`) change the server-side ETag. When Terraform later sends an update, sending the stale initial ETag causes the API to reject the PATCH request with `409 ABORTED: Etag mismatch`.
This PR:
1. Changes `etag` to `type: String` with `output: true` in `AgentGateway.yaml`, keeping it as a computed attribute in state while excluding it from update requests and `updateMask`.
2. Adds `etag` to `ImportStateVerifyIgnore` in `resource_network_services_agent_gateway_test.go` so import tests don't fail when the server updates the ETag.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
networkservices: fixed an issue where updating `google_network_services_agent_gateway` failed with `409 ABORTED: Etag mismatch`
```