### PR TITLE
networksecurity: add leftover list resources

### DIFF
--- a/mmv1/products/networksecurity/AuthorizationPolicy.yaml
+++ b/mmv1/products/networksecurity/AuthorizationPolicy.yaml
@@ -19,7 +19,7 @@ references:
   guides:
   api: https://cloud.google.com/traffic-director/docs/reference/network-security/rest/v1beta1/projects.locations.authorizationPolicies
 docs:
-base_url: projects/{{project}}/locations/{{location}}/authorizationPolicies
+base_url: projects/{{project}}/locations/global/authorizationPolicies
 min_version: beta
 create_url: projects/{{project}}/locations/{{location}}/authorizationPolicies?authorizationPolicyId={{name}}
 update_mask: true

--- a/mmv1/products/networksecurity/AuthorizationPolicy.yaml
+++ b/mmv1/products/networksecurity/AuthorizationPolicy.yaml
@@ -26,6 +26,7 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/authorizationPolicies/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 30
   update_minutes: 30

--- a/mmv1/products/networksecurity/BackendAuthenticationConfig.yaml
+++ b/mmv1/products/networksecurity/BackendAuthenticationConfig.yaml
@@ -26,6 +26,7 @@ update_verb: PATCH
 sweeper:
   url_substitutions:
     - region: global
+generate_list_resource: true
 async:
   type: OpAsync
   operation:

--- a/mmv1/products/networksecurity/BackendAuthenticationConfig.yaml
+++ b/mmv1/products/networksecurity/BackendAuthenticationConfig.yaml
@@ -18,7 +18,7 @@ description: |
 references:
   guides:
     Backend mTLS: https://cloud.google.com/load-balancing/docs/backend-authenticated-tls-backend-mtls#backend-authentication-config
-base_url: projects/{{project}}/locations/{{location}}/backendAuthenticationConfigs
+base_url: projects/{{project}}/locations/global/backendAuthenticationConfigs
 self_link: projects/{{project}}/locations/{{location}}/backendAuthenticationConfigs/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/backendAuthenticationConfigs?backendAuthenticationConfigId={{name}}
 update_mask: true

--- a/mmv1/products/networksecurity/ClientTlsPolicy.yaml
+++ b/mmv1/products/networksecurity/ClientTlsPolicy.yaml
@@ -26,6 +26,7 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/clientTlsPolicies/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 30
   update_minutes: 30

--- a/mmv1/products/networksecurity/ClientTlsPolicy.yaml
+++ b/mmv1/products/networksecurity/ClientTlsPolicy.yaml
@@ -20,7 +20,7 @@ references:
     Service Security: https://cloud.google.com/traffic-director/docs/security-use-cases
   api: https://cloud.google.com/traffic-director/docs/reference/network-security/rest/v1beta1/projects.locations.clientTlsPolicies
 docs:
-base_url: projects/{{project}}/locations/{{location}}/clientTlsPolicies
+base_url: projects/{{project}}/locations/global/clientTlsPolicies
 create_url: projects/{{project}}/locations/{{location}}/clientTlsPolicies?clientTlsPolicyId={{name}}
 update_mask: true
 update_verb: PATCH

--- a/mmv1/products/networksecurity/GatewaySecurityPolicy.yaml
+++ b/mmv1/products/networksecurity/GatewaySecurityPolicy.yaml
@@ -26,6 +26,7 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 30
   update_minutes: 30

--- a/mmv1/products/networksecurity/GatewaySecurityPolicy.yaml
+++ b/mmv1/products/networksecurity/GatewaySecurityPolicy.yaml
@@ -19,7 +19,7 @@ references:
   guides:
   api: https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1/projects.locations.gatewaySecurityPolicies
 docs:
-base_url: projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies
+base_url: projects/{{project}}/locations/us-central1/gatewaySecurityPolicies
 self_link: projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/gatewaySecurityPolicies?gatewaySecurityPolicyId={{name}}
 update_mask: true

--- a/mmv1/products/networksecurity/ServerTlsPolicy.yaml
+++ b/mmv1/products/networksecurity/ServerTlsPolicy.yaml
@@ -20,7 +20,7 @@ references:
     Use ServerTlsPolicy: https://cloud.google.com/load-balancing/docs/mtls
   api: https://cloud.google.com/traffic-director/docs/reference/network-security/rest/v1beta1/projects.locations.serverTlsPolicies
 docs:
-base_url: projects/{{project}}/locations/{{location}}/serverTlsPolicies
+base_url: projects/{{project}}/locations/global/serverTlsPolicies
 create_url: projects/{{project}}/locations/{{location}}/serverTlsPolicies?serverTlsPolicyId={{name}}
 update_mask: true
 update_verb: PATCH

--- a/mmv1/products/networksecurity/ServerTlsPolicy.yaml
+++ b/mmv1/products/networksecurity/ServerTlsPolicy.yaml
@@ -26,6 +26,7 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/serverTlsPolicies/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 30
   update_minutes: 30

--- a/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
+++ b/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
@@ -26,6 +26,7 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/tlsInspectionPolicies/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 30
   update_minutes: 30

--- a/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
+++ b/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
@@ -19,7 +19,7 @@ references:
     Use TlsInspectionPolicy: https://cloud.google.com/secure-web-proxy/docs/tls-inspection-overview
   api: https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1/projects.locations.tlsInspectionPolicies
 docs:
-base_url: projects/{{project}}/locations/{{location}}/tlsInspectionPolicies
+base_url: projects/{{project}}/locations/us-central1/tlsInspectionPolicies
 self_link: projects/{{project}}/locations/{{location}}/tlsInspectionPolicies/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/tlsInspectionPolicies?tlsInspectionPolicyId={{name}}
 update_mask: true

--- a/mmv1/products/networksecurity/UrlLists.yaml
+++ b/mmv1/products/networksecurity/UrlLists.yaml
@@ -28,6 +28,7 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/urlLists/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 30
   update_minutes: 30

--- a/mmv1/products/networksecurity/UrlLists.yaml
+++ b/mmv1/products/networksecurity/UrlLists.yaml
@@ -21,7 +21,7 @@ references:
     Use UrlLists: ' https://cloud.google.com/secure-web-proxy/docs/use-url-list'
   api: https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1/projects.locations.urlLists
 docs:
-base_url: projects/{{project}}/locations/{{location}}/urlLists
+base_url: projects/{{project}}/locations/us-central1/urlLists
 self_link: projects/{{project}}/locations/{{location}}/urlLists/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/urlLists?urlListId={{name}}
 update_mask: true


### PR DESCRIPTION
Adds list-resource generation for 7 remaining eligible `networksecurity` resources dropped from #18433.

`DnsThreatDetector`, `SacAttachment`, `UllMirroringCollector`, and `UllMirroringEngine` stay out: first sample has `exclude_test: true`.

`ClientTlsPolicy` samples have `skip_vcr: true`, so magician will ask for manual verification of that list-query test.

```release-note:new-list-resource
`google_network_security_authorization_policy` (beta)
```

```release-note:new-list-resource
`google_network_security_backend_authentication_config`
```

```release-note:new-list-resource
`google_network_security_client_tls_policy`
```

```release-note:new-list-resource
`google_network_security_gateway_security_policy`
```

```release-note:new-list-resource
`google_network_security_server_tls_policy`
```

```release-note:new-list-resource
`google_network_security_tls_inspection_policy`
```

```release-note:new-list-resource
`google_network_security_url_lists`
```
