### PR TITLE
vertexai: add audio_transcription to google_vertex_ai_reasoning_engine

### DIFF
--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -1280,6 +1280,42 @@ properties:
                                                 type: String
                                                 description: |-
                                                   The end offset of the video.
+                                          - name: 'audioTranscription'
+                                            type: NestedObject
+                                            description: |-
+                                              Audio (input or output) transcription. This is only set when this Part contains audio data.
+                                            properties:
+                                              - name: 'speakerLabel'
+                                                type: String
+                                                description: |-
+                                                  A label identifying the speaker of this audio segment (e.g. spk_1, spk_2). Present when diarization is set.
+                                              - name: 'text'
+                                                type: String
+                                                description: |-
+                                                  The transcription text of this audio segment.
+                                                required: true
+                                              - name: 'words'
+                                                type: Array
+                                                description: |-
+                                                  Detailed word-level transcriptions and timing details. Present when word_timestamp is set.
+                                                item_type:
+                                                  type: NestedObject
+                                                  properties:
+                                                    - name: 'endOffset'
+                                                      type: String
+                                                      diff_suppress_func: 'tpgresource.DurationDiffSuppress'
+                                                      description: |-
+                                                        End offset in time of the word relative to the start of the audio.
+                                                    - name: 'startOffset'
+                                                      type: String
+                                                      diff_suppress_func: 'tpgresource.DurationDiffSuppress'
+                                                      description: |-
+                                                        Start offset in time of the word relative to the start of the audio.
+                                                    - name: 'word'
+                                                      type: String
+                                                      description: |-
+                                                        Transcript of the word.
+                                                      required: true
                       - name: 'generatedMemories'
                         type: Array
                         description: |-

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
@@ -76,6 +76,17 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
                     output  = "pizza"
                   }
                 }
+                parts {
+                  audio_transcription {
+                    speaker_label = "spk_1"
+                    text          = "I like pepperoni pizza"
+                    words {
+                      start_offset = "0.5s"
+                      end_offset   = "1.5s"
+                      word         = "pepperoni"
+                    }
+                  }
+                }
               }
             }
           }

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -1026,6 +1026,17 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
                     data      = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
                   }
                 }
+                parts {
+                  audio_transcription {
+                    speaker_label = "spk_1"
+                    text          = "I like pepperoni pizza"
+                    words {
+                      start_offset = "0.5s"
+                      end_offset   = "1.5s"
+                      word         = "pepperoni"
+                    }
+                  }
+                }
               }
             }
           }
@@ -1142,6 +1153,17 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
                   inline_data {
                     mime_type = "image/png"
                     data      = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                  }
+                }
+                parts {
+                  audio_transcription {
+                    speaker_label = "spk_2"
+                    text          = "Remember that I prefer dark mode"
+                    words {
+                      start_offset = "1s"
+                      end_offset   = "2.5s"
+                      word         = "dark"
+                    }
                   }
                 }
               }


### PR DESCRIPTION
Adds `audio_transcription` (`speaker_label`, `text`, `words`) to `context_spec.memory_bank_config.customization_configs.generate_memories_examples.conversation_source.events.content.parts` on `google_vertex_ai_reasoning_engine`.

```release-note:enhancement
vertexai: added `audio_transcription` field to `google_vertex_ai_reasoning_engine` resource
```
