### PR TITLE
vertexai: add disable_natural_language_memories and generate_memories_examples to google_vertex_ai_reasoning_engine

### DIFF
--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -1106,6 +1106,206 @@ properties:
                   type: Boolean
                   description: |-
                     Optional. Generate memories in the third person if set to true.
+                - name: 'disableNaturalLanguageMemories'
+                  type: Boolean
+                  description: |-
+                    Optional. Indicates whether natural language memory generation should be disabled.
+                - name: 'generateMemoriesExamples'
+                  type: Array
+                  description: |-
+                    Optional. Provides examples of how to generate memories for a particular scope.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'conversationSource'
+                        type: NestedObject
+                        description: |-
+                          Optional. A conversation source for the example.
+                        properties:
+                          - name: 'events'
+                            type: Array
+                            description: |-
+                              Optional. Represents the input conversation events for the example.
+                            item_type:
+                              type: NestedObject
+                              properties:
+                                - name: 'content'
+                                  type: NestedObject
+                                  description: |-
+                                    Required. Represents the content of the event.
+                                  properties:
+                                    - name: 'role'
+                                      type: String
+                                      description: |-
+                                        Optional. The producer of the content. Must be either 'user' or 'model'. If not set, the service will default to 'user'.
+                                    - name: 'parts'
+                                      type: Array
+                                      description: |-
+                                        Required. A list of Part objects that make up a single message.
+                                      item_type:
+                                        type: NestedObject
+                                        properties:
+                                          - name: 'text'
+                                            type: String
+                                            description: |-
+                                              Optional. The text content of the part.
+                                          - name: 'thought'
+                                            type: Boolean
+                                            description: |-
+                                              Optional. Indicates whether the part represents the model's thought process or reasoning.
+                                          - name: 'inlineData'
+                                            type: NestedObject
+                                            description: |-
+                                              Optional. The inline data content of the part.
+                                            properties:
+                                              - name: 'mimeType'
+                                                type: String
+                                                description: |-
+                                                  Required. The IANA standard MIME type of the source data.
+                                                required: true
+                                              - name: 'data'
+                                                type: String
+                                                description: |-
+                                                  Required. Raw bytes, which should be base64-encoded.
+                                                required: true
+                                          - name: 'fileData'
+                                            type: NestedObject
+                                            description: |-
+                                              Optional. URI based data.
+                                            properties:
+                                              - name: 'mimeType'
+                                                type: String
+                                                description: |-
+                                                  Required. The IANA standard MIME type of the source data.
+                                                required: true
+                                              - name: 'fileUri'
+                                                type: String
+                                                description: |-
+                                                  Required. The URI of the file in Google Cloud Storage.
+                                                required: true
+                                          - name: 'functionCall'
+                                            type: NestedObject
+                                            description: |-
+                                              Optional. A predicted function call returned from the model.
+                                            properties:
+                                              - name: 'id'
+                                                type: String
+                                                description: |-
+                                                  Optional. The unique id of the function call.
+                                              - name: 'name'
+                                                type: String
+                                                description: |-
+                                                  Required. The name of the function to call.
+                                                required: true
+                                              - name: 'args'
+                                                type: String
+                                                description: |-
+                                                  Optional. The function parameters and values in JSON object format.
+                                                state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                                                custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                                                custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+                                                validation:
+                                                  function: 'validation.StringIsJSON'
+                                          - name: 'functionResponse'
+                                            type: NestedObject
+                                            description: |-
+                                              Optional. The result of a function call.
+                                            properties:
+                                              - name: 'id'
+                                                type: String
+                                                description: |-
+                                                  Optional. The id of the function call this response is for.
+                                              - name: 'name'
+                                                type: String
+                                                description: |-
+                                                  Required. The name of the function to call.
+                                                required: true
+                                              - name: 'response'
+                                                type: String
+                                                description: |-
+                                                  Required. The function response in JSON object format.
+                                                state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                                                custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                                                custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+                                                validation:
+                                                  function: 'validation.StringIsJSON'
+                                          - name: 'executableCode'
+                                            type: NestedObject
+                                            description: |-
+                                              Optional. Code generated by the model that is intended to be executed.
+                                            properties:
+                                              - name: 'id'
+                                                type: String
+                                                description: |-
+                                                  Optional. Unique identifier of the ExecutableCode part.
+                                              - name: 'language'
+                                                type: String
+                                                description: |-
+                                                  Required. Supported programming languages for the generated code. Possible values: ["LANGUAGE_UNSPECIFIED", "PYTHON", "BASH"]
+                                                required: true
+                                              - name: 'code'
+                                                type: String
+                                                description: |-
+                                                  Required. The code to be executed.
+                                                required: true
+                                          - name: 'codeExecutionResult'
+                                            type: NestedObject
+                                            description: |-
+                                              Optional. Result of executing the ExecutableCode.
+                                            properties:
+                                              - name: 'id'
+                                                type: String
+                                                description: |-
+                                                  Optional. The identifier of the ExecutableCode part this result is for.
+                                              - name: 'outcome'
+                                                type: String
+                                                description: |-
+                                                  Required. Outcome of the code execution. Possible values: ["OUTCOME_UNSPECIFIED", "OUTCOME_OK", "OUTCOME_FAILED", "OUTCOME_DEADLINE_EXCEEDED"]
+                                                required: true
+                                              - name: 'output'
+                                                type: String
+                                                description: |-
+                                                  Optional. Contains stdout when code execution is successful, stderr or other description otherwise.
+                                          - name: 'videoMetadata'
+                                            type: NestedObject
+                                            description: |-
+                                              Optional. Video metadata.
+                                            properties:
+                                              - name: 'startOffset'
+                                                type: String
+                                                description: |-
+                                                  Optional. The start offset of the video.
+                                              - name: 'endOffset'
+                                                type: String
+                                                description: |-
+                                                  Optional. The end offset of the video.
+                      - name: 'generatedMemories'
+                        type: Array
+                        description: |-
+                          Optional. Represents the memories that are expected to be generated from the input conversation.
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: 'fact'
+                              type: String
+                              description: |-
+                                Required. Represents the fact to generate a memory from.
+                              required: true
+                            - name: 'topics'
+                              type: Array
+                              description: |-
+                                Optional. Represents the list of topics that the memory should be associated with.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'customMemoryTopicLabel'
+                                    type: String
+                                    description: |-
+                                      Optional. Represents the custom memory topic label.
+                                  - name: 'managedMemoryTopic'
+                                    type: String
+                                    description: |-
+                                      Optional. Represents the managed memory topic. Possible values: ["USER_PERSONAL_INFO", "USER_PREFERENCES", "KEY_CONVERSATION_DETAILS", "EXPLICIT_INSTRUCTIONS"]
           - name: 'structuredMemoryConfigs'
             type: Array
             description: |-

