### PR TITLE
ces: add max_snippets to google_ces_tool

### DIFF
--- a/mmv1/products/ces/Tool.yaml
+++ b/mmv1/products/ces/Tool.yaml
@@ -853,6 +853,11 @@ properties:
                   type: Boolean
                   description: Whether snippets are enabled.
                   send_empty_value: true
+                - name: maxSnippets
+                  type: Integer
+                  description: |-
+                    Number of snippets to return per query.
+                    If unset, returns all snippets from the service by default.
             - name: summarizationConfig
               type: NestedObject
               description: Summarization configuration.

--- a/mmv1/templates/terraform/samples/services/ces/ces_tool_data_store_tool_engine_source_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_tool_data_store_tool_engine_source_basic.tf.tmpl
@@ -74,6 +74,10 @@ resource "google_ces_tool" "{{$.PrimaryResourceId}}" {
                 grounding_level = 3
                 disabled = false
             }
+            snippets_config {
+                enable_snippets = true
+                max_snippets    = 5
+            }
         }
 
         engine_source {

--- a/mmv1/third_party/terraform/services/ces/ces_tool_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_tool_test.go
@@ -390,6 +390,7 @@ resource "google_ces_tool" "ces_tool_data_store_tool_engine_source_basic" {
             }
             snippets_config {
                 enable_snippets = true
+                max_snippets    = 5
             }
         }
 
@@ -488,6 +489,7 @@ resource "google_ces_tool" "ces_tool_data_store_tool_engine_source_basic" {
             }
             snippets_config {
                 enable_snippets = false
+                max_snippets    = 10
             }
         }
 


### PR DESCRIPTION
Add support for `dataStoreTool.modalityConfigs.snippetsConfig.maxSnippets` in `google_ces_tool`.

```release-note:enhancement
ces: added `max_snippets` field to `google_ces_tool`
```