### PR TITLE
agents: replace create-pr with prepare-pr-link skill

### DIFF
--- a/.agents/WORKFLOWS.md
+++ b/.agents/WORKFLOWS.md
@@ -31,7 +31,7 @@ specific one.
 *   **New Resource Workflow** (`.agents/skills/workflows/new_resource/SKILL.md`): Specifically for creating a new resource, supporting both autogen and manual generation.
 *   **Add Fields Workflow** (`.agents/skills/workflows/add_fields/SKILL.md`): Specifically for adding new fields to existing MMv1 or handwritten resources.
 *   **Test Fix Workflow** (`.agents/skills/workflows/test_fix/SKILL.md`): Specifically for resolving failing acceptance tests from GitHub issues, direct prompts, or debug logs.
-*   **Add List Resource Workflow** (`.agents/skills/workflows/add_list_resource/SKILL.md`): Opts one product's eligible MMv1 resources into list-resource generation by setting `generate_list_resource: true`, validates locally, and opens a PR.
+*   **Add List Resource Workflow** (`.agents/skills/workflows/add_list_resource/SKILL.md`): Opts one product's eligible MMv1 resources into list-resource generation by setting `generate_list_resource: true`, and validates locally.
 *   **Prepare Release Workflow** (`.agents/skills/workflows/prepare_release/SKILL.md`): Prepares and cuts weekly releases for both `terraform-provider-google` (TPG) and `terraform-provider-google-beta` (TPGB) providers.
 *   **Test Monitor Workflow** (`.agents/skills/workflows/test_monitor/SKILL.md`): For fetching, triaging, analyzing, and reporting on nightly acceptance test results across Beta and GA providers.
 *   **Add IAM Support Workflow** (`.agents/skills/workflows/add_iam_resources/SKILL.md`): Adds IAM support to an existing MMv1 resource.

--- a/.agents/skills/operations/prepare-pr-link/SKILL.md
+++ b/.agents/skills/operations/prepare-pr-link/SKILL.md
@@ -1,26 +1,26 @@
 ---
-name: create-pr
-description: "Create a Pull Request (PR) against GoogleCloudPlatform/magic-modules following repository standards, including branch management, commit formatting, mandatory release notes, pre-PR verification checks, and gh CLI commands."
+name: prepare-pr-link
+description: "Prepares a feature branch, stages and commits changes, pushes to the user's personal fork, and generates a pre-filled GitHub comparison link for the user to review and submit a Pull Request."
 ---
 
-# `create-pr`
+# `prepare-pr-link`
 
 > **Note to AI Agents:** You MUST read the YAML frontmatter above first. Only read the rest of this file if the `description` matches your current roadblock or required task.
 
-This skill provides step-by-step instructions for preparing, formatting, and opening a Pull Request (PR) for `magic-modules` following official contribution guidelines.
+This skill provides step-by-step instructions for preparing, committing, pushing a feature branch to a personal fork, and generating a pre-filled GitHub Pull Request comparison link for the user to review and submit.
 
 ## Prerequisites
 
 * You are in the `magic-modules` root directory.
 * Your git working directory is clean except for the files intended for the PR.
-* Downstream provider changes are NOT staged or committed to `magic-modules`.
+* Downstream provider changes are NOT staged or committed in `magic-modules`.
 * Remote repositories are configured (e.g., `upstream` pointing to `GoogleCloudPlatform/magic-modules` and a personal fork remote such as `origin`).
 
 ---
 
 ## Pre-PR Verification & Guardrails
 
-Before creating a branch or opening a PR, verify all of the following rules:
+Before creating a branch or generating the link, verify all of the following rules:
 
 1. **Single Self-Contained Change:** Each PR must contain only **one** logical change.
    - Adding multiple resources? Put **one resource per PR**.
@@ -30,7 +30,7 @@ Before creating a branch or opening a PR, verify all of the following rules:
    - Format: `<product>: <action> <target>` (e.g. `beyondcorp: deprecate google_beyondcorp_app_*` or `compute: add foo field to google_compute_instance`).
 3. **No Downstream Artifacts in Magic Modules:**
    - Do NOT commit generated downstream provider code into `magic-modules`.
