### PR TITLE
networkservices: add `forward_attributes` to `google_network_services_authz_extension`

### DIFF
--- a/mmv1/products/networkservices/AuthzExtension.yaml
+++ b/mmv1/products/networkservices/AuthzExtension.yaml
@@ -162,6 +162,17 @@ properties:
       List of the HTTP headers to forward to the extension (from the client). If omitted, all headers are sent. Each element is a string indicating the header name.
     item_type:
       type: String
+  - name: 'forwardAttributes'
+    type: Array
+    description: |
+      List of the Envoy attributes to forward to the extension server. The attributes
+      provided here are included as part of the `ProcessingRequest.attributes` field
+      (of type `map`), where the keys are the attribute names. Refer to the
+      [documentation](https://cloud.google.com/service-extensions/docs/attributes)
+      for the names of attributes that can be forwarded. If omitted, no attributes
+      are sent. Each element is a string indicating the attribute name.
+    item_type:
+      type: String
   - name: 'wireFormat'
     type: Enum
     description: |

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_authz_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_authz_extension_test.go
@@ -162,6 +162,7 @@ resource "google_network_services_authz_extension" "default" {
   timeout               = "0.1s"
   fail_open             = false
   forward_headers       = ["Authorization"]
+  forward_attributes    = ["request.host", "request.path"]
 }
 `, context)
 }
@@ -281,6 +282,7 @@ resource "google_network_services_authz_extension" "default" {
   timeout               = "0.1s"
   fail_open             = false
   forward_headers       = ["Authorization"]
+  forward_attributes    = ["request.host", "request.path", "request.scheme"]
 
   metadata = {
     forwarding_rule_id = google_compute_forwarding_rule.default.id


### PR DESCRIPTION
### Description
Adds support for the `forward_attributes` (API: `forwardAttributes`) field to `google_network_services_authz_extension`.

`forward_attributes` allows users to specify a list of Envoy attributes (up to 16) forwarded to the callout extension server in the `ProcessingRequest.attributes` map field.

### Affected Resource(s)
- `google_network_services_authz_extension`

### Tests
- Updated acceptance test `TestAccNetworkServicesAuthzExtension_update` to cover create and update of `forward_attributes`.
- Ran `make test` in `mmv1`.

**Release Note Template**

```release-note:enhancement
networkservices: added `forward_attributes` field to `google_network_services_authz_extension`
```
