### PR TITLE
compute: make custom_learned_ip_ranges on google_compute_router_peer a set

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.tmpl
@@ -293,6 +293,38 @@ func TestAccComputeRouterPeer_UpdateRouterCustomLearnedRoutePriority(t *testing.
 	})
 }
 
+func TestAccComputeRouterPeer_customLearnedIpRangesOrder(t *testing.T) {
+	t.Parallel()
+	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	resourceName := "google_compute_router_peer.peer"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterPeerCustomLearnedIpRanges(routerName, []string{"10.1.0.0/24", "10.2.0.0/24"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "custom_learned_ip_ranges.#", "2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set", "zero_custom_learned_route_priority"},
+			},
+			{
+				// The API keeps the ranges in the order it received them. The same
+				// set in another order must not plan a change.
+				Config:             testAccComputeRouterPeerCustomLearnedIpRanges(routerName, []string{"10.2.0.0/24", "10.1.0.0/24"}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccComputeRouterPeer_UpdateRouterAdvertisedRoutePriority(t *testing.T) {
 	t.Parallel()
 	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
@@ -1176,6 +1208,47 @@ resource "google_compute_router_peer" "peer" {
   zero_custom_learned_route_priority = %t
 }
   `, routerName, routerName, routerName, routerName, customLearnedRoutePriority, zeroCustomLearnedRoutePriority)
+}
+
+func testAccComputeRouterPeerCustomLearnedIpRanges(routerName string, ranges []string) string {
+	blocks := ""
+	for _, r := range ranges {
+		blocks += fmt.Sprintf(`
+  custom_learned_ip_ranges {
+    range = "%s"
+  }`, r)
+	}
+	return fmt.Sprintf(`
+resource "google_compute_network" "network" {
+  name                    = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "%s-sub"
+  network       = google_compute_network.network.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "router" {
+  name    = "%s-router"
+  region  = google_compute_subnetwork.subnetwork.region
+  network = google_compute_network.network.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_peer" "peer" {
+  name      = "%s-router-peer"
+  router    = google_compute_router.router.name
+  region    = google_compute_router.router.region
+  interface = "interface-1"
+  peer_asn  = 65513
+%s
+}
+  `, routerName, routerName, routerName, routerName, blocks)
 }
 
 func testAccComputeRouterPeerKeepRouter(routerName string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
@@ -141,20 +141,11 @@ length, the routes with the lowest priority value win.`,
 				Description: "An internal boolean field for provider use for zero_advertised_route_priority.",
 			},
 			"custom_learned_ip_ranges": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Description: `The custom learned route IP address range. Must be a valid CIDR-formatted prefix. If an 
 IP address is provided without a subnet mask, it is interpreted as, for IPv4, a /32 singular IP address range, and, for IPv6, /128.`,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"range": {
-							Type:     schema.TypeString,
-							Required: true,
-							Description: `The IP range to learn. The value must be a
-CIDR-formatted string.`,
-						},
-					},
-				},
+				Elem: computeRouterBgpPeerCustomLearnedIpRangesSchema(),
 			},
 			"custom_learned_route_priority": {
 				Type:     schema.TypeInt,
@@ -394,6 +385,19 @@ CIDR-formatted string.`,
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: `User-specified description for the IP range.`,
+			},
+		},
+	}
+}
+
+func computeRouterBgpPeerCustomLearnedIpRangesSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"range": {
+				Type:     schema.TypeString,
+				Required: true,
+				Description: `The IP range to learn. The value must be a
+CIDR-formatted string.`,
 			},
 		},
 	}
@@ -1202,16 +1206,15 @@ func flattenNestedComputeRouterBgpPeerCustomLearnedIpRanges(v interface{}, d *sc
 		return v
 	}
 	l := v.([]interface{})
-	transformed := make([]interface{}, 0, len(l))
+	transformed := schema.NewSet(schema.HashResource(computeRouterBgpPeerCustomLearnedIpRangesSchema()), []interface{}{})
 	for _, raw := range l {
 		original := raw.(map[string]interface{})
 		if len(original) < 1 {
 			// Do not include empty json objects coming back from the api
 			continue
 		}
-		transformed = append(transformed, map[string]interface{}{
-			"range":       flattenNestedComputeRouterBgpPeerCustomLearnedIpRangesRange(original["range"], d, config),
-	
+		transformed.Add(map[string]interface{}{
+			"range": flattenNestedComputeRouterBgpPeerCustomLearnedIpRangesRange(original["range"], d, config),
 		})
 	}
 	return transformed
@@ -1451,6 +1454,7 @@ func expandNestedComputeRouterBgpPeerAdvertisedIpRangesDescription(v interface{}
 	return v, nil
 }
 func expandNestedComputeRouterBgpPeerCustomLearnedIpRanges(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	v = v.(*schema.Set).List()
 	l := v.([]interface{})
 	req := make([]interface{}, 0, len(l))
 	for _, raw := range l {


### PR DESCRIPTION
`google_compute_router_peer.custom_learned_ip_ranges` is a `TypeList`, but the Compute API treats the ranges as an unordered collection (all of them share `custom_learned_route_priority`) and returns them in whatever order it last received them. When another client writes the same ranges in a different order (for example `gcloud compute routers update-bgp-peer --set-custom-learned-route-ranges`, which sorts the list), the provider plans an in-place update that changes nothing:

```
~ custom_learned_ip_ranges {
    ~ range = "2001:db8::/125" -> "2607:6bc0:2::/64"
  }
~ custom_learned_ip_ranges {
    ~ range = "2607:6bc0:2::/64" -> "2001:db8::/125"
  }
```

This changes the field to a `TypeSet`, mirroring `advertised_ip_ranges` on the same resource (schema, expander, flattener). Per the breaking-changes guidance, List → Set is allowed in a minor release when the field is unordered and the API's order is not stable, which is the case here.

Adds `TestAccComputeRouterPeer_customLearnedIpRangesOrder`: applies two ranges, import-verifies, then plans the same two ranges in the other order with `PlanOnly` and expects no change.

Verified: pre-gen static checks pass; GA provider generated and `google/services/compute` builds; the test package compiles.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed a perma-diff on `custom_learned_ip_ranges` in `google_compute_router_peer` when the API returns the ranges in a different order; the field is now a set
```