-4. **Workspace Cleanup:** Run `git status --porcelain` and ensure no untracked temporary test files exist before opening the PR.
+4. **Workspace Cleanup:** Run `git status --porcelain` and ensure no untracked temporary test files exist before pushing.
 
 ---
 
@@ -42,9 +42,11 @@ Before creating a branch or opening a PR, verify all of the following rules:
 UPSTREAM_REMOTE=$(git remote -v | grep -i "GoogleCloudPlatform/magic-modules" | head -n 1 | awk '{print $1}')
 UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-upstream}"
 
-git fetch "$UPSTREAM_REMOTE" main
+BASE_BRANCH="main" # or target major release feature branch, e.g. FEATURE-BRANCH-major-release-8.0.0
+git fetch "$UPSTREAM_REMOTE" "$BASE_BRANCH"
+
 BRANCH="<short-descriptive-branch-name>" # e.g. deprecate-beyondcorp-app
-git checkout -b "$BRANCH" "$UPSTREAM_REMOTE/main"
+git checkout -b "$BRANCH" "$UPSTREAM_REMOTE/$BASE_BRANCH"
 ```
 
 ### 2. Stage and Commit Changes
@@ -69,7 +71,7 @@ git push -u "$FORK_REMOTE" "$BRANCH"
 
 Every PR must contain a clear summary and a release note block in the PR body.
 
-Refer to [docs/content/code-review/release-notes.md](../../../../docs/content/code-review/release-notes.md) for details on categories (`enhancement`, `bug`, `none`, `new-resource`, `deprecation`, `breaking-change`).
+Refer to [docs/content/code-review/release-notes.md](../../../../docs/content/code-review/release-notes.md) for details on categories (`enhancement`, `bug`, `none`, `new-resource`, `new-datasource`, `new-list-resource`, `deprecation`, `breaking-change`).
 
 #### Sample PR Body
 ```markdown
@@ -84,46 +86,30 @@ Fixes https://github.com/hashicorp/terraform-provider-google/issues/12345
 
 ---
 
-### 5. Create PR or Provide Pre-Filled Web Link
+### 5. Generate Pre-Filled Web URL (Always Provide as Hyperlink)
 
-Write the PR body to a temporary file (`/tmp/pr_body.txt`) using a single-quoted HEREDOC:
-
-```bash
-PR_TITLE="<product>: <short description under 70 chars>"
-BASE_BRANCH="main" # or FEATURE-BRANCH-major-release-8.0.0
-
-cat <<'EOF' > /tmp/pr_body.txt
-<summary of what changed and why>
-
-Fixes <issue link if applicable>
-
-```release-note:<type>
-<product>: <release note description>
-```
-EOF
-```
-
-#### Attempt `gh pr create`:
-```bash
-gh pr create \
-  --repo GoogleCloudPlatform/magic-modules \
-  --base "$BASE_BRANCH" \
-  --head "$(gh api user -q .login):$BRANCH" \
-  --title "$PR_TITLE" \
-  --body-file /tmp/pr_body.txt
-```
-
-#### Generate Pre-Filled Web URL (Always Provide as Hyperlink):
-Always generate and present a clickable markdown link with the PR title and description pre-filled in query parameters for easy user review and submission:
+Run Python to generate the pre-filled comparison URL with title and body URL-encoded:
 
 ```python
 import urllib.parse
+import subprocess
+import re
 
-base_branch = "main" # or "FEATURE-BRANCH-major-release-8.0.0"
-head_ref = f"{username}:{branch}" # e.g. "c2thorn:deprecate-beyondcorp-app"
-title = "..."
-body = "..."
+base_branch = "main" # or target feature branch, e.g. "FEATURE-BRANCH-major-release-8.0.0"
+branch = "<BRANCH>"
+title = "<PR_TITLE>"
+body = """<PR_BODY>"""
 
+# Auto-detect fork remote and username
+fork_remote_cmd = "git remote -v | grep -v -i 'GoogleCloudPlatform/magic-modules' | head -n 1 | awk '{print $1}'"
+fork_remote = subprocess.check_output(fork_remote_cmd, shell=True, text=True).strip() or "origin"
+fork_url = subprocess.check_output(["git", "remote", "get-url", fork_remote], text=True).strip()
+
+# Extract username from git URL (ssh or https)
+m = re.search(r"github\.com[:/]([^/]+)/", fork_url)
+username = m.group(1) if m else "<username>"
+
+head_ref = f"{username}:{branch}"
 url = f"https://github.com/GoogleCloudPlatform/magic-modules/compare/{base_branch}...{head_ref}?expand=1&title={urllib.parse.quote(title)}&body={urllib.parse.quote(body)}"
 print(url)
 ```
