### PR TITLE
Make Dataflow tests agnostic to service-added labels

### DIFF
--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.tmpl
@@ -553,7 +553,11 @@ func TestAccDataflowJob_withAttributionLabelCreationOnly(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.goog-terraform-provisioned", "true"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.user_label", "foo"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "5"), // Includes 3 server generated labels
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.user_label", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.goog-terraform-provisioned", "true"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-name"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-type"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-version"),
 				),
 			},
 			{
@@ -572,7 +576,11 @@ func TestAccDataflowJob_withAttributionLabelCreationOnly(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.goog-terraform-provisioned", "true"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.user_label", "bar"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "5"), // Includes 3 server generated labels
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.user_label", "bar"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.goog-terraform-provisioned", "true"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-name"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-type"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-version"),
 				),
 			},
 			{
@@ -610,7 +618,11 @@ func TestAccDataflowJob_withAttributionLabelProactive(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "1"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.user_label", "foo"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "4"), // Includes 3 server generated labels
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.user_label", "foo"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-name"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-type"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-version"),
+					resource.TestCheckNoResourceAttr("google_dataflow_job.big_data", "effective_labels.goog-terraform-provisioned"),
 				),
 			},
 			{
@@ -629,7 +641,11 @@ func TestAccDataflowJob_withAttributionLabelProactive(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.goog-terraform-provisioned", "true"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.user_label", "bar"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "5"), // Includes 3 server generated labels
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.user_label", "bar"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.goog-terraform-provisioned", "true"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-name"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-type"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-version"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.tmpl
@@ -260,7 +260,13 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "7"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.default_key1", "default_value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.goog-terraform-provisioned", "true"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-name"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-type"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-version"),
 				),
 			},
 			{
@@ -282,7 +288,13 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "7"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.default_key1", "value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.goog-terraform-provisioned", "true"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-name"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-type"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-version"),
 				),
 			},
 			{
@@ -305,7 +317,13 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "7"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.default_key1", "value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.goog-terraform-provisioned", "true"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-name"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-type"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-version"),
 				),
 			},
 			{
@@ -327,7 +345,13 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "7"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.default_key1", "value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.goog-terraform-provisioned", "true"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-name"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-type"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-version"),
 				),
 			},
 			{
@@ -341,7 +365,10 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_dataflow_job.big_data", "labels.%"),
 					// goog-terraform-provisioned: true is added
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "4"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.goog-terraform-provisioned", "true"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-name"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-type"),
+					resource.TestCheckResourceAttrSet("google_dataflow_job.big_data", "effective_labels.goog-dataflow-provided-template-version"),
 				),
 			},
 			{
@@ -1413,3 +1440,6 @@ func TestResourceDataflowJobTemplateGcsPathDiffSuppress(t *testing.T) {
 		}
 	}
 }
+
+
+


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: none
Makes Dataflow tests agnostic to service-added labels
```
