### PR TITLE
compute: add list resource support for google_compute_route

### DIFF
--- a/mmv1/products/compute/Route.yaml
+++ b/mmv1/products/compute/Route.yaml
@@ -48,6 +48,7 @@ docs:
       `next_hop_instance`.  Omit if `next_hop_instance` is specified as
       a URL.
 base_url: 'projects/{{project}}/global/routes'
+generate_list_resource: true
 has_self_link: true
 immutable: true
 mutex: 'projects/{{project}}/global/networks/{{network}}/peerings'


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/26908

## Details

Adds `generate_list_resource: true` to `google_compute_route` so that `terraform query` can enumerate compute routes via the list resource framework.

## Tests

Generated test included via `list_compute_route_generated_test.go`.

## Release Note

```release-note:enhancement
`google_compute_route`: added list resource support for `terraform query`
```