### PR TITLE
container: add `autopilot_general_profile` field to `google_container_cluster`

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1051,6 +1051,13 @@ func ResourceContainerCluster() *schema.Resource {
 						  Optional:    true,
 						  Description: `Specifies whether default compute class behaviour is enabled. If enabled, cluster autoscaler will use Compute Class with name default for all the workloads, if not overriden.`,
 						},
+						"autopilot_general_profile": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.StringInSlice([]string{"NONE", "NO_PERFORMANCE"}, false),
+							Description:  `The Autopilot general profile for the cluster. Set to NO_PERFORMANCE to turn off Autopilot's proactive capacity provisioning, which avoids extra IP consumption at the cost of slower scale-up for general-purpose workloads. Accepted values are NONE and NO_PERFORMANCE. Only applicable to Autopilot clusters.`,
+						},
 					},
 				},
 			},
@@ -6573,6 +6580,7 @@ func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *c
 		ResourceLimits:                   resourceLimits,
 		DefaultComputeClassConfig:        defaultCCConfig,
 		AutoscalingProfile:               config["autoscaling_profile"].(string),
+		AutopilotGeneralProfile:          config["autopilot_general_profile"].(string),
 		AutoprovisioningNodePoolDefaults: defaults,
 		AutoprovisioningLocations:        tpgresource.ConvertStringArr(config["auto_provisioning_locations"].([]interface{})),
 	}
@@ -8530,6 +8538,7 @@ func flattenClusterAutoscaling(a *container.ClusterAutoscaling) []map[string]int
 	}
 	r["resource_limits"] = resourceLimits
 	r["autoscaling_profile"] = a.AutoscalingProfile
+	r["autopilot_general_profile"] = a.AutopilotGeneralProfile
 	if a.AutoprovisioningNodePoolDefaults != nil {
 		r["auto_provisioning_defaults"] = flattenAutoProvisioningDefaults(a.AutoprovisioningNodePoolDefaults)
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -108,6 +108,8 @@ fields:
     api_field: 'autoscaling.autoprovisioningNodePoolDefaults.upgradeSettings.strategy'
   - field: 'cluster_autoscaling.auto_provisioning_locations'
     api_field: 'autoscaling.autoprovisioningLocations'
+  - field: 'cluster_autoscaling.autopilot_general_profile'
+    api_field: 'autoscaling.autopilotGeneralProfile'
   - field: 'cluster_autoscaling.autoscaling_profile'
     api_field: 'autoscaling.autoscalingProfile'
   - field: 'cluster_autoscaling.default_compute_class_enabled'

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -4928,6 +4928,64 @@ resource "google_container_cluster" "primary" {
 	return res
 }
 
+func TestAccContainerCluster_withAutopilotGeneralProfile(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withAutopilotGeneralProfile(clusterName, networkName, subnetworkName, "NO_PERFORMANCE"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "cluster_autoscaling.0.autopilot_general_profile", "NO_PERFORMANCE"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "node_pool"},
+			},
+			{
+				Config: testAccContainerCluster_withAutopilotGeneralProfile(clusterName, networkName, subnetworkName, "NONE"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "cluster_autoscaling.0.autopilot_general_profile", "NONE"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "node_pool"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withAutopilotGeneralProfile(clusterName, networkName, subnetworkName, profile string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1"
+  initial_node_count  = 1
+  network             = "%s"
+  subnetwork          = "%s"
+  enable_autopilot    = true
+  deletion_protection = false
+
+  cluster_autoscaling {
+    autopilot_general_profile = "%s"
+  }
+}
+`, clusterName, networkName, subnetworkName, profile)
+}
+
 func TestAccContainerCluster_withAutopilotClusterPolicy(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -710,6 +710,11 @@ when deciding to remove nodes from a cluster. Can be `BALANCED` or `OPTIMIZE_UTI
 
 * `default_compute_class_enabled` - (Optional) Specifies whether default compute class behaviour is enabled. If enabled, cluster autoscaler will use Compute Class with name default for all the workloads, if not overriden.
 
+* `autopilot_general_profile` - (Optional) The Autopilot general profile for the cluster. Set to `NO_PERFORMANCE` to turn off
+Autopilot's [proactive capacity provisioning](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview),
+which avoids extra IP consumption at the cost of slower scale-up for general-purpose workloads.
+Accepted values are `NONE` and `NO_PERFORMANCE`. Only applicable to Autopilot clusters.
+
 <a name="nested_resource_limits"></a>The `resource_limits` block supports:
 
 * `resource_type` - (Required) The type of the resource. For example, `cpu` and


### PR DESCRIPTION
Adds support for the `ClusterAutoscaling.autopilotGeneralProfile` API field to `google_container_cluster`, exposed as `cluster_autoscaling.autopilot_general_profile`.

Setting it to `NO_PERFORMANCE` turns off Autopilot's [proactive capacity provisioning](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview), which today is only reachable via `gcloud container clusters update --autopilot-general-profile` — Terraform-managed Autopilot clusters lose the setting silently on recreate and show no drift when it changes out of band.

Implementation notes:
- The API field is GA (`v1`) and already present in the pinned `google.golang.org/api` (v0.293.0), so no dependency changes are needed.
- Modeled as Optional + Computed, since the API omits the field for clusters where it was never set; validated against the accepted values `NONE` and `NO_PERFORMANCE`.
- Updates ride the existing `cluster_autoscaling` update path (`desiredClusterAutoscaling`) — no new update handling required.
- Added an acceptance test covering create with `NO_PERFORMANCE`, update to `NONE`, and import for both.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/26958

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `cluster_autoscaling.autopilot_general_profile` field to `google_container_cluster` resource
```