--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -1133,6 +1133,7 @@ properties:
                                   type: NestedObject
                                   description: |-
                                     Required. Represents the content of the event.
+                                  required: true
                                   properties:
                                     - name: 'role'
                                       type: String
@@ -1142,6 +1143,7 @@ properties:
                                       type: Array
                                       description: |-
                                         Required. A list of Part objects that make up a single message.
+                                      required: true
                                       item_type:
                                         type: NestedObject
                                         properties:
@@ -1195,8 +1197,7 @@ properties:
                                               - name: 'name'
                                                 type: String
                                                 description: |-
-                                                  Required. The name of the function to call.
-                                                required: true
+                                                  Optional. The name of the function to call.
                                               - name: 'args'
                                                 type: String
                                                 description: |-

--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -1109,40 +1109,40 @@ properties:
                 - name: 'disableNaturalLanguageMemories'
                   type: Boolean
                   description: |-
-                    Optional. Indicates whether natural language memory generation should be disabled.
+                    Indicates whether natural language memory generation should be disabled.
                 - name: 'generateMemoriesExamples'
                   type: Array
                   description: |-
-                    Optional. Provides examples of how to generate memories for a particular scope.
+                    Provides examples of how to generate memories for a particular scope.
                   item_type:
                     type: NestedObject
                     properties:
                       - name: 'conversationSource'
                         type: NestedObject
                         description: |-
-                          Optional. A conversation source for the example.
+                          A conversation source for the example.
                         properties:
                           - name: 'events'
                             type: Array
                             description: |-
