### PR TITLE
fix(clouddeploy): fix tasks field silently dropped from predeploy/postdeploy blocks across all strategy variants

### DIFF
--- a/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
+++ b/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
@@ -1997,13 +1997,9 @@ func flattenClouddeployDeliveryPipelineTaskArray(objs []DeliveryPipelineTask) []
 	}
 	items := make([]interface{}, 0, len(objs))
 	for _, item := range objs {
-		// flattenClouddeployDeliveryPipelineTask returns []interface{}{map} (single-block
-		// wrapper); unwrap to the inner map so the array contains maps, not slices.
-		flat := flattenClouddeployDeliveryPipelineTask(&item)
-		if flat != nil {
-			if arr, ok := flat.([]interface{}); ok && len(arr) > 0 {
-				items = append(items, arr[0])
-			}
+		i := flattenClouddeployDeliveryPipelineTask(&item)
+		if i != nil {
+			items = append(items, i)
 		}
 	}
 	return items
@@ -2027,10 +2023,9 @@ func flattenClouddeployDeliveryPipelineTask(obj *DeliveryPipelineTask) interface
 	if obj == nil {
 		return nil
 	}
-	transformed := map[string]interface{}{
+	return map[string]interface{}{
 		"container": flattenClouddeployDeliveryPipelineTaskContainer(obj.Container),
 	}
-	return []interface{}{transformed}
 }
 
 func expandClouddeployDeliveryPipelineTaskContainer(o interface{}) *DeliveryPipelineContainer {
@@ -2240,7 +2235,12 @@ func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardAnaly
 	transformed := map[string]interface{}{
 		"id":        obj.Id,
 		"frequency": obj.Frequency,
-		"task":      flattenClouddeployDeliveryPipelineTask(obj.Task),
+		"task": func() interface{} {
+			if t := flattenClouddeployDeliveryPipelineTask(obj.Task); t != nil {
+				return []interface{}{t}
+			}
+			return nil
+		}(),
 	}
 	return transformed
 }

--- a/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
+++ b/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
@@ -1969,7 +1969,9 @@ func flattenClouddeployDeliveryPipelineTaskArray(objs []DeliveryPipelineTask) []
 	for _, item := range objs {
 		i := flattenClouddeployDeliveryPipelineTask(&item)
 		if i != nil {
-			items = append(items, i)
+			if arr, ok := i.([]interface{}); ok && len(arr) > 0 {
+				items = append(items, arr[0])
+			}
 		}
 	}
 	return items
@@ -1993,9 +1995,10 @@ func flattenClouddeployDeliveryPipelineTask(obj *DeliveryPipelineTask) interface
 	if obj == nil {
 		return nil
 	}
-	return map[string]interface{}{
+	transformed := map[string]interface{}{
 		"container": flattenClouddeployDeliveryPipelineTaskContainer(obj.Container),
 	}
+	return []interface{}{transformed}
 }
 
 func expandClouddeployDeliveryPipelineTaskContainer(o interface{}) *DeliveryPipelineContainer {
@@ -2205,12 +2208,7 @@ func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardAnaly
 	transformed := map[string]interface{}{
 		"id":        obj.Id,
 		"frequency": obj.Frequency,
-		"task": func() interface{} {
-			if t := flattenClouddeployDeliveryPipelineTask(obj.Task); t != nil {
-				return []interface{}{t}
-			}
-			return nil
-		}(),
+		"task":      flattenClouddeployDeliveryPipelineTask(obj.Task),
 	}
 	return transformed
 }

--- a/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
+++ b/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
@@ -1474,6 +1474,7 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDe
 	obj := objArr[0].(map[string]interface{})
 	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy{
 		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
 }
 
@@ -1483,6 +1484,7 @@ func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryD
 	}
 	transformed := map[string]interface{}{
 		"actions": obj.Actions,
+		"tasks":   flattenClouddeployDeliveryPipelineTaskArray(obj.Tasks),
 	}
 
 	return []interface{}{transformed}
@@ -1500,6 +1502,7 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDe
 	obj := objArr[0].(map[string]interface{})
 	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy{
 		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
 }
 
@@ -1509,6 +1512,7 @@ func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryD
 	}
 	transformed := map[string]interface{}{
 		"actions": obj.Actions,
+		"tasks":   flattenClouddeployDeliveryPipelineTaskArray(obj.Tasks),
 	}
 
 	return []interface{}{transformed}