@@ -131,9 +117,4 @@ print(url)
 Present the result in chat as:
 👉 **[Create Pull Request on GitHub](<URL>)**
 
----
-
-## Verification & Summary
-
-1. If `gh pr create` succeeds, view the published PR: `gh pr view --repo GoogleCloudPlatform/magic-modules`.
-2. Share the confirmed PR URL (or the pre-filled direct compare URL) with the user.
+Inform the user that the branch has been pushed to their fork and they can click the link to review the diff and submit the Pull Request.

--- a/.agents/skills/workflows/add_list_resource/SKILL.md
+++ b/.agents/skills/workflows/add_list_resource/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: add-list-resource-workflow
-description: "Opt resource into MMv1 list-resource generation by setting `generate_list_resource: true`, validate it locally, and open a one-resource PR against GoogleCloudPlatform/magic-modules. Invoke when the user asks to add list-resource support for a specific MMv1 resource or to enable `generate_list_resource` for an eligible resource."
+description: "Opt resource into MMv1 list-resource generation by setting `generate_list_resource: true` and validate it locally with generated tests. Invoke when the user asks to add list-resource support for a specific MMv1 resource or to enable `generate_list_resource` for an eligible resource."
 ---
 
 # `add-list-resource-workflow`
 
 > **Note to AI Agents:** You MUST read the YAML frontmatter above first. Only read the rest of this file if the `description` matches your current roadblock or required task.
 
-This workflow produces a single PR scoped to **one product** that flips `generate_list_resource: true` on every eligible MMv1 resource in that product, generates the downstream code, runs the generated list-query tests, and opens the PR. Do **one product per PR**, with as many eligible resources as pass.
+This workflow produces a change scoped to **one product** that flips `generate_list_resource: true` on every eligible MMv1 resource in that product, generates the downstream code, and runs the generated list-query tests. Do **one product per change**, with as many eligible resources as pass.
 
 Consult `.agents/knowledge/index.md` for the topics this task touches and open the relevant sources.
 
@@ -15,8 +15,7 @@ Consult `.agents/knowledge/index.md` for the topics this task touches and open t
 
 * You are in the `magic-modules` root directory.
 * `$GOPATH` is set and `terraform-provider-google` is checked out at `$GOPATH/src/github.com/hashicorp/terraform-provider-google` (or another known path — confirm with the user).
-* The magic-modules `mau` remote points at the user's personal fork (`git remote get-url mau`). Confirm with the user if it is missing.
-* `gh` CLI is authenticated as the user (`gh auth status`).
+* Remote repositories are configured (e.g. `upstream` pointing to `GoogleCloudPlatform/magic-modules` and personal fork remote such as `origin`).
 * The user has named **one** target product (e.g. `compute`). Resources will be selected automatically by the eligibility scan.
 
 ## Eligibility Check
@@ -138,69 +137,11 @@ TF_ACC=1 go test -v -timeout 120m \
 
 Required environment for a live run: `GOOGLE_PROJECT`, `GOOGLE_REGION`, `GOOGLE_ZONE`, `GOOGLE_CREDENTIALS` (or ADC). Confirm with the user before consuming GCP resources.
 