-                              Optional. Represents the input conversation events for the example.
+                              Represents the input conversation events for the example.
                             item_type:
                               type: NestedObject
                               properties:
                                 - name: 'content'
                                   type: NestedObject
                                   description: |-
-                                    Required. Represents the content of the event.
+                                    Represents the content of the event.
                                   required: true
                                   properties:
                                     - name: 'role'
                                       type: String
                                       description: |-
-                                        Optional. The producer of the content. Must be either 'user' or 'model'. If not set, the service will default to 'user'.
+                                        The producer of the content. Must be either 'user' or 'model'. If not set, the service will default to 'user'.
                                     - name: 'parts'
                                       type: Array
                                       description: |-
-                                        Required. A list of Part objects that make up a single message.
+                                        A list of Part objects that make up a single message.
                                       required: true
                                       item_type:
                                         type: NestedObject
@@ -1150,58 +1150,58 @@ properties:
                                           - name: 'text'
                                             type: String
                                             description: |-
-                                              Optional. The text content of the part.
+                                              The text content of the part.
                                           - name: 'thought'
                                             type: Boolean
                                             description: |-
-                                              Optional. Indicates whether the part represents the model's thought process or reasoning.
+                                              Indicates whether the part represents the model's thought process or reasoning.
                                           - name: 'inlineData'
                                             type: NestedObject
                                             description: |-
-                                              Optional. The inline data content of the part.
+                                              The inline data content of the part.
                                             properties:
                                               - name: 'mimeType'
                                                 type: String
                                                 description: |-
-                                                  Required. The IANA standard MIME type of the source data.
+                                                  The IANA standard MIME type of the source data.
                                                 required: true
                                               - name: 'data'
                                                 type: String
                                                 description: |-
-                                                  Required. Raw bytes, which should be base64-encoded.
+                                                  Raw bytes, which should be base64-encoded.
                                                 required: true
                                           - name: 'fileData'
                                             type: NestedObject
                                             description: |-
-                                              Optional. URI based data.
+                                              URI based data.
                                             properties:
                                               - name: 'mimeType'
                                                 type: String
                                                 description: |-
-                                                  Required. The IANA standard MIME type of the source data.
+                                                  The IANA standard MIME type of the source data.
                                                 required: true
                                               - name: 'fileUri'
                                                 type: String
                                                 description: |-
-                                                  Required. The URI of the file in Google Cloud Storage.
+                                                  The URI of the file in Google Cloud Storage.
                                                 required: true
                                           - name: 'functionCall'
                                             type: NestedObject
                                             description: |-
-                                              Optional. A predicted function call returned from the model.
+                                              A predicted function call returned from the model.
                                             properties:
                                               - name: 'id'
                                                 type: String
                                                 description: |-
-                                                  Optional. The unique id of the function call.
+                                                  The unique id of the function call.
                                               - name: 'name'
                                                 type: String
                                                 description: |-
-                                                  Optional. The name of the function to call.
+                                                  The name of the function to call.
                                               - name: 'args'
                                                 type: String
                                                 description: |-
-                                                  Optional. The function parameters and values in JSON object format.
+                                                  The function parameters and values in JSON object format.
                                                 state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
                                                 custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
                                                 custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
@@ -1210,21 +1210,21 @@ properties:
                                           - name: 'functionResponse'
                                             type: NestedObject
                                             description: |-
-                                              Optional. The result of a function call.
+                                              The result of a function call.
                                             properties:
                                               - name: 'id'
                                                 type: String
                                                 description: |-
-                                                  Optional. The id of the function call this response is for.
+                                                  The id of the function call this response is for.
                                               - name: 'name'
                                                 type: String
                                                 description: |-
-                                                  Required. The name of the function to call.
+                                                  The name of the function to call.
                                                 required: true
                                               - name: 'response'
                                                 type: String
                                                 description: |-
-                                                  Required. The function response in JSON object format.
+                                                  The function response in JSON object format.
                                                 state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
                                                 custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
                                                 custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
@@ -1233,80 +1233,80 @@ properties:
                                           - name: 'executableCode'
                                             type: NestedObject
                                             description: |-
-                                              Optional. Code generated by the model that is intended to be executed.
+                                              Code generated by the model that is intended to be executed.
                                             properties:
                                               - name: 'id'
                                                 type: String
                                                 description: |-
