### PR TITLE
accesscontextmanager: add require_verified_chrome_os to access level condition and access levels

### DIFF
--- a/mmv1/products/accesscontextmanager/AccessLevelCondition.yaml
+++ b/mmv1/products/accesscontextmanager/AccessLevelCondition.yaml
@@ -203,6 +203,9 @@ properties:
                 The minimum allowed OS version. If not set, any version
                 of this OS satisfies the constraint.
                 Format: "major.minor.patch" such as "10.5.301", "9.2.1".
+            - name: requireVerifiedChromeOs
+              type: Boolean
+              description: If you specify DESKTOP_CHROME_OS for osType, you can optionally include requireVerifiedChromeOs to require Chrome Verified Access.
             - name: osType
               type: Enum
               description: |

--- a/mmv1/products/accesscontextmanager/AccessLevels.yaml
+++ b/mmv1/products/accesscontextmanager/AccessLevels.yaml
@@ -233,6 +233,9 @@ properties:
                                 The minimum allowed OS version. If not set, any version
                                 of this OS satisfies the constraint.
                                 Format: "major.minor.patch" such as "10.5.301", "9.2.1".
+                            - name: requireVerifiedChromeOs
+                              type: Boolean
+                              description: If you specify DESKTOP_CHROME_OS for osType, you can optionally include requireVerifiedChromeOs to require Chrome Verified Access.
                             - name: osType
                               type: Enum
                               description: |

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_condition_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_condition_test.go
@@ -27,25 +27,32 @@ func testAccAccessContextManagerAccessLevelCondition_basicTest(t *testing.T) {
 	serviceAccountName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	vpcName := fmt.Sprintf("test-vpc-%s", acctest.RandString(t, 10))
 
-	expected := map[string]interface{}{
-		"members": []interface{}{fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", serviceAccountName, project)},
-		"devicePolicy": map[string]interface{}{
-			"requireCorpOwned": true,
-			"osConstraints": []interface{}{
+	// requireVerifiedChromeOs is only returned by the API when it is set, so the expected
+	// condition differs between the two steps.
+	expected := func(requireVerifiedChromeOs bool) map[string]interface{} {
+		osConstraint := map[string]interface{}{
+			"osType": "DESKTOP_CHROME_OS",
+		}
+		if requireVerifiedChromeOs {
+			osConstraint["requireVerifiedChromeOs"] = true
+		}
+
+		return map[string]interface{}{
+			"members": []interface{}{fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", serviceAccountName, project)},
+			"devicePolicy": map[string]interface{}{
+				"requireCorpOwned": true,
+				"osConstraints":    []interface{}{osConstraint},
+			},
+			"regions": []interface{}{"IT", "US"},
+			"vpcNetworkSources": []interface{}{
 				map[string]interface{}{
-					"osType": "DESKTOP_CHROME_OS",
+					"vpcSubnetwork": map[string]interface{}{
+						"network":          fmt.Sprintf("//compute.googleapis.com/projects/%s/global/networks/%s", project, vpcName),
+						"vpcIpSubnetworks": []interface{}{"20.0.5.0/24"},
+					},
 				},
 			},
-		},
-		"regions": []interface{}{"IT", "US"},
-		"vpcNetworkSources": []interface{}{
-			map[string]interface{}{
-				"vpcSubnetwork": map[string]interface{}{
-					"network":          fmt.Sprintf("//compute.googleapis.com/projects/%s/global/networks/%s", project, vpcName),
-					"vpcIpSubnetworks": []interface{}{"20.0.5.0/24"},
-				},
-			},
-		},
+		}
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -54,8 +61,13 @@ func testAccAccessContextManagerAccessLevelCondition_basicTest(t *testing.T) {
 		CheckDestroy:             testAccCheckAccessContextManagerAccessLevelConditionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessContextManagerAccessLevelCondition_basic(org, "my policy", "level", serviceAccountName, vpcName),
-				Check:  testAccCheckAccessContextManagerAccessLevelConditionPresent(t, "google_access_context_manager_access_level_condition.access-level-condition", expected),
+				Config: testAccAccessContextManagerAccessLevelCondition_basic(org, "my policy", "level", serviceAccountName, vpcName, true),
+				Check:  testAccCheckAccessContextManagerAccessLevelConditionPresent(t, "google_access_context_manager_access_level_condition.access-level-condition", expected(true)),
+			},
+			{
+				// The resource is immutable, so flipping require_verified_chrome_os replaces it.
+				Config: testAccAccessContextManagerAccessLevelCondition_basic(org, "my policy", "level", serviceAccountName, vpcName, false),
+				Check:  testAccCheckAccessContextManagerAccessLevelConditionPresent(t, "google_access_context_manager_access_level_condition.access-level-condition", expected(false)),
 			},
 		},
 	})
@@ -121,7 +133,7 @@ func testAccCheckAccessContextManagerAccessLevelConditionDestroyProducer(t *test
 	}
 }
 
-func testAccAccessContextManagerAccessLevelCondition_basic(org, policyTitle, levelTitleName, saName, vpcName string) string {
+func testAccAccessContextManagerAccessLevelCondition_basic(org, policyTitle, levelTitleName, saName, vpcName string, requireVerifiedChromeOs bool) string {
 	return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
@@ -174,7 +186,7 @@ resource "google_access_context_manager_access_level_condition" "access-level-co
     require_corp_owned = true
     os_constraints {
       os_type = "DESKTOP_CHROME_OS"
-      require_verified_chrome_os = true
+      require_verified_chrome_os = %t
     }
   }
   regions = [
@@ -189,5 +201,5 @@ resource "google_access_context_manager_access_level_condition" "access-level-co
 		}
 	}
 }
-`, org, policyTitle, levelTitleName, levelTitleName, saName, vpcName)
+`, org, policyTitle, levelTitleName, levelTitleName, saName, vpcName, requireVerifiedChromeOs)
 }

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_condition_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_condition_test.go
@@ -174,6 +174,7 @@ resource "google_access_context_manager_access_level_condition" "access-level-co
     require_corp_owned = true
     os_constraints {
       os_type = "DESKTOP_CHROME_OS"
+      require_verified_chrome_os = true
     }
   }
   regions = [

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_levels_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_levels_test.go
@@ -101,6 +101,12 @@ resource "google_access_context_manager_access_levels" "test-access" {
 	  combining_function = "AND"
 	  conditions {
 	    ip_subnetworks = ["192.0.4.0/24"]
+	    device_policy {
+	      os_constraints {
+	        os_type                    = "DESKTOP_CHROME_OS"
+	        require_verified_chrome_os = true
+	      }
+	    }
 	  }
     }
   }