-If **any** test fails, do not patch the generator or the YAML to suppress the failure. Report the failing resources to the user. The user decides whether to (a) drop those resources from this PR and re-generate, or (b) abort the PR entirely. Never silently ship a PR that has failing list-query tests.
-
-### 5. Open the PR
-
-Stage only the YAML changes in magic-modules; the downstream provider edits are throwaway artifacts and must not be committed in magic-modules.
-
-```bash
-cd <magic-modules-root>
-git add mmv1/products/<PRODUCT>/
-git commit -m "<product>: add list resources for <N> resources"
-git push mau "$BRANCH"
-```
-
-Write the PR body to `/tmp/pr_body.md` before invoking `gh pr create`. Include one `release-note:new-list-resource` block per resource and the trimmed `--- PASS:` lines from the test output.
-
-```markdown
-Adds list-resource generation for the following <product> resources:
-
-- `google_<product>_<resource_a>`
-- `google_<product>_<resource_b>`
-- ...
-
-```release-note:new-list-resource
-`google_<product>_<resource_a>`
-```
-
-```release-note:new-list-resource
-`google_<product>_<resource_b>`
-```
-
-<details><summary>Local test output</summary>
-
-```
-<paste trimmed `--- PASS: TestAcc...ListQuery_generated` lines and the final `PASS / ok` summary>
-```
-
-</details>
-```
-
-Open the PR from the `mau` fork against `GoogleCloudPlatform/magic-modules:main`:
-
-```bash
-gh pr create \
-  --repo GoogleCloudPlatform/magic-modules \
-  --base main \
-  --head "$(gh api user -q .login):$BRANCH" \
-  --title "<product>: add list resources" \
-  --body-file /tmp/pr_body.md
-```
-
-### 6. Request a reviewer
-
-After the PR is created, post a comment so `modular-magician` assigns a human reviewer:
-
-```bash
-gh pr comment <PR_NUMBER> \
-  --repo GoogleCloudPlatform/magic-modules \
-  --body "@modular-magician reassign-reviewer"
-```
+If **any** test fails, do not patch the generator or the YAML to suppress the failure. Report the failing resources to the user. The user decides whether to (a) drop those resources and re-generate, or (b) abort entirely. Never silently ship a change that has failing list-query tests.
 
 ## Handoff & Guardrails
 
-* **One product per PR.** Bundle every eligible resource in the product into a single PR. Do not split a product across multiple PRs unless the user explicitly asks.
+* **One product per change.** Bundle every eligible resource in the product into a single change. Do not split a product across multiple changes unless the user explicitly asks.
 * **Never edit the generator** (`mmv1/api/`, `mmv1/provider/`, `mmv1/templates/terraform/list_resource*`) from this workflow. If the generator misbehaves, stop and escalate to the user.
 * **Never commit downstream provider files** to the magic-modules branch.
-* On any failure during generate/build, abort and report the exact failing command and output. On test failures, drop the failing resource(s) from the PR (or abort) per the user's choice — never ship a PR with failing list-query tests.
+* On any failure during generate/build, abort and report the exact failing command and output. On test failures, drop the failing resource(s) (or abort) per the user's choice — never ship a change with failing list-query tests.

--- a/.agents/skills/workflows/bug_fix/SKILL.md
+++ b/.agents/skills/workflows/bug_fix/SKILL.md
@@ -54,7 +54,6 @@ This document outlines the structured 6-step lifecycle for investigating, planni
     4. **Breaking Change Validation:** Execute the `validate-provider-changes` skill (`.agents/skills/utils/validate-provider-changes/`) if schemas or properties were modified.
 *   **Workspace Cleanup:** Run `git status --porcelain` and remove any untracked `.log`, `.test`, or temporary test artifacts across both repositories before reporting resolution or creating a PR.
 *   **Artifact Report:** If code changes or verification tests were performed, compile these results into a separate verification/test report artifact.
-*   **PR Creation:** When opening a PR, execute the `create-pr` skill (`.agents/skills/operations/create-pr/`), which governs branch creation, PR title length, release notes, and reference linking (`Modeled after:` / `Based on:`).
 *   **GitHub Response Draft:** Draft a final, succinct public response containing verified PR/commit links.
     *   **Succinct Public Communication:** Responses should be concise (2–3 sentences preferred): state what changed, why, and refer readers to the PR or documentation for technical deep-dives.
 *   **HIL steering checkpoint:** Present the final response draft and any new verification reports to the user for sign-off and issue closure.

