### PR TITLE
apigee: add list resources for TargetServer, KVM, Organization

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -258,6 +258,11 @@ type Resource struct {
 	// types that share the same API URL (e.g. engines filtered by solutionType).
 	ListFilter string `yaml:"list_filter,omitempty"`
 
+	// [Optional] If true, the list API response is a bare JSON array instead of
+	// a wrapped object with a named key. Use ListArrayPages instead of ListPages
+	// when generating the list function.
+	ListResponseIsArray bool `yaml:"list_response_is_array,omitempty"`
+
 	// If true, skip sweeper generation for this resource
 	ExcludeSweeper bool `yaml:"exclude_sweeper,omitempty"`
 

--- a/mmv1/products/apigee/EnvironmentKeyvaluemaps.yaml
+++ b/mmv1/products/apigee/EnvironmentKeyvaluemaps.yaml
@@ -29,6 +29,8 @@ delete_url: '{{env_id}}/keyvaluemaps/{{name}}'
 import_format:
   - '{{env_id}}/keyvaluemaps/{{name}}'
   - '{{env_id}}/{{name}}'
+generate_list_resource: true
+list_response_is_array: true
 timeouts:
   insert_minutes: 1
   update_minutes: 20

--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -25,6 +25,7 @@ base_url: 'organizations'
 self_link: 'organizations/{{name}}'
 create_url: 'organizations?parent=projects/{{project_id}}'
 delete_url: 'organizations/{{name}}?retention={{retention}}'
+generate_list_resource: true
 timeouts:
   insert_minutes: 45
   update_minutes: 45
@@ -46,6 +47,7 @@ sweeper:
   identifier_field: "organization"
 custom_code:
   encoder: 'templates/terraform/encoders/apigee_organization.go.tmpl'
+  decoder: 'templates/terraform/decoders/apigee_organization.go.tmpl'
   custom_import: 'templates/terraform/custom_import/apigee_organization.go.tmpl'
 samples:
   - name: 'apigee_organization_cloud_basic'

--- a/mmv1/products/apigee/TargetServer.yaml
+++ b/mmv1/products/apigee/TargetServer.yaml
@@ -28,6 +28,8 @@ update_url: '{{env_id}}/targetservers/{{name}}'
 import_format:
   - '{{env_id}}/targetservers/{{name}}'
   - '{{env_id}}/{{name}}'
+generate_list_resource: true
+list_response_is_array: true
 timeouts:
   insert_minutes: 1
   update_minutes: 1

--- a/mmv1/templates/terraform/decoders/apigee_environment_keyvaluemaps.go.tmpl
+++ b/mmv1/templates/terraform/decoders/apigee_environment_keyvaluemaps.go.tmpl
@@ -1,9 +1,13 @@
 config := meta.(*transport_tpg.Config)
-name, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}name{{"}}"}}")
-if err != nil {
-    return nil, err
+// List items are bare strings already copied into res["name"]. Keep that
+// value; ReplaceVars only has name on direct reads/imports.
+if existing, ok := res["name"].(string); !ok || existing == "" {
+	name, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}name{{"}}"}}")
+	if err != nil {
+		return nil, err
+	}
+	res["name"] = name
 }
-res["name"] = name
 // "encrypted" field is retained for backward compatibility and the value of encrypted will always be true. Apigee X and hybrid do not support unencrypted key value maps.
 res["encrypted"] = true
 

--- a/mmv1/templates/terraform/decoders/apigee_organization.go.tmpl
+++ b/mmv1/templates/terraform/decoders/apigee_organization.go.tmpl
@@ -1,0 +1,9 @@
+// The list response returns items where the org name is in "organization".
+// For a direct read response the org name is already in "name". Normalise so
+// the identity field ("name") is always populated.
+if name, ok := res["name"].(string); !ok || name == "" {
+	if orgName, ok := res["organization"].(string); ok && orgName != "" {
+		res["name"] = orgName
+	}
+}
+return res, nil

--- a/mmv1/templates/terraform/list_resource.go.tmpl
+++ b/mmv1/templates/terraform/list_resource.go.tmpl
@@ -37,7 +37,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
+	{{- if $.ListScopeProperties }}
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	{{- end }}
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 

--- a/mmv1/templates/terraform/list_resource_method.go.tmpl
+++ b/mmv1/templates/terraform/list_resource_method.go.tmpl
@@ -51,6 +51,15 @@ func List{{ $.ResourceName }}s(config *transport_tpg.Config,
 		return err
 	}
 
