### PR TITLE
Add Observability Bucket Resource

### DIFF
--- a/mmv1/products/observability/Bucket.yaml
+++ b/mmv1/products/observability/Bucket.yaml
@@ -1,0 +1,108 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Bucket
+description: Bucket configuration for storing observability data.
+base_url: projects/{{project}}/locations/{{location}}/buckets
+min_version: beta
+self_link: projects/{{project}}/locations/{{location}}/buckets/{{bucket_id}}
+create_url: projects/{{project}}/locations/{{location}}/buckets?bucketId={{bucket_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/buckets/{{bucket_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/buckets/{{bucket_id}}
+async:
+  operation:
+    timeouts:
+      insert_minutes: 10
+      update_minutes: 10
+      delete_minutes: 20
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: true
+exclude_delete: true
+autogen_async: true
+custom_code:
+  pre_create: templates/terraform/pre_create/observability_bucket.go.tmpl
+samples:
+  # name is used to generate the test name.
+  - name: "observability_bucket_basic"
+    # primary_resource_id will be used for the Terraform resource id in the configuration file.
+    primary_resource_id: "primary"
+    steps:
+      # The first step defines the initial create configuration.
+      # Step name: Matches the template file name by default (for example, pubsub_topic_minimal.tf.tmpl). Use config_path to override this.
+      - name: "observability_bucket_basic"
+        test_env_vars:
+          project_name: PROJECT_NAME
+parameters:
+  - name: location
+    type: String
+    description: The location of the bucket.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: bucketId
+    type: String
+    description: A client-assigned identifier for the bucket.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: cmekSettings
+    type: NestedObject
+    description: Settings for configuring CMEK for a bucket.
+    properties:
+      - name: kmsKey
+        type: String
+        description: |-
+          The resource name for the configured Cloud KMS key. The format is: projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]
+      - name: kmsKeyVersion
+        type: String
+        description: The CryptoKeyVersion resource name for the configured Cloud KMS key.
+        output: true
+      - name: serviceAccountId
+        type: String
+        description: The service account used to access the key.
+        output: true
+  - name: createTime
+    type: String
+    description: Output only. Create timestamp.
+    output: true
+  - name: deleteTime
+    type: String
+    description: Output only. Delete timestamp.
+    output: true
+  - name: description
+    type: String
+    description: Description of the bucket.
+    default_from_api: true
+  - name: displayName
+    type: String
+    description: User friendly display name.
+    default_from_api: true
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the bucket. The format is: projects/[PROJECT_ID]/locations/[LOCATION]/buckets/[BUCKET_ID]
+    output: true
+  - name: purgeTime
+    type: String
+    description: Output only. Timestamp when the bucket in soft-deleted state is purged.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. Update timestamp.
+    output: true

--- a/mmv1/products/observability/Bucket.yaml
+++ b/mmv1/products/observability/Bucket.yaml
@@ -85,7 +85,8 @@ properties:
           The resource name for the configured Cloud KMS key. The format is: projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]
       - name: kmsKeyVersion
         type: String
-        description: The CryptoKeyVersion resource name for the configured Cloud KMS key.
+        description: |-
+          The CryptoKeyVersion resource name for the configured Cloud KMS key. The format is: projects/[PROJECT_ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY]/cryptoKeyVersions/[VERSION]
         output: true
       - name: serviceAccountId
         type: String

--- a/mmv1/products/observability/Bucket.yaml
+++ b/mmv1/products/observability/Bucket.yaml
@@ -43,18 +43,20 @@ samples:
     steps:
       - name: "observability_bucket_basic"
         test_env_vars:
-          project_name: PROJECT_NAME
+          org_id: ORG_ID
+          billing_account: BILLING_ACCT
         test_vars_overrides:
-          kms_key: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key1").CryptoKey.Name
+          kms_key: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-east1", "tf-bootstrap-observability-key1").CryptoKey.Name
         vars:
           display_name: "Initial Display Name"
           description: "Initial description"
           kms_key: example-key-1
       - name: "observability_bucket_basic"
         test_env_vars:
-          project_name: PROJECT_NAME
+          org_id: ORG_ID
+          billing_account: BILLING_ACCT
         test_vars_overrides:
-          kms_key: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key2").CryptoKey.Name
+          kms_key: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-east1", "tf-bootstrap-observability-key2").CryptoKey.Name
         vars:
           display_name: "Updated Display Name"
           description: "Updated description"

--- a/mmv1/products/observability/Bucket.yaml
+++ b/mmv1/products/observability/Bucket.yaml
@@ -42,33 +42,23 @@ samples:
     external_providers: [time]
     steps:
       - name: "observability_bucket_basic"
-        resource_id_vars:
-          kms_key_name_1: example-key-1
-          kms_key_name_2: example-key-2
-        test_vars_overrides:
-          kms_key_name_1: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key1").CryptoKey.Name
-          kms_key_name_2: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key2").CryptoKey.Name
-          kms_key_name: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key1").CryptoKey.Name
         test_env_vars:
           project_name: PROJECT_NAME
+        test_vars_overrides:
+          kms_key: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key1").CryptoKey.Name
         vars:
           display_name: "Initial Display Name"
           description: "Initial description"
-          kms_key_name: example-key-1
+          kms_key: example-key-1
       - name: "observability_bucket_basic"
-        resource_id_vars:
-          kms_key_name_1: example-key-1
-          kms_key_name_2: example-key-2
-        test_vars_overrides:
-          kms_key_name_1: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key1").CryptoKey.Name
-          kms_key_name_2: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key2").CryptoKey.Name
-          kms_key_name: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key2").CryptoKey.Name
         test_env_vars:
           project_name: PROJECT_NAME
+        test_vars_overrides:
+          kms_key: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key2").CryptoKey.Name
         vars:
           display_name: "Updated Display Name"
           description: "Updated description"
-          kms_key_name: example-key-2
+          kms_key: example-key-2
 parameters:
   - name: location
     type: String

--- a/mmv1/products/observability/Bucket.yaml
+++ b/mmv1/products/observability/Bucket.yaml
@@ -37,16 +37,38 @@ autogen_async: true
 custom_code:
   pre_create: templates/terraform/pre_create/observability_bucket.go.tmpl
 samples:
-  # name is used to generate the test name.
   - name: "observability_bucket_basic"
-    # primary_resource_id will be used for the Terraform resource id in the configuration file.
     primary_resource_id: "primary"
+    external_providers: [time]
     steps:
-      # The first step defines the initial create configuration.
-      # Step name: Matches the template file name by default (for example, pubsub_topic_minimal.tf.tmpl). Use config_path to override this.
       - name: "observability_bucket_basic"
+        resource_id_vars:
+          kms_key_name_1: example-key-1
+          kms_key_name_2: example-key-2
+        test_vars_overrides:
+          kms_key_name_1: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key1").CryptoKey.Name
+          kms_key_name_2: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key2").CryptoKey.Name
+          kms_key_name: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key1").CryptoKey.Name
         test_env_vars:
           project_name: PROJECT_NAME
+        vars:
+          display_name: "Initial Display Name"
+          description: "Initial description"
+          kms_key_name: example-key-1
+      - name: "observability_bucket_basic"
+        resource_id_vars:
+          kms_key_name_1: example-key-1
+          kms_key_name_2: example-key-2
+        test_vars_overrides:
+          kms_key_name_1: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key1").CryptoKey.Name
+          kms_key_name_2: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key2").CryptoKey.Name
+          kms_key_name: kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-observability-key2").CryptoKey.Name
+        test_env_vars:
+          project_name: PROJECT_NAME
+        vars:
+          display_name: "Updated Display Name"
+          description: "Updated description"
+          kms_key_name: example-key-2
 parameters:
   - name: location
     type: String

--- a/mmv1/templates/terraform/pre_create/observability_bucket.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/observability_bucket.go.tmpl
@@ -1,0 +1,26 @@
+// Check if the Observability Bucket already exists. Do an update if so.
+
+getUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ObservabilityBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/buckets/{{"{{"}}bucket_id{{"}}"}}")
+if err != nil {
+	return err
+}
+_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    getUrl,
+	UserAgent: userAgent,
+	Headers:   headers,
+})
+
+if err == nil {
+	// Observability Bucket already exists
+	log.Printf("[DEBUG] Observability Bucket already exists %s", d.Get("bucket_id"))
+	// Replace import id for the resource id
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/buckets/{{"{{"}}bucket_id{{"}}"}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return resourceObservabilityBucketUpdate(d, meta)
+}

--- a/mmv1/templates/terraform/samples/services/observability/observability_bucket_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/observability/observability_bucket_basic.tf.tmpl
@@ -1,6 +1,65 @@
+resource "google_project_service" "observability_api" {
+  provider           = "google-beta"
+  project            = "%{project_name}"
+  service            = "observability.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Actively force the creation of the Service Agent identity
+resource "google_project_service_identity" "observability_sa" {
+  provider = "google-beta"
+  project  = "%{project_name}"
+  service  = "observability.googleapis.com"
+
+  depends_on = [
+    google_project_service.observability_api
+  ]
+}
+
+# Short buffer for the new identity to propagate to global IAM indexes
+resource "time_sleep" "wait_for_sa_propagation" {
+  create_duration = "30s"
+  depends_on      = [
+    google_project_service_identity.observability_sa
+  ]
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key_1" {
+  provider      = "google-beta"
+  crypto_key_id = "%{kms_key_name_1}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_project_service_identity.observability_sa.email}"
+
+  depends_on = [
+    time_sleep.wait_for_sa_propagation
+  ]
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key_2" {
+  provider      = "google-beta"
+  crypto_key_id = "%{kms_key_name_2}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_project_service_identity.observability_sa.email}"
+
+  depends_on = [
+    time_sleep.wait_for_sa_propagation
+  ]
+}
+
 resource "google_observability_bucket" "primary" {
   provider     = "google-beta"
   bucket_id    = "_Trace"
   location     = "us"
   project      = "%{project_name}"
+  display_name = "%{display_name}"
+  description  = "%{description}"
+
+  cmek_settings {
+    kms_key = "%{kms_key_name}"
+  }
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.crypto_key_1,
+    google_kms_crypto_key_iam_member.crypto_key_2
+  ]
 }

--- a/mmv1/templates/terraform/samples/services/observability/observability_bucket_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/observability/observability_bucket_basic.tf.tmpl
@@ -1,0 +1,6 @@
+resource "google_observability_bucket" "primary" {
+  provider     = "google-beta"
+  bucket_id    = "_Trace"
+  location     = "us"
+  project      = "%{project_name}"
+}

--- a/mmv1/templates/terraform/samples/services/observability/observability_bucket_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/observability/observability_bucket_basic.tf.tmpl
@@ -24,20 +24,9 @@ resource "time_sleep" "wait_for_sa_propagation" {
   ]
 }
 
