### PR TITLE
bigquerydatatransfer:  add state upgrader for `Int -> String` type conversion of `secret_access_key_wo_version` field

### DIFF
--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -34,6 +34,8 @@ timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+schema_version: 1
+state_upgraders: true
 custom_code:
   constants: 'templates/terraform/constants/bigquery_data_transfer.go.tmpl'
   encoder: 'templates/terraform/encoders/bigquery_data_transfer.go.tmpl'

--- a/mmv1/templates/terraform/state_migrations/bigquery_data_transfer_config.go.tmpl
+++ b/mmv1/templates/terraform/state_migrations/bigquery_data_transfer_config.go.tmpl
@@ -1,18 +1,134 @@
 func resourceBigqueryDataTransferConfigResourceV0() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
+			"data_source_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"params": {
+				Type:     schema.TypeMap,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"data_refresh_window_days": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"destination_dataset_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"disabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"email_preferences": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_failure_email": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
+			"encryption_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kms_key_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"location": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "US",
+			},
+			"notification_pubsub_topic": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"schedule": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"schedule_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"disable_auto_scheduling": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"end_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"start_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"sensitive_params": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"secret_access_key": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
+						"secret_access_key_wo": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"secret_access_key_wo_version": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
 					},
 				},
+			},
+			"service_account_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"deletion_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 		},
 		UseJSONNumber: true,

--- a/mmv1/templates/terraform/state_migrations/bigquery_data_transfer_config.go.tmpl
+++ b/mmv1/templates/terraform/state_migrations/bigquery_data_transfer_config.go.tmpl
@@ -1,0 +1,82 @@
+func resourceBigqueryDataTransferConfigResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"sensitive_params": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"secret_access_key": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
+						"secret_access_key_wo": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"secret_access_key_wo_version": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+		UseJSONNumber: true,
+	}
+}
+
+func ResourceBigqueryDataTransferConfigUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", rawState)
+	// sensitive_params.secret_access_key_wo_version was originally TypeInt.
+	// The field was changed to TypeString with no default. The old zero value of
+	// 0 maps to "" (unset) so that resources that never explicitly set the
+	// version see no update-in-place after upgrading. Non-zero values are
+	// preserved as their decimal string equivalent.
+	// UseJSONNumber is set on this resource, so numbers arrive as json.Number.
+	raw, ok := rawState["sensitive_params"]
+	if !ok || raw == nil {
+		log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
+		return rawState, nil
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
+		return rawState, nil
+	}
+	for _, item := range list {
+		m, ok := item.(map[string]interface{})
+		if !ok || m == nil {
+			continue
+		}
+		v, exists := m["secret_access_key_wo_version"]
+		if !exists {
+			continue
+		}
+		m["secret_access_key_wo_version"] = convertSecretAccessKeyWoVersionToString(v)
+	}
+	log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
+	return rawState, nil
+}
+
+func convertSecretAccessKeyWoVersionToString(v interface{}) string {
+	intVal := int64(0)
+	switch typed := v.(type) {
+	case json.Number:
+		intVal, _ = typed.Int64()
+	case float64:
+		intVal = int64(typed)
+	case int:
+		intVal = int64(typed)
+	case int64:
+		intVal = typed
+	case string:
+		return typed
+	}
+	if intVal == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", intVal)
+}

