### PR TITLE
Make consumer_reject_lists and nat_subnets sets instead of lists on goole_compute_service_attachment

### DIFF
--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -245,8 +245,10 @@ properties:
     type: Array
     description: |
       An array of subnets that is provided for NAT in this service attachment.
+    is_set: true
     required: true
     send_empty_value: true
+    set_hash_func: 'tpgresource.SelfLinkRelativePathHash'
     custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.tmpl'
     item_type:
       name: 'subnet'
@@ -293,6 +295,7 @@ properties:
     description: |
       An array of projects that are not allowed to connect to this service
       attachment.
+    is_set: true
     send_empty_value: true
     is_missing_in_cai: true # Ignored in TGC tests due to timing issues in CAI updates where the field disappears in intermediate steps.
     item_type:

--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -248,7 +248,7 @@ properties:
     is_set: true
     required: true
     send_empty_value: true
-    set_hash_func: 'tpgresource.SelfLinkRelativePathHash'
+    set_hash_func: 'tpgresource.SelfLinkNameHash'
     custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.tmpl'
     item_type:
       name: 'subnet'

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachment_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachment_test.go
@@ -89,7 +89,7 @@ resource "google_compute_service_attachment" "psc_ilb_service_attachment" {
 
   enable_proxy_protocol = false
   connection_preference = "ACCEPT_AUTOMATIC"
-  nat_subnets           = [google_compute_subnetwork.psc_ilb_nat.id]
+  nat_subnets           = [google_compute_subnetwork.psc_ilb_nat.self_link]
   target_service        = google_compute_forwarding_rule.psc_ilb_target_service.id
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go
@@ -755,7 +755,7 @@ resource "google_compute_forwarding_rule" "psc_ilb_consumer" {
   name                  = "tf-test-consumer-fr-%{random_suffix}"
   region                = "us-west2"
   target                = google_compute_service_attachment.psc_ilb_service_attachment.id
-  load_balancing_scheme = "" 
+  load_balancing_scheme = ""
   network               = "default"
   ip_address            = google_compute_address.psc_ilb_consumer_address.id
 }
@@ -1018,6 +1018,99 @@ resource "google_compute_subnetwork" "psc_ilb_nat" {
   network       = google_compute_network.psc_ilb_network.id
   purpose       = "PRIVATE_SERVICE_CONNECT"
   ip_cidr_range = "10.1.0.0/16"
+}
+`, context)
+}
+
+func TestAccComputeServiceAttachment_serviceAttachmentMultipleSubnets(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeServiceAttachmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeServiceAttachment_serviceAttachmentMultipleSubnets(context),
+			},
+			{
+				ResourceName:            "google_compute_service_attachment.psc_ilb_service_attachment",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region", "show_nat_ips"},
+			},
+		},
+	})
+}
+
+func testAccComputeServiceAttachment_serviceAttachmentMultipleSubnets(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_service_attachment" "psc_ilb_service_attachment" {
+  name        = "tf-test-my-psc-ilb%{random_suffix}"
+  region      = "us-west2"
+  description = "A service attachment configured with Terraform"
+  enable_proxy_protocol    = true
+  connection_preference    = "ACCEPT_AUTOMATIC"
+  nat_subnets              = [for subnet in google_compute_subnetwork.psc_ilb_nat : subnet.id]
+  target_service           = google_compute_forwarding_rule.psc_ilb_target_service.id
+}
+resource "google_compute_address" "psc_ilb_consumer_address" {
+  name   = "tf-test-psc-ilb-consumer-address%{random_suffix}"
+  region = "us-west2"
+  subnetwork   = "default"
+  address_type = "INTERNAL"
+}
+resource "google_compute_forwarding_rule" "psc_ilb_consumer" {
+  name   = "tf-test-psc-ilb-consumer-forwarding-rule%{random_suffix}"
+  region = "us-west2"
+  target                = google_compute_service_attachment.psc_ilb_service_attachment.id
+  load_balancing_scheme = "" # need to override EXTERNAL default when target is a service attachment
+  network               = "default"
+  ip_address            = google_compute_address.psc_ilb_consumer_address.id
+}
+resource "google_compute_forwarding_rule" "psc_ilb_target_service" {
+  name   = "tf-test-producer-forwarding-rule%{random_suffix}"
+  region = "us-west2"
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.producer_service_backend.id
+  all_ports             = true
+  network               = google_compute_network.psc_ilb_network.name
+  subnetwork            = google_compute_subnetwork.psc_ilb_producer_subnetwork.name
+}
+resource "google_compute_region_backend_service" "producer_service_backend" {
+  name   = "tf-test-producer-service%{random_suffix}"
+  region = "us-west2"
+  health_checks = [google_compute_health_check.producer_service_health_check.id]
+}
+resource "google_compute_health_check" "producer_service_health_check" {
+  name = "tf-test-producer-service-health-check%{random_suffix}"
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = "80"
+  }
+}
+resource "google_compute_network" "psc_ilb_network" {
+  name = "tf-test-psc-ilb-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+resource "google_compute_subnetwork" "psc_ilb_producer_subnetwork" {
+  name   = "tf-test-psc-ilb-producer-subnetwork%{random_suffix}"
+  region = "us-west2"
+  network       = google_compute_network.psc_ilb_network.id
+  ip_cidr_range = "10.0.0.0/16"
+}
+resource "google_compute_subnetwork" "psc_ilb_nat" {
+  count = 8
+  name   = "tf-test-psc-ilb-nat%{random_suffix}-${count.index}"
+  region = "us-west2"
+  network       = google_compute_network.psc_ilb_network.id
+  purpose       =  "PRIVATE_SERVICE_CONNECT"
+  ip_cidr_range = cidrsubnet("10.0.0.0/8", 8, count.index + 1)
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
@@ -188,6 +188,16 @@ The default value of `load_balancing_scheme` for `google_compute_global_forwardi
 Configurations that do not set `load_balancing_scheme` will now default to `EXTERNAL_MANAGED` instead of `EXTERNAL`.
 To maintain the previous behavior (Classic Application Load Balancer), set `load_balancing_scheme = "EXTERNAL"` explicitly.
 
+## Resource: `google_compute_service_attachment`
+
+### `nat_subnets` is now a set
+
+`nat_subnets` has been converted from a `list` to a `set` to resolve perpetual diffs caused by non-deterministic API ordering. References that use list indexing (for example, `google_compute_service_attachment.<name>.nat_subnets[0]`) should be updated to use `tolist(google_compute_service_attachment.<name>.nat_subnets)[0]` or `for` expressions.
+
+### `consumer_reject_lists` is now a set
+
+`consumer_reject_lists` has been converted from a `list` to a `set` to resolve perpetual diffs caused by non-deterministic API ordering. References that use list indexing (for example, `google_compute_service_attachment.<name>.consumer_reject_lists[0]`) should be updated to use `tolist(google_compute_service_attachment.<name>.consumer_reject_lists)[0]` or `for` expressions.
+
 ## Resource: `google_data_loss_prevention_job_trigger`
 
 ### `actions.publish_findings_to_cloud_data_catalog` is now removed


### PR DESCRIPTION


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

fixes https://github.com/hashicorp/terraform-provider-google/issues/25913

Adopts https://github.com/GoogleCloudPlatform/magic-modules/pull/15873. The PR was failing some tests by using `SelfLinkRelativePathHash`, which fails on short subnet names (like subnet.name) and hashes to 0, creating a hash mismatch and permadiff against the API's full self-link URLs. The PR was also missing upgrade guide documentation

Changes made from the original PR:
- Switched set_hash_func to tpgresource.SelfLinkNameHash to correctly normalize short names, relative IDs, and full self-links to the same hash.
- Added 8.0.0 upgrade guide documentation.

**Release Note Template for Downstream PRs (will be copied)**
```release-note:breaking-change
compute: `nat_subnets` and `consumer_reject_lists` on `google_compute_service_attachment` have been changed from lists to sets to resolve non-deterministic API ordering diffs.
```
