### PR TITLE
ces: add api_authentication to google_ces_tool remote_agent_tool

### DIFF
--- a/mmv1/products/ces/Tool.yaml
+++ b/mmv1/products/ces/Tool.yaml
@@ -20,7 +20,7 @@ docs:
 
     Individual tools of type `openApiTool`, `mcpTool`, `connectorTool`, and `remoteAgentTool` **cannot** be created, updated, or managed directly using the `google_ces_tool` resource.
 
-    `openApiTool`, `mcpTool`, and `connectorTool` are dynamically generated at runtime based on their corresponding **toolsets** (configured via the `google_ces_toolset` resource). `remoteAgentTool` represents A2A connections configured externally, and `systemTool` represents pre-defined platform tools managed entirely by Google Cloud.
+    `openApiTool`, `mcpTool`, and `connectorTool` are dynamically generated at runtime based on their corresponding **toolsets** (configured via the `google_ces_toolset` resource), `remoteAgentTool` represents A2A connections configured externally, and `systemTool` represents pre-defined platform tools managed entirely by Google Cloud.
 
     Consequently, blocks like `open_api_tool`, `mcp_tool`, `connector_tool`, `remote_agent_tool`, and `system_tool` are marked as **read-only (output-only)** in this resource. They are populated by the server for reference purposes only (e.g., after importing an existing tool into your state) and **cannot** be configured in your Terraform HCL configuration.
 base_url: projects/{{project}}/locations/{{location}}/apps/{{app}}/tools
@@ -1531,6 +1531,118 @@ properties:
                   output: true
                   item_type:
                     type: String
+      - name: apiAuthentication
+        type: NestedObject
+        description: Authentication information required for calling the remote agent.
+        output: true
+        properties:
+          - name: apiKeyConfig
+            type: NestedObject
+            description: Configurations for authentication with API key.
+            output: true
+            properties:
+              - name: apiKeySecretVersion
+                type: String
+                description: |-
+                  The name of the SecretManager secret version resource storing the API key.
+                  Format: `projects/{project}/secrets/{secret}/versions/{version}`
+                  Note: You should grant `roles/secretmanager.secretAccessor` role to the CES
+                  service agent
+                  `service-<PROJECT-NUMBER>@gcp-sa-ces.iam.gserviceaccount.com`.
+                output: true
+              - name: keyName
+                type: String
+                description: |-
+                  The parameter name or the header name of the API key.
+                  E.g., If the API request is "https://example.com/act?X-Api-Key=", "X-Api-Key" would be the parameter name.
+                output: true
+              - name: requestLocation
+                type: String
+                description: |-
+                  Key location in the request.
+                  Possible values:
+                  HEADER
+                  QUERY_STRING
+                output: true
+          - name: bearerTokenConfig
+            type: NestedObject
+            description: Configurations for authentication with a bearer token.
+            output: true
+            properties:
+              - name: token
+                type: String
+                description: The bearer token. Must be in the format $context.variables.<name_of_variable>.
+                output: true
+          - name: oauthConfig
+            type: NestedObject
+            description: Configurations for authentication with OAuth.
+            output: true
+            properties:
+              - name: clientId
+                type: String
+                description: The client ID from the OAuth provider.
+                output: true
+              - name: clientSecretVersion
+                type: String
+                description: |-
+                  The name of the SecretManager secret version resource storing the
+                  client secret.
+                  Format: `projects/{project}/secrets/{secret}/versions/{version}`
+                  Note: You should grant `roles/secretmanager.secretAccessor` role to the CES
+                  service agent
+                  `service-<PROJECT-NUMBER>@gcp-sa-ces.iam.gserviceaccount.com`.
+                output: true
+              - name: oauthGrantType
+                type: String
+                description: |-
+                  OAuth grant types.
+                  Possible values:
+                  CLIENT_CREDENTIAL
+                output: true
+              - name: scopes
+                type: Array
+                description: The OAuth scopes to grant.
+                output: true
+                item_type:
+                  type: String
+              - name: tokenEndpoint
+                type: String
+                description: The token endpoint in the OAuth provider to exchange for an access token.
+                output: true
+          - name: serviceAccountAuthConfig
+            type: NestedObject
+            description: Configurations for authentication using a custom service account.
+            output: true
+            properties:
+              - name: serviceAccount
+                type: String
+                description: |-
+                  The email address of the service account used for authenticatation. CES
+                  uses this service account to exchange an access token and the access token
+                  is then sent in the `Authorization` header of the request.
+                  The service account must have the
+                  `roles/iam.serviceAccountTokenCreator` role granted to the
+                  CES service agent
+                  `service-<PROJECT-NUMBER>@gcp-sa-ces.iam.gserviceaccount.com`.
+                output: true
+              - name: scopes
+                type: Array
+                description: |-
+                  The OAuth scopes to grant. If not specified, the default scope
+                  `https://www.googleapis.com/auth/cloud-platform` is used.
+                output: true
+                item_type:
+                  type: String
+          - name: serviceAgentIdTokenAuthConfig
+            type: NestedObject
+            description: |-
+              Configurations for authentication with [ID
+              token](https://cloud.google.com/docs/authentication/token-types#id) generated
+              from service agent.
+            allow_empty_object: true
+            send_empty_value: true
+            output: true
+            properties: [] # Explicitly show no properties
   - name: systemTool
     type: NestedObject
     description: The system tool.


### PR DESCRIPTION
Added `api_authentication` and its sub-fields to `remote_agent_tool` in `google_ces_tool` as output-only fields.

`remote_agent_tool` is currently output-only. Adding `api_authentication` as `output: true` allows the resource to read and flatten the full authentication configuration on imported or server-managed tools. More info at b/548697177

```release-note:enhancement
ces: added `api_authentication` field to `google_ces_tool.remote_agent_tool`
```