--- a/mmv1/templates/terraform/state_migrations/bigquery_data_transfer_config.go.tmpl
+++ b/mmv1/templates/terraform/state_migrations/bigquery_data_transfer_config.go.tmpl
@@ -7,15 +7,6 @@ func resourceBigqueryDataTransferConfigResourceV0() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"secret_access_key": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Sensitive: true,
-						},
-						"secret_access_key_wo": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
 						"secret_access_key_wo_version": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -36,47 +27,24 @@ func ResourceBigqueryDataTransferConfigUpgradeV0(_ context.Context, rawState map
 	// version see no update-in-place after upgrading. Non-zero values are
 	// preserved as their decimal string equivalent.
 	// UseJSONNumber is set on this resource, so numbers arrive as json.Number.
-	raw, ok := rawState["sensitive_params"]
-	if !ok || raw == nil {
-		log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
-		return rawState, nil
-	}
-	list, ok := raw.([]interface{})
-	if !ok {
-		log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
-		return rawState, nil
-	}
-	for _, item := range list {
-		m, ok := item.(map[string]interface{})
-		if !ok || m == nil {
-			continue
+	if params, ok := rawState["sensitive_params"].([]interface{}); ok && len(params) > 0 {
+		if m, ok := params[0].(map[string]interface{}); ok {
+			intVal := int64(0)
+			switch v := m["secret_access_key_wo_version"].(type) {
+			case json.Number:
+				intVal, _ = v.Int64()
+			case float64:
+				intVal = int64(v)
+			case int:
+				intVal = int64(v)
+			}
+			if intVal == 0 {
+				m["secret_access_key_wo_version"] = ""
+			} else {
+				m["secret_access_key_wo_version"] = fmt.Sprintf("%d", intVal)
+			}
 		}
-		v, exists := m["secret_access_key_wo_version"]
-		if !exists {
-			continue
-		}
-		m["secret_access_key_wo_version"] = convertSecretAccessKeyWoVersionToString(v)
 	}
 	log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
 	return rawState, nil
-}
-
-func convertSecretAccessKeyWoVersionToString(v interface{}) string {
-	intVal := int64(0)
-	switch typed := v.(type) {
-	case json.Number:
-		intVal, _ = typed.Int64()
-	case float64:
-		intVal = int64(typed)
-	case int:
-		intVal = int64(typed)
-	case int64:
-		intVal = typed
-	case string:
-		return typed
-	}
-	if intVal == 0 {
-		return ""
-	}
-	return fmt.Sprintf("%d", intVal)
 }

--- a/mmv1/third_party/terraform/services/bigquerydatatransfer/resource_bigquery_data_transfer_config_test.go
+++ b/mmv1/third_party/terraform/services/bigquerydatatransfer/resource_bigquery_data_transfer_config_test.go
@@ -1,14 +1,7 @@
 package bigquerydatatransfer_test
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"reflect"
-	"strings"
-	"testing"
-	"time"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -19,69 +12,10 @@ import (
 	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"strings"
+	"testing"
+	"time"
 )
-
-func TestBigqueryDataTransferConfigStateUpgradeV0(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		Attributes map[string]interface{}
-		Expected   map[string]interface{}
-	}{
-		"zero int becomes unset": {
-			Attributes: map[string]interface{}{
-				"sensitive_params": []interface{}{
-					map[string]interface{}{
-						"secret_access_key_wo_version": 0,
-					},
-				},
-			},
-			Expected: map[string]interface{}{
-				"sensitive_params": []interface{}{
-					map[string]interface{}{
-						"secret_access_key_wo_version": "",
-					},
-				},
-			},
-		},
-		"nonzero int becomes decimal string": {
-			Attributes: map[string]interface{}{
-				"sensitive_params": []interface{}{
-					map[string]interface{}{
-						"secret_access_key_wo_version": json.Number("2"),
-					},
-				},
-			},
-			Expected: map[string]interface{}{
-				"sensitive_params": []interface{}{
-					map[string]interface{}{
-						"secret_access_key_wo_version": "2",
-					},
-				},
-			},
-		},
-		"missing sensitive_params is a no-op": {
-			Attributes: map[string]interface{}{
-				"display_name": "keep-me",
-			},
-			Expected: map[string]interface{}{
-				"display_name": "keep-me",
-			},
-		},
-	}
-
-	for tn, tc := range cases {
-		t.Run(tn, func(t *testing.T) {
-			actual, err := bigquerydatatransfer.ResourceBigqueryDataTransferConfigUpgradeV0(context.Background(), tc.Attributes, nil)
-			if err != nil {
-				t.Fatalf("error migrating state: %s", err)
-			}
-			if !reflect.DeepEqual(tc.Expected, actual) {
-				t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", tc.Expected, actual)
-			}
-		})
-	}
-}
 
 func TestBigqueryDataTransferConfig_resourceBigqueryDTCParamsCustomDiffFuncForceNewWhenGoogleCloudStorage(t *testing.T) {
 	t.Parallel()

--- a/mmv1/third_party/terraform/services/bigquerydatatransfer/resource_bigquery_data_transfer_config_test.go
+++ b/mmv1/third_party/terraform/services/bigquerydatatransfer/resource_bigquery_data_transfer_config_test.go
@@ -1,7 +1,14 @@
 package bigquerydatatransfer_test
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -12,10 +19,69 @@ import (
 	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
-	"strings"
-	"testing"
-	"time"
 )
+
+func TestBigqueryDataTransferConfigStateUpgradeV0(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Attributes map[string]interface{}
+		Expected   map[string]interface{}
+	}{
+		"zero int becomes unset": {
+			Attributes: map[string]interface{}{
+				"sensitive_params": []interface{}{
+					map[string]interface{}{
+						"secret_access_key_wo_version": 0,
+					},
+				},
+			},
+			Expected: map[string]interface{}{
+				"sensitive_params": []interface{}{
+					map[string]interface{}{
+						"secret_access_key_wo_version": "",
+					},
+				},
+			},
+		},
+		"nonzero int becomes decimal string": {
+			Attributes: map[string]interface{}{
+				"sensitive_params": []interface{}{
+					map[string]interface{}{
+						"secret_access_key_wo_version": json.Number("2"),
+					},
+				},
+			},
+			Expected: map[string]interface{}{
+				"sensitive_params": []interface{}{
+					map[string]interface{}{
+						"secret_access_key_wo_version": "2",
+					},
+				},
+			},
+		},
+		"missing sensitive_params is a no-op": {
+			Attributes: map[string]interface{}{
+				"display_name": "keep-me",
+			},
+			Expected: map[string]interface{}{
+				"display_name": "keep-me",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual, err := bigquerydatatransfer.ResourceBigqueryDataTransferConfigUpgradeV0(context.Background(), tc.Attributes, nil)
+			if err != nil {
+				t.Fatalf("error migrating state: %s", err)
+			}
+			if !reflect.DeepEqual(tc.Expected, actual) {
+				t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", tc.Expected, actual)
+			}
+		})
+	}
+}
 
 func TestBigqueryDataTransferConfig_resourceBigqueryDTCParamsCustomDiffFuncForceNewWhenGoogleCloudStorage(t *testing.T) {
 	t.Parallel()

--- a/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
@@ -256,6 +256,12 @@ When upgrading to version 8.0.0:
 - If your configuration sets both `sensitive_params.0.secret_access_key` and `sensitive_params.0.secret_access_key_wo`, remove one of them.
 - Update any `sensitive_params.0.secret_access_key_wo_version = <integer>` in your configuration to a string value (e.g. `secret_access_key_wo_version = "1"`). Existing integer values in state are converted automatically.
 
+## Resource: `google_monitoring_uptime_check_config`
+
+### `http_check.0.auth_info.0.password` and `http_check.0.auth_info.0.password_wo` now require exactly one to be set
+
+The constraint between `http_check.0.auth_info.0.password` and `http_check.0.auth_info.0.password_wo` is now `ExactlyOneOf`. Configurations that set both fields must be updated to set only one.
+
 ## Resource: `google_secret_manager_secret_version`
 
 ### `secret_data_wo_version` type changed from `Integer` to `String`

--- a/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
@@ -262,8 +262,13 @@ When upgrading to version 8.0.0:
 
 The `secret_data_wo_version` field has changed type from `Integer` to `String`. The `ExactlyOneOf` constraint between `secret_data` and `secret_data_wo` remains unchanged. Existing state is automatically migrated on the first `terraform apply` after upgrading: the old default value of `0` is converted to `""` (unset), and non-zero values are converted to their string equivalents.
 
+### `secret_data_wo` now requires `secret_data_wo_version`
+
+`secret_data_wo` and `secret_data_wo_version` are now linked with `RequiredWith`. Previously, `secret_data_wo_version` defaulted to `0` and could be omitted. Configurations that set `secret_data_wo` must now also set `secret_data_wo_version` to a non-empty string.
+
 When upgrading to version 8.0.0:
 - If you were using `secret_data`: no configuration change needed.
+- If you were using `secret_data_wo` without `secret_data_wo_version`: add an explicit non-zero string value (e.g. `secret_data_wo_version = "1"`). The previous default of `0` has been removed.
 - If you were using `secret_data_wo` + `secret_data_wo_version = 0`: change this to a non-zero string value (e.g. `secret_data_wo_version = "1"`) before upgrading. The value `0` is now treated as unset, so leaving `= 0` in your configuration will cause a forced replacement on the next apply.
 - If you were using `secret_data_wo` + `secret_data_wo_version = <non-zero integer>`: update the value to a quoted string (e.g. change `secret_data_wo_version = 1` to `secret_data_wo_version = "1"`).
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Follow-Up of https://github.com/GoogleCloudPlatform/magic-modules/pull/18325

Avoids an update-in-place on 8.0 upgrade by converting existing integer state

Adds the secret_data_wo RequiredWith change in 8.0.0 upgrade guide

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:breaking-change
bigquerydatatransfer:  add state upgrader for `Int -> String` type conversion of `secret_access_key_wo_version` field in `google_bigquery_data_transfer_config` resource
```