--- a/.agents/skills/workflows/deprecate_resource_or_field/SKILL.md
+++ b/.agents/skills/workflows/deprecate_resource_or_field/SKILL.md
@@ -49,16 +49,3 @@ Follow the conventions in `docs/content/breaking-changes/make-a-breaking-change.
 ### 6. Verification Testing
 
 - Invoke [qa-test-runner](.agents/skills/operations/qa-test-runner/SKILL.md) to verify acceptance tests pass (`PASS`).
-
-### 7. PR Creation & Release Note
-
-Execute [create-pr](.agents/skills/operations/create-pr/SKILL.md) targeting `main`:
-- **Title Length Limit**: Must be strictly **under 70 characters** (e.g. `<product>: deprecate <target>`).
-- **Body**:
-  ```markdown
-  ```release-note:deprecation
-  <product>: deprecated `<field_name>` on `google_<resource_name>`. Use `<replacement>` instead.
-  ```
-  *(or `<product>: deprecated `google_<resource_name>` resource/data source`)*
-  ```
-- **Pre-Filled Hyperlink**: Always generate and provide a pre-filled markdown compare URL in chat for easy user submission.

--- a/.agents/skills/workflows/major_release_removal/SKILL.md
+++ b/.agents/skills/workflows/major_release_removal/SKILL.md
@@ -93,18 +93,3 @@ Add entries to `${UPGRADE_GUIDE}` following existing entries in that file and gu
 ### 7. Verification Testing
 
 Invoke [qa-test-runner](.agents/skills/operations/qa-test-runner/SKILL.md) to run acceptance tests for remaining or adjacent resources to ensure no regressions.
-
----
-
-### 8. PR Creation & Release Note
-
-Execute [create-pr](.agents/skills/operations/create-pr/SKILL.md) targeting `${FEATURE_BRANCH}`:
-- **Title Length Limit**: Must be strictly **under 70 characters** (e.g. `<product>: remove deprecated google_<resource>_* for ${MAJOR_VERSION}`).
-- **Body**:
-  ```markdown
-  ```release-note:breaking-change
-  <product>: removed deprecated `<field_name>` from `google_<resource_name>`
-  ```
-  *(or `<product>: removed deprecated `google_<resource_name>` resource/data source`)*
-  ```
-- **Pre-Filled Hyperlink**: Always generate and provide a pre-filled markdown compare URL in chat for easy user submission.

--- a/.agents/skills/workflows/test_fix/SKILL.md
+++ b/.agents/skills/workflows/test_fix/SKILL.md
@@ -59,10 +59,9 @@ Consult `.agents/skills/utils/test-failure-decision-tree/SKILL.md` for full symp
 
 ---
 
-### 3. Verification & PR Handoff
+### 3. Verification & Compliance Checks
 * Verify that test output reports `PASS` for all failing targets (`ga`, `beta`, or `both`).
 * **Verify Handwritten Test Naming Compliance**: For handwritten test files (`*_test.go`), verify that any newly added unit tests are named `Test...` (without the `TestAcc` prefix) and handwritten acceptance tests are named `TestAcc...`. (Generated acceptance tests from MMv1 samples handle naming automatically).
 * **Verify Remediation Scope**: Verify that code modifications are strictly scoped to the specific field(s) or resource(s) proven by the test failure log or plan diff to be causing the failure. Do NOT include assumption-based edits to adjacent/sibling fields without empirical evidence.
 * **Verify Breaking Change Compliance & User Notification**: Consult all files in `docs/content/breaking-changes/` (`breaking-changes.md` and `make-a-breaking-change.md`) before making any schema or behavioral modifications. If a breaking change needs to be made, explicitly state it to the user and list out the reason why, referencing the applicable policy in `docs/content/breaking-changes/`.
 * Verify that no test-dodging flags (`ignore_read`, `default_from_api`, etc.) were introduced without justification.
-* If requested by the user (e.g. "create a PR for the fix"), automatically invoke the `create-pr` skill (`.agents/skills/operations/create-pr/`) to open a pull request.


### PR DESCRIPTION
Replaces the `create-pr` skill with `prepare-pr-link`, focusing on pushing feature branches to personal forks and generating pre-filled GitHub comparison links rather than executing `gh pr create`. 

Also cleans up workflows to remove PR creation for consistency across all workflows.

```release-note:none

```