### PR TITLE
Make networks in hypercomputecluster sweepable

### DIFF
--- a/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
+++ b/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
@@ -127,7 +127,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
     id = "network-default"
     config {
       new_network {
-        network = "projects/${local.project_id}/global/networks/net-%{random_suffix}"
+        network = "projects/${local.project_id}/global/networks/tf-test-%{random_suffix}"
       }
     }
   }
@@ -224,7 +224,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
     id = "network-default"
     config {
       new_network {
-        network = "projects/${local.project_id}/global/networks/net-%{random_suffix}"
+        network = "projects/${local.project_id}/global/networks/tf-test-%{random_suffix}"
       }
     }
   }
@@ -307,13 +307,13 @@ locals {
 }
 
 resource "google_compute_network" "vpc" {
-  name                    = "existing-net-%{random_suffix}"
+  name                    = "tf-test-existing-net-%{random_suffix}"
   auto_create_subnetworks = false
   routing_mode            = "REGIONAL"
 }
 
 resource "google_compute_subnetwork" "subnet" {
-  name          = "existing-subnet-%{random_suffix}"
+  name          = "tf-test-existing-subnet-%{random_suffix}"
   ip_cidr_range = "10.0.1.0/24"
   region        = "us-central1"
   network       = google_compute_network.vpc.id
@@ -347,7 +347,7 @@ resource "google_filestore_instance" "filestore_instance" {
     name        = "share"
   }
   networks {
-    network = "existing-net-%{random_suffix}"
+    network = "tf-test-existing-net-%{random_suffix}"
     modes   = ["MODE_IPV4"]
   }
   depends_on = [google_compute_network.vpc] 
@@ -497,7 +497,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
     config {
       new_network {
         description = "Network one"
-        network = "projects/${local.project_id}/global/networks/net-%{random_suffix}"
+        network = "projects/${local.project_id}/global/networks/tf-test-%{random_suffix}"
       }
     }
   }
@@ -691,7 +691,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
     id = "network-default"
     config {
       new_network {
-        network = "projects/${local.project_id}/global/networks/net-ipu-%{random_suffix}"
+        network = "projects/${local.project_id}/global/networks/tf-test-ipu-%{random_suffix}"
       }
     }
   }
@@ -755,7 +755,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
     id = "network-default"
     config {
       new_network {
-        network = "projects/${local.project_id}/global/networks/net-ipu-%{random_suffix}"
+        network = "projects/${local.project_id}/global/networks/tf-test-ipu-%{random_suffix}"
       }
     }
   }


### PR DESCRIPTION
Updated network names in test cases to use 'tf-test' prefix to allow the sweepers to recognize and delete orphans.

```release-note:none

```
