### PR TITLE
cloudquotas: allow ignoring multiple quota safety checks at once 

### DIFF
--- a/mmv1/products/cloudquotas/QuotaPreference.yaml
+++ b/mmv1/products/cloudquotas/QuotaPreference.yaml
@@ -23,8 +23,8 @@ docs:
 id_format: '{{parent}}/locations/global/quotaPreferences/{{name}}'
 base_url: '{{parent}}/locations/global/quotaPreferences'
 self_link: '{{parent}}/locations/global/quotaPreferences/{{name}}'
-create_url: '{{parent}}/locations/global/quotaPreferences?quotaPreferenceId={{name}}&ignoreSafetyChecks={{ignore_safety_checks}}'
-update_url: '{{parent}}/locations/global/quotaPreferences/{{name}}?ignoreSafetyChecks={{ignore_safety_checks}}'
+create_url: '{{parent}}/locations/global/quotaPreferences?quotaPreferenceId={{name}}'
+update_url: '{{parent}}/locations/global/quotaPreferences/{{name}}'
 update_verb: 'PATCH'
 update_mask: true
 exclude_delete: true
@@ -37,6 +37,8 @@ timeouts:
 include_in_tgc_next: true
 custom_code:
   constants: 'templates/terraform/constants/google_cloud_quotas_quota_preference.go.tmpl'
+  pre_create: 'templates/terraform/pre_create/google_cloud_quotas_quota_preference.go.tmpl'
+  pre_update: 'templates/terraform/pre_update/google_cloud_quotas_quota_preference.go.tmpl'
 samples:
   - name: 'cloudquotas_quota_preference_basic'
     primary_resource_id: 'preference'

--- a/mmv1/products/cloudquotas/QuotaPreference.yaml
+++ b/mmv1/products/cloudquotas/QuotaPreference.yaml
@@ -39,6 +39,8 @@ custom_code:
   constants: 'templates/terraform/constants/google_cloud_quotas_quota_preference.go.tmpl'
   pre_create: 'templates/terraform/pre_create/google_cloud_quotas_quota_preference.go.tmpl'
   pre_update: 'templates/terraform/pre_update/google_cloud_quotas_quota_preference.go.tmpl'
+custom_diff:
+  - 'quotaPreferenceSafetyChecksConflictDiff'
 samples:
   - name: 'cloudquotas_quota_preference_basic'
     primary_resource_id: 'preference'
@@ -59,13 +61,25 @@ parameters:
     default_from_api: true
   - name: 'ignore_safety_checks'
     type: Enum
-    description: The list of quota safety checks to be ignored.
+    description: The quota safety check to be ignored. Cannot be used with `ignore_safety_checks_set`.
     url_param_only: true
     default_value: "QUOTA_SAFETY_CHECK_UNSPECIFIED"
+    deprecation_message: '`ignore_safety_checks` is deprecated and will be removed in a future major release. Use `ignore_safety_checks_set` instead, which supports ignoring multiple safety checks at once.'
     enum_values:
       - 'QUOTA_SAFETY_CHECK_UNSPECIFIED'
       - 'QUOTA_DECREASE_BELOW_USAGE'
       - 'QUOTA_DECREASE_PERCENTAGE_TOO_HIGH'
+  - name: 'ignore_safety_checks_set'
+    type: Array
+    description: The set of quota safety checks to be ignored. Cannot be used with `ignore_safety_checks`.
+    url_param_only: true
+    is_set: true
+    item_type:
+      type: Enum
+      description: A quota safety check to be ignored.
+      enum_values:
+        - 'QUOTA_DECREASE_BELOW_USAGE'
+        - 'QUOTA_DECREASE_PERCENTAGE_TOO_HIGH'
 properties:
   - name: 'name'
     type: String

--- a/mmv1/templates/terraform/constants/google_cloud_quotas_quota_preference.go.tmpl
+++ b/mmv1/templates/terraform/constants/google_cloud_quotas_quota_preference.go.tmpl
@@ -6,3 +6,18 @@ func QuotaPreferredValueDiffSuppress(k, old, new string, d *schema.ResourceData)
 	
 	return (oldEmpty && n == "0") || (o == "0" && newEmpty)
 }
+
+// ignore_safety_checks and ignore_safety_checks_set both map to the same
+// ignoreSafetyChecks query parameter and cannot be combined. ConflictsWith
+// is not generated for url_param_only parameters, so the conflict is
+// enforced here at plan time instead.
+func quotaPreferenceSafetyChecksConflictDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	rawConfig := diff.GetRawConfig()
+	if rawConfig.IsNull() {
+		return nil
+	}
+	if !rawConfig.GetAttr("ignore_safety_checks").IsNull() && !rawConfig.GetAttr("ignore_safety_checks_set").IsNull() {
+		return fmt.Errorf("\"ignore_safety_checks\": conflicts with ignore_safety_checks_set")
+	}
+	return nil
+}

--- a/mmv1/templates/terraform/pre_create/google_cloud_quotas_quota_preference.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/google_cloud_quotas_quota_preference.go.tmpl
@@ -1,0 +1,6 @@
+if v, ok := d.GetOk("ignore_safety_checks"); ok && v.(string) != "QUOTA_SAFETY_CHECK_UNSPECIFIED" {
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"ignoreSafetyChecks": v.(string)})
+	if err != nil {
+		return err
+	}
+}

