### PR TITLE
Make updatable: google_discovery_engine_search_engine search_engine_config.required_subscription_tier

### DIFF
--- a/mmv1/products/discoveryengine/SearchEngine.yaml
+++ b/mmv1/products/discoveryengine/SearchEngine.yaml
@@ -151,10 +151,9 @@ properties:
         description: |
           The required subscription tier of this engine.
 
-          They cannot be modified after engine creation. If the required subscription tier is search, user with higher license tier like assist can still access the standalone app associated with this engine.
+          If the required subscription tier is search, user with higher license tier like assist can still access the standalone app associated with this engine.
         default_from_api: true
         required: false
-        immutable: true
         enum_values:
           - SUBSCRIPTION_TIER_UNSPECIFIED
           - SUBSCRIPTION_TIER_SEARCH

--- a/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_searchengine_agentspace_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_searchengine_agentspace_basic.tf.tmpl
@@ -23,6 +23,7 @@ resource "google_discovery_engine_search_engine" "agentspace_basic" {
   features = {
     "agent-sharing-without-admin-approval" = "FEATURE_STATE_ON"
     "disable-agent-sharing"                = "FEATURE_STATE_OFF"
+    "enable-end-user-sharing-with-groups"  = "FEATURE_STATE_OFF"
   }
   knowledge_graph_config {
   }

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_search_engine_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_search_engine_test.go
@@ -83,6 +83,7 @@ resource "google_discovery_engine_search_engine" "basic" {
   features = {
     "agent-sharing-without-admin-approval" = "FEATURE_STATE_ON"
     "disable-agent-sharing" = "FEATURE_STATE_OFF"
+    "enable-end-user-sharing-with-groups" = "FEATURE_STATE_OFF"
   }
   knowledge_graph_config {
     enable_cloud_knowledge_graph = false
@@ -126,13 +127,14 @@ resource "google_discovery_engine_search_engine" "basic" {
   app_type = "APP_TYPE_INTRANET"
   search_engine_config {
     search_tier = "SEARCH_TIER_STANDARD"
-    required_subscription_tier = "SUBSCRIPTION_TIER_ENTERPRISE"
+    required_subscription_tier = "SUBSCRIPTION_TIER_SEARCH"
     search_add_ons = ["SEARCH_ADD_ON_LLM"]
   }
   features = {
     feedback = "FEATURE_STATE_OFF"
     "agent-sharing-without-admin-approval" = "FEATURE_STATE_ON"
     "disable-agent-sharing" = "FEATURE_STATE_OFF"
+    "enable-end-user-sharing-with-groups" = "FEATURE_STATE_OFF"
   }
   knowledge_graph_config {
     enable_cloud_knowledge_graph = false


### PR DESCRIPTION
Fixes b/548578892

Anrtigravity fixed some unrelated test failures at the same time, the parent field is O+C so I didn't work on them further than accepting those changes. It's a mixed-management set issue.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
discoveryengine: made `google_discovery_engine_search_engine search_engine_config.required_subscription_tier` updatable
```