-resource "google_kms_crypto_key_iam_member" "crypto_key_1" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   provider      = "google-beta"
-  crypto_key_id = "%{kms_key_name_1}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${google_project_service_identity.observability_sa.email}"
-
-  depends_on = [
-    time_sleep.wait_for_sa_propagation
-  ]
-}
-
-resource "google_kms_crypto_key_iam_member" "crypto_key_2" {
-  provider      = "google-beta"
-  crypto_key_id = "%{kms_key_name_2}"
+  crypto_key_id = "%{kms_key}"
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = "serviceAccount:${google_project_service_identity.observability_sa.email}"
 
@@ -55,11 +44,10 @@ resource "google_observability_bucket" "primary" {
   description  = "%{description}"
 
   cmek_settings {
-    kms_key = "%{kms_key_name}"
+    kms_key = "%{kms_key}"
   }
 
   depends_on = [
-    google_kms_crypto_key_iam_member.crypto_key_1,
-    google_kms_crypto_key_iam_member.crypto_key_2
+    google_kms_crypto_key_iam_member.crypto_key
   ]
 }

--- a/mmv1/templates/terraform/samples/services/observability/observability_bucket_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/observability/observability_bucket_basic.tf.tmpl
@@ -1,6 +1,15 @@
+resource "google_project" "project" {
+  provider        = "google-beta"
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
 resource "google_project_service" "observability_api" {
   provider           = "google-beta"
-  project            = "%{project_name}"
+  project            = google_project.project.project_id
   service            = "observability.googleapis.com"
   disable_on_destroy = false
 }
@@ -8,7 +17,7 @@ resource "google_project_service" "observability_api" {
 # Actively force the creation of the Service Agent identity
 resource "google_project_service_identity" "observability_sa" {
   provider = "google-beta"
-  project  = "%{project_name}"
+  project  = google_project.project.project_id
   service  = "observability.googleapis.com"
 
   depends_on = [
@@ -38,8 +47,8 @@ resource "google_kms_crypto_key_iam_member" "crypto_key" {
 resource "google_observability_bucket" "primary" {
   provider     = "google-beta"
   bucket_id    = "_Trace"
-  location     = "us"
-  project      = "%{project_name}"
+  location     = "us-east1"
+  project      = google_project.project.project_id
   display_name = "%{display_name}"
   description  = "%{description}"
 


### PR DESCRIPTION
**Description:**

This PR introduces the `google_observability_bucket` resource to Magic Modules for the `google-beta` provider, part of the Observability API surface for customers to manage observability resources.

A few notes for context:
- There can only be one Observability bucket per project
- That bucket must have a `bucket_id` of `_Trace`; that is the only id allowed.
- There is currently no publicly accessible `DELETE` method for buckets; once it's been created it cannot be deleted.
- Creating the Observability `_Trace` bucket automatically creates the `Spans` dataset; that is the only dataset name currently allowed.

**Fixes:** [b/547897016](https://b.corp.google.com/issues/547897016)

> [!NOTE]  
> Escalation approved in [b/546650516](https://b.corp.google.com/issues/546650516)

**Release Note**

```release-note:new-resource
`google_observability_bucket` (beta)
```
