### PR TITLE
cloudrunv2: support explicitly disabling autoscaling signals with 0.0 via raw config inspection

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -80,6 +80,15 @@ samples:
           concurrency_util: '0.8'
         ignore_read_extra:
           - 'deletion_protection'
+      - name: 'cloudrunv2_service_scaling_controls'
+        min_version: 'beta'
+        resource_id_vars:
+          cloud_run_service_name: 'cloudrun-service'
+        vars:
+          cpu_util: '0.6'
+          concurrency_util: '0'
+        ignore_read_extra:
+          - 'deletion_protection'
   - name: 'cloudrunv2_service_limits'
     primary_resource_id: 'default'
     steps:
@@ -489,6 +498,7 @@ properties:
         description: |
           Scaling settings for this Revision.
         default_from_api: true
+        custom_expand: 'templates/terraform/custom_expand/cloudrunv2_service_template_scaling.go.tmpl'
         properties:
           - name: 'minInstanceCount'
             type: Integer

--- a/mmv1/templates/terraform/custom_expand/cloudrunv2_service_template_scaling.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/cloudrunv2_service_template_scaling.go.tmpl
@@ -40,6 +40,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 		transformed["maxInstanceCount"] = max
 	}
 
+{{- if ne $.ResourceMetadata.TargetVersionName "ga" }}
 {{- if not (contains $.ResourceMetadata.ProductMetadata.Compiler "terraformgoogleconversion") }}
 	if rd, ok := d.(*schema.ResourceData); ok {
 		cpuPath := cty.GetAttrPath("template").IndexInt(0).GetAttr("scaling").IndexInt(0).GetAttr("cpu_utilization")
@@ -58,6 +59,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 	if concurrency, ok := original["concurrency_utilization"].(float64); ok && concurrency > 0 {
 		transformed["concurrencyUtilization"] = concurrency
 	}
+{{- end }}
 {{- end }}
 
 	return transformed, nil

--- a/mmv1/templates/terraform/custom_expand/cloudrunv2_service_template_scaling.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/cloudrunv2_service_template_scaling.go.tmpl
@@ -1,0 +1,64 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google LLC. All Rights Reserved.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+
+// expand{{$.GetPrefix}}{{$.TitlelizeProperty}} uses raw config inspection to support explicitly
+// disabling autoscaling signals by setting `cpu_utilization = 0` or `concurrency_utilization = 0`.
+//
+// In Terraform SDKv2, 0.0 is the zero value for floats and is omitted by default. Conversely,
+// unconfigured float fields default to 0.0 in schema data, which if sent unconditionally triggers
+// Cloud Run API 400 errors ("CPU and concurrency scaling cannot both be disabled").
+// Using GetRawConfigAt ensures 0.0 is only included in the payload when explicitly specified in HCL.
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	if min, ok := original["min_instance_count"].(int); ok && min > 0 {
+		transformed["minInstanceCount"] = min
+	}
+	if max, ok := original["max_instance_count"].(int); ok && max > 0 {
+		transformed["maxInstanceCount"] = max
+	}
+
+{{- if not (contains $.ResourceMetadata.ProductMetadata.Compiler "terraformgoogleconversion") }}
+	if rd, ok := d.(*schema.ResourceData); ok {
+		cpuPath := cty.GetAttrPath("template").IndexInt(0).GetAttr("scaling").IndexInt(0).GetAttr("cpu_utilization")
+		if val, _ := rd.GetRawConfigAt(cpuPath); !val.IsNull() && val.IsKnown() {
+			transformed["cpuUtilization"] = original["cpu_utilization"]
+		}
+		concurrencyPath := cty.GetAttrPath("template").IndexInt(0).GetAttr("scaling").IndexInt(0).GetAttr("concurrency_utilization")
+		if val, _ := rd.GetRawConfigAt(concurrencyPath); !val.IsNull() && val.IsKnown() {
+			transformed["concurrencyUtilization"] = original["concurrency_utilization"]
+		}
+	}
+{{- else }}
+	if cpu, ok := original["cpu_utilization"].(float64); ok && cpu > 0 {
+		transformed["cpuUtilization"] = cpu
+	}
+	if concurrency, ok := original["concurrency_utilization"].(float64); ok && concurrency > 0 {
+		transformed["concurrencyUtilization"] = concurrency
+	}
+{{- end }}
+
+	return transformed, nil
+}


### PR DESCRIPTION
### Description
In Terraform SDKv2, `0.0` is the zero value for float fields and is omitted by default during serialization. Conversely, unconfigured float fields default to `0.0` in schema data, which if sent unconditionally triggers Cloud Run API 400 errors (`"CPU and concurrency scaling cannot both be disabled"`).

This PR adds a custom expander with raw HCL configuration inspection (`rd.GetRawConfigAt(...)`) to ensure that `0.0` is sent to the Cloud Run API if and only if explicitly specified by the user (allowing explicit disabling of `cpu_utilization` or `concurrency_utilization`).

```release-note:enhancement
cloudrunv2: supported explicitly disabling `cpu_utilization` and `concurrency_utilization` autoscaling thresholds with `0.0` in `google_cloud_run_v2_service`
```