+{{- if $.ListResponseIsArray }}
+	return transport_tpg.ListArrayPages(transport_tpg.ListArrayPagesOptions{
+		Config:         config,
+		TempData:       resourceData,
+		Resource:       Resource{{ $.ResourceName -}}(),
+		ListURL:        url,
+		BillingProject: billingProject,
+		UserAgent:      userAgent,
+{{- else }}
 	return transport_tpg.ListPages(transport_tpg.ListPagesOptions{
 		Config:         config,
 		TempData:       resourceData,
@@ -62,6 +71,7 @@ func List{{ $.ResourceName }}s(config *transport_tpg.Config,
 		{{- if $.ListFilter }}
 		Filter:         "{{ $.ListFilter }}",
 		{{- end }}
+{{- end }}
 		Flattener: func(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config) error {
 			headers := make(http.Header)
 			var err error

--- a/mmv1/third_party/terraform/transport/list_array_pages_test.go
+++ b/mmv1/third_party/terraform/transport/list_array_pages_test.go
@@ -1,0 +1,31 @@
+package transport
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestListItemAsMap(t *testing.T) {
+	t.Parallel()
+
+	got, err := listItemAsMap(map[string]interface{}{"name": "ts1", "port": 443})
+	if err != nil {
+		t.Fatalf("map item: %v", err)
+	}
+	if got["name"] != "ts1" {
+		t.Fatalf("map item name = %v", got["name"])
+	}
+
+	got, err = listItemAsMap("kvm1")
+	if err != nil {
+		t.Fatalf("string item: %v", err)
+	}
+	want := map[string]interface{}{"name": "kvm1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("string item = %#v, want %#v", got, want)
+	}
+
+	if _, err := listItemAsMap(1); err == nil {
+		t.Fatal("expected error for int item")
+	}
+}

--- a/mmv1/third_party/terraform/transport/transport.go
+++ b/mmv1/third_party/terraform/transport/transport.go
@@ -387,3 +387,109 @@ func ListPages(opt ListPagesOptions) error {
 	}
 	return nil
 }
+
+func listItemAsMap(item interface{}) (map[string]interface{}, error) {
+	switch v := item.(type) {
+	case map[string]interface{}:
+		return v, nil
+	case string:
+		// Apigee keyvaluemaps list returns ["kvm1", "kvm2", ...]
+		return map[string]interface{}{"name": v}, nil
+	default:
+		return nil, fmt.Errorf("expected item to be map[string]interface{} or string, got %T", item)
+	}
+}
+
+type ListArrayPagesOptions struct {
+	Config         *Config
+	TempData       *schema.ResourceData
+	Resource       *schema.Resource
+	ListURL        string
+	BillingProject string
+	UserAgent      string
+	Flattener      func(item map[string]interface{}, d *schema.ResourceData, config *Config) error
+	Callback       func(rd *schema.ResourceData) error
+}
+
+// ListArrayPages performs a GET against ListURL where the response body is a
+// top-level JSON array (not a wrapped object). String elements are coerced to
+// {"name": value} so the same flattener path as ListPages can run.
+func ListArrayPages(opt ListArrayPagesOptions) error {
+	if opt.Config == nil || opt.Config.Client == nil {
+		return fmt.Errorf("client is nil for list request to %s", opt.ListURL)
+	}
+
+	url, err := AddQueryParams(opt.ListURL, map[string]string{})
+	if err != nil {
+		return err
+	}
+
+	reqHeaders := make(http.Header)
+	reqHeaders.Set("User-Agent", opt.UserAgent)
+	reqHeaders.Set("Content-Type", "application/json")
+	if opt.Config.UserProjectOverride && opt.BillingProject != "" {
+		if opt.BillingProject == "NO_BILLING_PROJECT_OVERRIDE" {
+			reqHeaders.Set("X-Goog-User-Project", "")
+		} else {
+			reqHeaders.Set("X-Goog-User-Project", opt.BillingProject)
+		}
+	}
+
+	var res *http.Response
+	err = Retry(RetryOptions{
+		RetryFunc: func() error {
+			u, err := AddQueryParams(url, map[string]string{"alt": "json"})
+			if err != nil {
+				return err
+			}
+			req, err := http.NewRequest("GET", u, nil)
+			if err != nil {
+				return err
+			}
+			req.Header = reqHeaders
+			res, err = opt.Config.Client.Do(req)
+			if err != nil {
+				return err
+			}
+			if err := googleapi.CheckResponse(res); err != nil {
+				googleapi.CloseBody(res)
+				return err
+			}
+			return nil
+		},
+		Timeout:              DefaultRequestTimeout,
+		ErrorRetryPredicates: []RetryErrorPredicateFunc{Is429RetryableQuotaError},
+	})
+	if err != nil {
+		return HandleListGoogleApiError(err, url)
+	}
+	if res == nil {
+		return fmt.Errorf("unable to parse server response for list at %s", url)
+	}
+	defer googleapi.CloseBody(res)
+
+	if res.StatusCode == 204 {
+		return nil
+	}
+
+	var items []interface{}
+	if err := json.NewDecoder(res.Body).Decode(&items); err != nil {
+		return fmt.Errorf("error decoding array response from %s: %w", url, err)
+	}
+
+	seedState := opt.TempData.State()
+	for _, item := range items {
+		itemMap, err := listItemAsMap(item)
+		if err != nil {
+			return err
+		}
+		itemResourceData := opt.Resource.Data(seedState)
+		if err := opt.Flattener(itemMap, itemResourceData, opt.Config); err != nil {
+			return fmt.Errorf("error flattening instance: %s", err)
+		}
+		if err := opt.Callback(itemResourceData); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Adds list-resource generation for the three Apigee resources deferred from #18432 (P-08 / P-09). Companion to #18478 (`google_apigee_addons_config`).

- **TargetServer** and **EnvironmentKeyvaluemaps** — list APIs return a bare JSON array. New `list_response_is_array` flag emits `ListArrayPages`. String items (`["kvm1", ...]`) are coerced to `{"name": ...}` so the existing KVM decoder still works on direct reads.
- **Organization** — list items use `"organization"` while identity is `"name"`. Decoder copies when `name` is empty.

`types` import in `list_resource.go.tmpl` is gated on list scope (empty `ListModel` for Organization). Same guard is in #18478.

Generation for `PRODUCT=apigee` succeeded locally. Downstream checkout was dirty so the provider binary was not compiled in-tree; acc tests not run.

```release-note:new-list-resource
`google_apigee_target_server`
```

```release-note:new-list-resource
`google_apigee_environment_keyvaluemaps`
```

```release-note:new-list-resource
`google_apigee_organization`
```
