### PR TITLE
discoveryengine: add last_user_update_time to google_discovery_engine_license_config

### DIFF
--- a/mmv1/products/discoveryengine/LicenseConfig.yaml
+++ b/mmv1/products/discoveryengine/LicenseConfig.yaml
@@ -132,3 +132,7 @@ properties:
     type: Boolean
     description: |
       Whether the license config is for free trial.
+  - name: lastUserUpdateTime
+    type: Time
+    description: |
+      Timestamp of the most recent user-initiated update.

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_license_config_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_license_config_test.go
@@ -31,6 +31,9 @@ func TestAccDiscoveryEngineLicenseConfig_discoveryengineLicenseconfigBasicExampl
 			},
 			{
 				Config: testAccDiscoveryEngineLicenseConfig_discoveryengineLicenseconfigBasicExample_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_discovery_engine_license_config.basic", "last_user_update_time", "2026-08-19T20:00:00Z"),
+				),
 			},
 			{
 				ResourceName:            "google_discovery_engine_license_config.basic",
@@ -82,6 +85,7 @@ resource "google_discovery_engine_license_config" "basic" {
     day = 1
   }
   subscription_term = "SUBSCRIPTION_TERM_ONE_YEAR"
+  last_user_update_time = "2026-08-19T20:00:00Z"
 }
 `, context)
 }


### PR DESCRIPTION
Add `last_user_update_time` field to `google_discovery_engine_license_config`.

```release-note:enhancement
discoveryengine: added `last_user_update_time` field to `google_discovery_engine_license_config` resource
```
