### PR TITLE
fix(resourcemanager): retry default network deletion

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -264,12 +264,9 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 			return errwrap.Wrapf("Error enabling the Compute Engine API required to delete the default network: {{err}} ", err)
 		}
 
-		err = forceDeleteComputeNetwork(d, config, project.ProjectId, "default")
-		// Retry if API is not yet enabled.
-		if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 403) {
-			time.Sleep(15 * time.Second)
-			err = forceDeleteComputeNetwork(d, config, project.ProjectId, "default")
-		}
+		err = retryProjectDefaultNetworkDeletion(func() error {
+			return forceDeleteComputeNetwork(d, config, project.ProjectId, "default")
+		}, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
 				log.Printf("[DEBUG] Default network not found for project %q, no need to delete it", project.ProjectId)
@@ -279,6 +276,18 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 	return nil
+}
+
+func retryProjectDefaultNetworkDeletion(deleteNetwork func() error, timeout time.Duration) error {
+	return transport_tpg.Retry(transport_tpg.RetryOptions{
+		RetryFunc: deleteNetwork,
+		Timeout:   timeout,
+		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{
+			func(err error) (bool, string) {
+				return transport_tpg.IsApiNotEnabledError(err), "Compute Engine API enablement is still propagating"
+			},
+		},
+	})
 }
 
 func resourceGoogleProjectCheckPreRequisites(config *transport_tpg.Config, d *schema.ResourceData, userAgent string) error {

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_internal_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_internal_test.go
@@ -3,11 +3,46 @@ package resourcemanager
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/googleapi"
 )
+
+func TestRetryProjectDefaultNetworkDeletion_RetriesApiNotEnabled(t *testing.T) {
+	attempts := 0
+	err := retryProjectDefaultNetworkDeletion(func() error {
+		attempts++
+		if attempts < 3 {
+			return &googleapi.Error{Code: 403, Errors: []googleapi.ErrorItem{{Reason: "accessNotConfigured"}}}
+		}
+		return nil
+	}, 5*time.Second)
+
+	if err != nil {
+		t.Fatalf("retryProjectDefaultNetworkDeletion() returned error: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 deletion attempts, got %d", attempts)
+	}
+}
+
+func TestRetryProjectDefaultNetworkDeletion_DoesNotRetryOther403(t *testing.T) {
+	attempts := 0
+	err := retryProjectDefaultNetworkDeletion(func() error {
+		attempts++
+		return &googleapi.Error{Code: 403}
+	}, time.Second)
+
+	if err == nil {
+		t.Fatal("retryProjectDefaultNetworkDeletion() returned nil, want error")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 deletion attempt, got %d", attempts)
+	}
+}
 
 func TestPopulateGoogleProjectResourceData_DoesNotCopyAllLabelsToTerraformLabelsWhenUnset(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, ResourceGoogleProject().Schema, map[string]interface{}{


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Retries default network deletion while Compute Engine API activation propagates. Other 403 responses still fail immediately.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21953

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
resourcemanager: fixed intermittent `google_project` creation failures when `auto_create_network` is false
```