@@ -141,6 +147,12 @@ resource "google_access_context_manager_access_levels" "test-access" {
 	  combining_function = "AND"
 	  conditions {
 	    ip_subnetworks = ["192.0.2.0/24"]
+	    device_policy {
+	      os_constraints {
+	        os_type                    = "DESKTOP_CHROME_OS"
+	        require_verified_chrome_os = false
+	      }
+	    }
 	  }
     }
   }


### PR DESCRIPTION
`requireVerifiedChromeOs` belongs to the shared `OsConstraint` message in the Access Context Manager v1 API, so it applies to every resource that models a device policy OS constraint.

This is a followup to #4758, which I opened in May 2021 to add the field. Back then the whole product lived in a single `api.yaml` containing three separate `osConstraints` blocks, one each for `AccessLevel`, `AccessLevels`, and `AccessLevelCondition`. That PR only added the field to the `AccessLevel` block, so the other two have been missing it ever since, and the per-resource YAML split in #7068 carried the omission forward into `AccessLevels.yaml` and `AccessLevelCondition.yaml`.

The effect is that Chrome Verified Access cannot be required when device policy is managed through `google_access_context_manager_access_levels` or `google_access_context_manager_access_level_condition`. `AccessLevels.yaml` states the invariant this restores in its own header: "This is the plural of `AccessLevel`, any changes here should be made to `AccessLevel` as well". The field definition is copied verbatim from `AccessLevel.yaml`.

#4758 also added `require_verified_chrome_os = true` to `resource_access_context_manager_access_level_condition_test.go`, but to the `google_access_context_manager_access_level` dependency block rather than to the condition resource actually under test. This PR sets it on the condition resource's own `os_constraints` block, which already specifies `os_type = "DESKTOP_CHROME_OS"`. The plural resource's test has no `device_policy` block at all, so it is left unchanged rather than growing an unrelated block here.

API reference: https://cloud.google.com/access-context-manager/docs/reference/rest/v1/accessPolicies.accessLevels#OsConstraint


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
accesscontextmanager: added `require_verified_chrome_os` field to `google_access_context_manager_access_level_condition` and `google_access_context_manager_access_levels` resources
```