-                                                  Optional. Unique identifier of the ExecutableCode part.
+                                                  Unique identifier of the ExecutableCode part.
                                               - name: 'language'
                                                 type: String
                                                 description: |-
-                                                  Required. Supported programming languages for the generated code. Possible values: ["LANGUAGE_UNSPECIFIED", "PYTHON", "BASH"]
+                                                  Supported programming languages for the generated code. Possible values: ["LANGUAGE_UNSPECIFIED", "PYTHON", "BASH"]
                                                 required: true
                                               - name: 'code'
                                                 type: String
                                                 description: |-
-                                                  Required. The code to be executed.
+                                                  The code to be executed.
                                                 required: true
                                           - name: 'codeExecutionResult'
                                             type: NestedObject
                                             description: |-
-                                              Optional. Result of executing the ExecutableCode.
+                                              Result of executing the ExecutableCode.
                                             properties:
                                               - name: 'id'
                                                 type: String
                                                 description: |-
-                                                  Optional. The identifier of the ExecutableCode part this result is for.
+                                                  The identifier of the ExecutableCode part this result is for.
                                               - name: 'outcome'
                                                 type: String
                                                 description: |-
-                                                  Required. Outcome of the code execution. Possible values: ["OUTCOME_UNSPECIFIED", "OUTCOME_OK", "OUTCOME_FAILED", "OUTCOME_DEADLINE_EXCEEDED"]
+                                                  Outcome of the code execution. Possible values: ["OUTCOME_UNSPECIFIED", "OUTCOME_OK", "OUTCOME_FAILED", "OUTCOME_DEADLINE_EXCEEDED"]
                                                 required: true
                                               - name: 'output'
                                                 type: String
                                                 description: |-
-                                                  Optional. Contains stdout when code execution is successful, stderr or other description otherwise.
+                                                  Contains stdout when code execution is successful, stderr or other description otherwise.
                                           - name: 'videoMetadata'
                                             type: NestedObject
                                             description: |-
-                                              Optional. Video metadata.
+                                              Video metadata.
                                             properties:
                                               - name: 'startOffset'
                                                 type: String
                                                 description: |-
-                                                  Optional. The start offset of the video.
+                                                  The start offset of the video.
                                               - name: 'endOffset'
                                                 type: String
                                                 description: |-
-                                                  Optional. The end offset of the video.
+                                                  The end offset of the video.
                       - name: 'generatedMemories'
                         type: Array
                         description: |-
-                          Optional. Represents the memories that are expected to be generated from the input conversation.
+                          Represents the memories that are expected to be generated from the input conversation.
                         item_type:
                           type: NestedObject
                           properties:
                             - name: 'fact'
                               type: String
                               description: |-
-                                Required. Represents the fact to generate a memory from.
+                                Represents the fact to generate a memory from.
                               required: true
                             - name: 'topics'
                               type: Array
                               description: |-
-                                Optional. Represents the list of topics that the memory should be associated with.
+                                Represents the list of topics that the memory should be associated with.
                               item_type:
                                 type: NestedObject
                                 properties:
                                   - name: 'customMemoryTopicLabel'
                                     type: String
                                     description: |-
-                                      Optional. Represents the custom memory topic label.
+                                      Represents the custom memory topic label.
                                   - name: 'managedMemoryTopic'
                                     type: String
                                     description: |-
-                                      Optional. Represents the managed memory topic. Possible values: ["USER_PERSONAL_INFO", "USER_PREFERENCES", "KEY_CONVERSATION_DETAILS", "EXPLICIT_INSTRUCTIONS"]
+                                      Represents the managed memory topic. Possible values: ["USER_PERSONAL_INFO", "USER_PREFERENCES", "KEY_CONVERSATION_DETAILS", "EXPLICIT_INSTRUCTIONS"]
           - name: 'structuredMemoryConfigs'
             type: Array
             description: |-

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
@@ -36,6 +36,56 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
             managed_topic_enum = "USER_PREFERENCES"
           }
         }