--- a/mmv1/templates/terraform/pre_create/google_cloud_quotas_quota_preference.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/google_cloud_quotas_quota_preference.go.tmpl
@@ -3,4 +3,9 @@ if v, ok := d.GetOk("ignore_safety_checks"); ok && v.(string) != "QUOTA_SAFETY_C
 	if err != nil {
 		return err
 	}
+} else if v, ok := d.GetOk("ignore_safety_checks_set"); ok {
+	url, err = transport_tpg.AddArrayQueryParams(url, "ignoreSafetyChecks", v.(*schema.Set).List())
+	if err != nil {
+		return err
+	}
 }

--- a/mmv1/templates/terraform/pre_update/google_cloud_quotas_quota_preference.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/google_cloud_quotas_quota_preference.go.tmpl
@@ -1,0 +1,6 @@
+if v, ok := d.GetOk("ignore_safety_checks"); ok && v.(string) != "QUOTA_SAFETY_CHECK_UNSPECIFIED" {
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"ignoreSafetyChecks": v.(string)})
+	if err != nil {
+		return err
+	}
+}

--- a/mmv1/templates/terraform/pre_update/google_cloud_quotas_quota_preference.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/google_cloud_quotas_quota_preference.go.tmpl
@@ -3,4 +3,9 @@ if v, ok := d.GetOk("ignore_safety_checks"); ok && v.(string) != "QUOTA_SAFETY_C
 	if err != nil {
 		return err
 	}
+} else if v, ok := d.GetOk("ignore_safety_checks_set"); ok {
+	url, err = transport_tpg.AddArrayQueryParams(url, "ignoreSafetyChecks", v.(*schema.Set).List())
+	if err != nil {
+		return err
+	}
 }

--- a/mmv1/third_party/terraform/services/cloudquotas/resource_cloud_quotas_quota_preference_test.go
+++ b/mmv1/third_party/terraform/services/cloudquotas/resource_cloud_quotas_quota_preference_test.go
@@ -52,7 +52,7 @@ func TestAccCloudQuotasQuotaPreference_cloudquotasQuotaPreferenceBasicExample_up
 				ResourceName:            "google_cloud_quotas_quota_preference.my_preference",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"parent", "quota_preference_id", "ignore_safety_checks", "contact_email", "justification", "quota_config.0.annotations"},
+				ImportStateVerifyIgnore: []string{"parent", "quota_preference_id", "ignore_safety_checks", "ignore_safety_checks_set", "contact_email", "justification", "quota_config.0.annotations"},
 			},
 		},
 	})
@@ -175,11 +175,11 @@ func testAccCloudQuotasQuotaPreference_cloudquotasQuotaPreferenceBasicExample_de
 		}
 
 		resource "google_cloud_quotas_quota_preference" "my_preference"{
-			ignore_safety_checks = "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"
+			ignore_safety_checks_set = ["QUOTA_DECREASE_BELOW_USAGE", "QUOTA_DECREASE_PERCENTAGE_TOO_HIGH"]
 			quota_config  {
 				preferred_value  = 65
 			}
-			depends_on           = [google_project_service.billing]
+			depends_on            = [google_project_service.billing]
 		}
 	`, context)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/19276
Fixes https://github.com/hashicorp/terraform-provider-google/issues/25454

The API declares `ignoreSafetyChecks` as a repeated enum query parameter, but the provider models it as a single string. When a quota change trips both `QUOTA_DECREASE_BELOW_USAGE` and `QUOTA_DECREASE_PERCENTAGE_TOO_HIGH` (for example lowering a quota to 0 while there is recent usage), no single value is sufficient and the change cannot be applied with Terraform at all.

Two commits:

1. **Prerequisite refactor (no behavior change):** build the `ignoreSafetyChecks` query parameter in `pre_create`/`pre_update` instead of interpolating it in the URLs. URL templating cannot express a repeated parameter, and it must be built in exactly one place: otherwise the URL-injected default would be sent alongside the new values.
2. **Feature:** add `ignore_safety_checks_set`, sent as a repeated parameter via `transport_tpg.AddArrayQueryParams` (same mechanism as `aspectKeys` in `dataplex_entry`); deprecate `ignore_safety_checks`; update the acceptance test so the quota decrease exercises both checks at once.

Reviewer notes: the mutual exclusion uses a `CustomizeDiff` because `conflicts` is silently dropped for `url_param_only` parameters (`GetPropertySchemaPath` only resolves against properties). The new enum omits `QUOTA_SAFETY_CHECK_UNSPECIFIED` per the field-reference guidance, and I am open to a different field name.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudquotas: added `ignore_safety_checks_set` field to `google_cloud_quotas_quota_preference` resource, allowing multiple quota safety checks to be ignored at once
```

```release-note:deprecation
cloudquotas: deprecated `ignore_safety_checks` field on `google_cloud_quotas_quota_preference` resource. Use `ignore_safety_checks_set` instead.
```