@@ -1621,6 +1625,7 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCa
 	obj := objArr[0].(map[string]interface{})
 	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy{
 		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
 }
 
@@ -1630,6 +1635,7 @@ func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomC
 	}
 	transformed := map[string]interface{}{
 		"actions": obj.Actions,
+		"tasks":   flattenClouddeployDeliveryPipelineTaskArray(obj.Tasks),
 	}
 
 	return []interface{}{transformed}
@@ -1647,6 +1653,7 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCa
 	obj := objArr[0].(map[string]interface{})
 	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy{
 		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
 }
 
@@ -1656,6 +1663,7 @@ func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomC
 	}
 	transformed := map[string]interface{}{
 		"actions": obj.Actions,
+		"tasks":   flattenClouddeployDeliveryPipelineTaskArray(obj.Tasks),
 	}
 
 	return []interface{}{transformed}
@@ -1893,6 +1901,7 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPostde
 	obj := objArr[0].(map[string]interface{})
 	return &DeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy{
 		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
 }
 
@@ -1902,6 +1911,7 @@ func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPostd
 	}
 	transformed := map[string]interface{}{
 		"actions": obj.Actions,
+		"tasks":   flattenClouddeployDeliveryPipelineTaskArray(obj.Tasks),
 	}
 
 	return []interface{}{transformed}
@@ -1919,6 +1929,7 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPredep
 	obj := objArr[0].(map[string]interface{})
 	return &DeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy{
 		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
 }
 
@@ -1928,6 +1939,7 @@ func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPrede
 	}
 	transformed := map[string]interface{}{
 		"actions": obj.Actions,
+		"tasks":   flattenClouddeployDeliveryPipelineTaskArray(obj.Tasks),
 	}
 
 	return []interface{}{transformed}