+        generate_memories_examples {
+          conversation_source {
+            events {
+              content {
+                role = "user"
+                parts {
+                  text = "I like pepperoni pizza"
+                }
+                parts {
+                  function_call {
+                    id   = "fn-call-1"
+                    name = "order_pizza"
+                    args = jsonencode({
+                      type = "pepperoni"
+                    })
+                  }
+                }
+                parts {
+                  function_response {
+                    id   = "fn-resp-1"
+                    name = "order_pizza"
+                    response = jsonencode({
+                      status = "ordered"
+                    })
+                  }
+                }
+                parts {
+                  executable_code {
+                    id       = "exec-code-1"
+                    language = "PYTHON"
+                    code     = "print('pizza')"
+                  }
+                }
+                parts {
+                  code_execution_result {
+                    id      = "exec-result-1"
+                    outcome = "OUTCOME_OK"
+                    output  = "pizza"
+                  }
+                }
+              }
+            }
+          }
+          generated_memories {
+            fact = "User likes pepperoni pizza."
+            topics {
+              managed_memory_topic = "USER_PREFERENCES"
+            }
+          }
+        }
       }
 
       # 2. Session-level Customization Config (Transient scratchpad)

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -898,6 +898,218 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 }
 `, context)
 }
+
+func TestAccVertexAIReasoningEngine_customizationConfigsUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIReasoningEngine_customizationConfigsBefore(context),
+			},
+			{
+				ResourceName:      "google_vertex_ai_reasoning_engine.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccVertexAIReasoningEngine_customizationConfigsAfter(context),
+			},
+			{
+				ResourceName:      "google_vertex_ai_reasoning_engine.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccVertexAIReasoningEngine_customizationConfigsBefore(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_vertex_ai_reasoning_engine" "primary" {
+  provider     = google-beta
+  display_name = "tf-test-reasoning-engine-%{random_suffix}"
+  description  = "Reasoning engine testing customization configs update"
+  region       = "us-central1"
+
+  context_spec {
+    memory_bank_config {
+      generation_config {
+        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-2.5-flash"
+      }
+      similarity_search_config {
+        embedding_model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"
+      }
+      customization_configs {
+        scope_keys                        = ["user_id"]
+        enable_third_person_memories      = true
+        disable_natural_language_memories = false
+        consolidation_config {
+          revisions_per_candidate_count = 1
+        }
+        memory_topics {
+          managed_memory_topic {
+            managed_topic_enum = "USER_PREFERENCES"
+          }
+        }
+        generate_memories_examples {
+          conversation_source {
+            events {
+              content {
+                role = "user"
+                parts {
+                  text    = "I like pepperoni pizza"
+                  thought = false
+                }
+                parts {
+                  function_call {
+                    id   = "fn-call-1"
+                    name = "order_pizza"
+                    args = jsonencode({
+                      type = "pepperoni"
+                    })
+                  }
+                }
+                parts {
+                  function_response {
+                    id   = "fn-resp-1"
+                    name = "order_pizza"
+                    response = jsonencode({
+                      status = "ordered"
+                    })
+                  }
+                }
+                parts {
+                  executable_code {
+                    id       = "exec-code-1"
+                    language = "PYTHON"
+                    code     = "print('pizza')"
+                  }
+                }
+                parts {
+                  code_execution_result {
+                    id      = "exec-result-1"
+                    outcome = "OUTCOME_OK"
+                    output  = "pizza"
+                  }
+                }
+              }
+            }
+          }
+          generated_memories {
+            fact = "User likes pepperoni pizza."
+            topics {
+              managed_memory_topic = "USER_PREFERENCES"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccVertexAIReasoningEngine_customizationConfigsAfter(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_vertex_ai_reasoning_engine" "primary" {
+  provider     = google-beta
+  display_name = "tf-test-reasoning-engine-%{random_suffix}"
+  description  = "Reasoning engine testing customization configs update"
+  region       = "us-central1"
+
+  context_spec {
+    memory_bank_config {
+      generation_config {
+        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-2.5-flash"
+      }
+      similarity_search_config {
+        embedding_model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"
+      }
+      customization_configs {
+        scope_keys                        = ["user_id"]
+        enable_third_person_memories      = false
+        disable_natural_language_memories = true
+        consolidation_config {
+          revisions_per_candidate_count = 2
+        }
+        memory_topics {
+          managed_memory_topic {
+            managed_topic_enum = "EXPLICIT_INSTRUCTIONS"
+          }
+        }
+        generate_memories_examples {
+          conversation_source {
+            events {
+              content {
+                role = "user"
+                parts {
+                  text    = "Remember that I prefer dark mode"
+                  thought = true
+                }
+                parts {
+                  function_call {
+                    id   = "fn-call-2"
+                    name = "set_theme"
+                    args = jsonencode({
+                      theme = "dark"
+                    })
+                  }
+                }
+                parts {
+                  function_response {
+                    id   = "fn-resp-2"
+                    name = "set_theme"
+                    response = jsonencode({
+                      status = "success"
+                    })
+                  }
+                }
+                parts {
+                  executable_code {
+                    id       = "exec-code-2"
+                    language = "PYTHON"
+                    code     = "set_theme('dark')"
+                  }
+                }
+                parts {
+                  code_execution_result {
+                    id      = "exec-result-2"
+                    outcome = "OUTCOME_OK"
+                    output  = "success"
+                  }
+                }
+              }
+            }
+          }
+          generated_memories {
+            fact = "User prefers dark mode theme."
+            topics {
+              managed_memory_topic = "EXPLICIT_INSTRUCTIONS"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, context)
+}
 {{- end }}
 
 func TestAccVertexAIReasoningEngine_apiParityExternal(t *testing.T) {

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -963,6 +963,12 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
             managed_topic_enum = "USER_PREFERENCES"
           }
         }
+        memory_topics {
+          custom_memory_topic {
+            label       = "custom_user_workflow"
+            description = "Workflow and process steps preferred by user."
+          }
+        }
         generate_memories_examples {
           conversation_source {
             events {
@@ -1004,6 +1010,22 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
                     output  = "pizza"
                   }
                 }
+                parts {
+                  file_data {
+                    file_uri  = "gs://cloud-samples-data/generative-ai/video/pixel8.mp4"
+                    mime_type = "video/mp4"
+                  }
+                  video_metadata {
+                    start_offset = "0s"
+                    end_offset   = "10s"
+                  }
+                }
+                parts {
+                  inline_data {
+                    mime_type = "image/png"
+                    data      = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                  }
+                }
               }
             }
           }
@@ -1011,6 +1033,12 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
             fact = "User likes pepperoni pizza."
             topics {
               managed_memory_topic = "USER_PREFERENCES"
+            }
+          }
+          generated_memories {
+            fact = "User workflow preferences captured from sample video and diagram."
+            topics {
+              custom_memory_topic_label = "custom_user_workflow"
             }
           }
         }
@@ -1051,6 +1079,12 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
         memory_topics {
           managed_memory_topic {
             managed_topic_enum = "EXPLICIT_INSTRUCTIONS"
+          }
+        }
+        memory_topics {
+          custom_memory_topic {
+            label       = "custom_updated_workflow"
+            description = "Updated workflow preferences."
           }
         }
         generate_memories_examples {
@@ -1094,6 +1128,22 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
                     output  = "success"
                   }
                 }
+                parts {
+                  file_data {
+                    file_uri  = "gs://cloud-samples-data/generative-ai/video/pixel8.mp4"
+                    mime_type = "video/mp4"
+                  }
+                  video_metadata {
+                    start_offset = "2s"
+                    end_offset   = "12s"
+                  }
+                }
+                parts {
+                  inline_data {
+                    mime_type = "image/png"
+                    data      = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                  }
+                }
               }
             }
           }
@@ -1101,6 +1151,12 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
             fact = "User prefers dark mode theme."
             topics {
               managed_memory_topic = "EXPLICIT_INSTRUCTIONS"
+            }
+          }
+          generated_memories {
+            fact = "User updated workflow preferences."
+            topics {
+              custom_memory_topic_label = "custom_updated_workflow"
             }
           }
         }


### PR DESCRIPTION
Adds missing fields under `context_spec.memory_bank_config.customization_configs` for `google_vertex_ai_reasoning_engine`:
- `disable_natural_language_memories`
- `generate_memories_examples` (including `conversation_source.events.content.parts` with `function_call.id`, `function_response.id`, `executable_code.id`, `code_execution_result.id`, and `generated_memories`)

```release-note:enhancement
vertexai: added `disable_natural_language_memories` and `generate_memories_examples` fields to `google_vertex_ai_reasoning_engine` (beta)
```
