### PR TITLE
biglake: add serde_info to biglake table storage_descriptor

### DIFF
--- a/mmv1/products/biglake/Table.yaml
+++ b/mmv1/products/biglake/Table.yaml
@@ -137,3 +137,12 @@ properties:
             type: String
             description: |
               The fully qualified Java class name of the output format.
+          - name: serdeInfo
+            type: NestedObject
+            description: |
+              Serializer and deserializer information.
+            properties:
+              - name: serializationLib
+                type: String
+                description: |
+                  The fully qualified Java class name of the serialization library.

--- a/mmv1/templates/terraform/samples/services/biglake/biglake_table.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/biglake/biglake_table.tf.tmpl
@@ -45,6 +45,9 @@ resource "google_biglake_table" "{{$.PrimaryResourceId}}" {
         location_uri = "gs://${google_storage_bucket.bucket.name}/${google_storage_bucket_object.data_folder.name}"
         input_format  = "org.apache.hadoop.mapred.SequenceFileInputFormat"
         output_format = "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat"
+        serde_info {
+          serialization_lib = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+        }
       }
       # Some Example Parameters.
       parameters = {

--- a/mmv1/third_party/terraform/services/biglake/resource_biglake_table_test.go
+++ b/mmv1/third_party/terraform/services/biglake/resource_biglake_table_test.go
@@ -93,6 +93,9 @@ resource "google_biglake_table" "table" {
 		  location_uri = "gs://${google_storage_bucket.bucket.name}/${google_storage_bucket_object.data_folder.name}/data"
 		  input_format = "org.apache.hadoop.mapred.SequenceFileInputFormat2"
 		  output_format =  "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat2"
+		  serde_info {
+		    serialization_lib = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe2"
+		  }
 		}
 		# Some Example Parameters.
 		parameters = {


### PR DESCRIPTION
Add `serde_info` with `serialization_lib` to `google_biglake_table` `storage_descriptor`.

```release-note:enhancement
biglake: added `serde_info` field to `google_biglake_table` resource
```