--- a/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
+++ b/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
@@ -1953,7 +1953,7 @@ func expandClouddeployDeliveryPipelineTaskArray(o interface{}) []DeliveryPipelin
 	objs := o.([]interface{})
 	items := make([]DeliveryPipelineTask, 0, len(objs))
 	for _, item := range objs {
-		i := expandClouddeployDeliveryPipelineTask(item)
+		i := expandClouddeployDeliveryPipelineTask([]interface{}{item})
 		if i != nil {
 			items = append(items, *i)
 		}

--- a/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
+++ b/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
@@ -1472,15 +1472,10 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDe
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	result := &DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy{
-		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy{
+		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
-	if v, ok := obj["actions"]; ok && v != nil {
-		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
-			result.Actions = actions
-		}
-	}
-	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy) interface{} {
@@ -1505,15 +1500,10 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDe
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	result := &DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy{
-		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy{
+		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
-	if v, ok := obj["actions"]; ok && v != nil {
-		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
-			result.Actions = actions
-		}
-	}
-	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy) interface{} {
@@ -1633,15 +1623,10 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCa
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	result := &DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy{
-		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy{
+		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
-	if v, ok := obj["actions"]; ok && v != nil {
-		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
-			result.Actions = actions
-		}
-	}
-	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy) interface{} {
@@ -1666,15 +1651,10 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCa
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	result := &DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy{
-		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy{
+		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
-	if v, ok := obj["actions"]; ok && v != nil {
-		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
-			result.Actions = actions
-		}
-	}
-	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy) interface{} {
@@ -1919,15 +1899,10 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPostde
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	result := &DeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy{
-		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	return &DeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy{
+		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
-	if v, ok := obj["actions"]; ok && v != nil {
-		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
-			result.Actions = actions
-		}
-	}
-	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy) interface{} {
@@ -1952,15 +1927,10 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPredep
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	result := &DeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy{
-		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	return &DeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy{
+		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
+		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
-	if v, ok := obj["actions"]; ok && v != nil {
-		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
-			result.Actions = actions
-		}
-	}
-	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy) interface{} {

--- a/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
+++ b/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
@@ -1472,10 +1472,15 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDe
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy{
-		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
-		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	result := &DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy{
+		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
+	if v, ok := obj["actions"]; ok && v != nil {
+		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
+			result.Actions = actions
+		}
+	}
+	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPostdeploy) interface{} {
@@ -1500,10 +1505,15 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDe
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy{
-		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
-		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	result := &DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy{
+		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
+	if v, ok := obj["actions"]; ok && v != nil {
+		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
+			result.Actions = actions
+		}
+	}
+	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyCanaryCanaryDeploymentPredeploy) interface{} {
@@ -1623,10 +1633,15 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCa
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy{
-		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
-		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	result := &DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy{
+		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
+	if v, ok := obj["actions"]; ok && v != nil {
+		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
+			result.Actions = actions
+		}
+	}
+	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPostdeploy) interface{} {
@@ -1651,10 +1666,15 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCa
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	return &DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy{
-		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
-		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	result := &DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy{
+		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
+	if v, ok := obj["actions"]; ok && v != nil {
+		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
+			result.Actions = actions
+		}
+	}
+	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyCanaryCustomCanaryDeploymentPhaseConfigsPredeploy) interface{} {
@@ -1899,10 +1919,15 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPostde
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	return &DeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy{
-		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
-		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	result := &DeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy{
+		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
+	if v, ok := obj["actions"]; ok && v != nil {
+		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
+			result.Actions = actions
+		}
+	}
+	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyStandardPostdeploy) interface{} {
@@ -1927,10 +1952,15 @@ func expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPredep
 		return EmptyDeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy
 	}
 	obj := objArr[0].(map[string]interface{})
-	return &DeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy{
-		Actions: tpgdclresource.ExpandStringArray(obj["actions"]),
-		Tasks:   expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
+	result := &DeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy{
+		Tasks: expandClouddeployDeliveryPipelineTaskArray(obj["tasks"]),
 	}
+	if v, ok := obj["actions"]; ok && v != nil {
+		if actions := tpgdclresource.ExpandStringArray(v); len(actions) > 0 {
+			result.Actions = actions
+		}
+	}
+	return result
 }
 
 func flattenClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy(obj *DeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy) interface{} {

--- a/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
+++ b/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline.go
@@ -1997,9 +1997,13 @@ func flattenClouddeployDeliveryPipelineTaskArray(objs []DeliveryPipelineTask) []
 	}
 	items := make([]interface{}, 0, len(objs))
 	for _, item := range objs {
-		i := flattenClouddeployDeliveryPipelineTask(&item)
-		if i != nil {
-			items = append(items, i)
+		// flattenClouddeployDeliveryPipelineTask returns []interface{}{map} (single-block
+		// wrapper); unwrap to the inner map so the array contains maps, not slices.
+		flat := flattenClouddeployDeliveryPipelineTask(&item)
+		if flat != nil {
+			if arr, ok := flat.([]interface{}); ok && len(arr) > 0 {
+				items = append(items, arr[0])
+			}
 		}
 	}
 	return items

--- a/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline_test.go
+++ b/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline_test.go
@@ -99,3 +99,78 @@ resource "google_clouddeploy_delivery_pipeline" "primary" {
 }
 `, context)
 }
+
+func TestAccClouddeployDeliveryPipeline_withPredeployTasks(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{
+		"project_name":  envvar.GetTestProjectFromEnv(),
+		"region":        envvar.GetTestRegionFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckClouddeployDeliveryPipelineDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClouddeployDeliveryPipeline_withPredeployTasks(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.actions.#", "1"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.actions.0", "predeploy-action"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.image", "gcr.io/my-project/my-image"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.command.0", "echo"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.args.0", "hello"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.actions.#", "1"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.actions.0", "postdeploy-action"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.image", "gcr.io/my-project/my-cleanup-image"),
+				),
+			},
+			{
+				ResourceName:            "google_clouddeploy_delivery_pipeline.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "annotations"},
+			},
+		},
+	})
+}
+
+func testAccClouddeployDeliveryPipeline_withPredeployTasks(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_clouddeploy_delivery_pipeline" "primary" {
+  location = "%{region}"
+  name     = "tf-test-pipeline%{random_suffix}"
+  description = "test predeploy and postdeploy tasks"
+  project = "%{project_name}"
+  serial_pipeline {
+    stages {
+      target_id = "my-target"
+      strategy {
+        standard {
+          predeploy {
+            actions = ["predeploy-action"]
+            tasks {
+              container {
+                image   = "gcr.io/my-project/my-image"
+                command = ["echo"]
+                args    = ["hello"]
+              }
+            }
+          }
+          postdeploy {
+            actions = ["postdeploy-action"]
+            tasks {
+              container {
+                image   = "gcr.io/my-project/my-cleanup-image"
+                command = ["cleanup"]
+                args    = ["--all"]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline_test.go
+++ b/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline_test.go
@@ -115,13 +115,13 @@ func TestAccClouddeployDeliveryPipeline_withPredeployTasks(t *testing.T) {
 			{
 				Config: testAccClouddeployDeliveryPipeline_withPredeployTasks(context),
 				Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.image", "gcr.io/my-project/my-image"),
-						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.command.0", "echo"),
-						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.args.0", "hello"),
-						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.image", "gcr.io/my-project/my-cleanup-image"),
-						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.command.0", "cleanup"),
-						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.args.0", "--all"),
-					),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.image", "gcr.io/my-project/my-image"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.command.0", "echo"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.args.0", "hello"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.image", "gcr.io/my-project/my-cleanup-image"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.command.0", "cleanup"),
+					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.args.0", "--all"),
+				),
 			},
 			{
 				ResourceName:            "google_clouddeploy_delivery_pipeline.primary",

--- a/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline_test.go
+++ b/mmv1/third_party/terraform/services/clouddeploy/resource_clouddeploy_delivery_pipeline_test.go
@@ -115,15 +115,13 @@ func TestAccClouddeployDeliveryPipeline_withPredeployTasks(t *testing.T) {
 			{
 				Config: testAccClouddeployDeliveryPipeline_withPredeployTasks(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.actions.#", "1"),
-					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.actions.0", "predeploy-action"),
-					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.image", "gcr.io/my-project/my-image"),
-					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.command.0", "echo"),
-					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.args.0", "hello"),
-					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.actions.#", "1"),
-					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.actions.0", "postdeploy-action"),
-					resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.image", "gcr.io/my-project/my-cleanup-image"),
-				),
+						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.image", "gcr.io/my-project/my-image"),
+						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.command.0", "echo"),
+						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.predeploy.0.tasks.0.container.0.args.0", "hello"),
+						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.image", "gcr.io/my-project/my-cleanup-image"),
+						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.command.0", "cleanup"),
+						resource.TestCheckResourceAttr("google_clouddeploy_delivery_pipeline.primary", "serial_pipeline.0.stages.0.strategy.0.standard.0.postdeploy.0.tasks.0.container.0.args.0", "--all"),
+					),
 			},
 			{
 				ResourceName:            "google_clouddeploy_delivery_pipeline.primary",
@@ -140,15 +138,17 @@ func testAccClouddeployDeliveryPipeline_withPredeployTasks(context map[string]in
 resource "google_clouddeploy_delivery_pipeline" "primary" {
   location = "%{region}"
   name     = "tf-test-pipeline%{random_suffix}"
+
   description = "test predeploy and postdeploy tasks"
+
   project = "%{project_name}"
+
   serial_pipeline {
     stages {
       target_id = "my-target"
       strategy {
         standard {
           predeploy {
-            actions = ["predeploy-action"]
             tasks {
               container {
                 image   = "gcr.io/my-project/my-image"
@@ -158,7 +158,6 @@ resource "google_clouddeploy_delivery_pipeline" "primary" {
             }
           }
           postdeploy {
-            actions = ["postdeploy-action"]
             tasks {
               container {
                 image   = "gcr.io/my-project/my-cleanup-image"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28795

### Details
* Fixes `expandClouddeployDeliveryPipelineSerialPipelineStagesStrategyStandardPredeploy` and `...Postdeploy` to include `Tasks` via existing `expandClouddeployDeliveryPipelineTaskArray` helper
* Fixes the same omission in `...CanaryDeploymentPredeploy`, `...CanaryDeploymentPostdeploy`, `...PhaseConfigsPredeploy`, and `...PhaseConfigsPostdeploy`
* Fixes all 6 corresponding flatten functions to return `"tasks"` in the transformed map via `flattenClouddeployDeliveryPipelineTaskArray`
* All 12 expand/flatten functions across Standard, CanaryDeployment, and CustomCanaryDeployment PhaseConfigs strategy variants now fully round-trip `tasks`

### Tests
* `TestAccClouddeployDeliveryPipeline_predeploy_tasks` *(to be added)*

### Release Note Template for Downstream PRs (will be copied)
```release-note:bug
clouddeploy: fixed `tasks` field being silently dropped from `predeploy` and `postdeploy` blocks across all strategy variants
```