### PR TITLE
Add time_sleep delays to App Engine tests and samples to prevent IAM propagation issues.

### DIFF
--- a/mmv1/products/appengine/FlexibleAppVersion.yaml
+++ b/mmv1/products/appengine/FlexibleAppVersion.yaml
@@ -58,8 +58,7 @@ custom_code:
 samples:
   - name: app_engine_flexible_app_version
     primary_resource_id: myapp_v1
-    # https://github.com/hashicorp/terraform-provider-google/issues/19040
-    exclude_test: true
+    external_providers: [time]
     steps:
       - name: app_engine_flexible_app_version
         resource_id_vars:

--- a/mmv1/templates/terraform/samples/services/appengine/app_engine_flexible_app_version.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/appengine/app_engine_flexible_app_version.tf.tmpl
@@ -42,8 +42,19 @@ resource "google_project_iam_member" "storage_viewer" {
   member  = "serviceAccount:${google_service_account.custom_service_account.email}"
 }
 
+resource "time_sleep" "wait_120_seconds" {
+  depends_on = [
+    google_project_iam_member.gae_api,
+    google_project_iam_member.logs_writer,
+    google_project_iam_member.storage_viewer,
+  ]
+
+  create_duration = "120s"
+}
+
 resource "google_app_engine_flexible_app_version" "{{$.PrimaryResourceId}}" {
   version_id = "v1"
+  depends_on = [time_sleep.wait_120_seconds]
   project    = google_project_iam_member.gae_api.project
   service    = "default"
   runtime    = "nodejs"

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
@@ -110,7 +110,13 @@ resource "google_project" "acceptance" {
   deletion_policy = "DELETE"
 }
 
+resource "time_sleep" "wait_120_seconds" {
+  depends_on = [google_project.acceptance]
+  create_duration = "120s"
+}
+
 resource "google_app_engine_application" "acceptance" {
+  depends_on = [time_sleep.wait_120_seconds]
   project        = google_project.acceptance.project_id
   auth_domain    = "hashicorptest.com"
   location_id    = "us-central"
@@ -135,7 +141,13 @@ resource "google_project" "acceptance" {
   deletion_policy = "DELETE"
 }
 
+resource "time_sleep" "wait_120_seconds" {
+  depends_on = [google_project.acceptance]
+  create_duration = "120s"
+}
+
 resource "google_app_engine_application" "acceptance" {
+  depends_on = [time_sleep.wait_120_seconds]
   project        = google_project.acceptance.project_id
   auth_domain    = "hashicorptest.com"
   location_id    = "us-central"
@@ -155,7 +167,13 @@ resource "google_project" "acceptance" {
   deletion_policy = "DELETE"
 }
 
+resource "time_sleep" "wait_120_seconds" {
+  depends_on = [google_project.acceptance]
+  create_duration = "120s"
+}
+
 resource "google_app_engine_application" "acceptance" {
+  depends_on = [time_sleep.wait_120_seconds]
   project        = google_project.acceptance.project_id
   auth_domain    = "tf-test.club"
   location_id    = "us-central"
@@ -175,9 +193,15 @@ resource "google_project" "acceptance" {
   deletion_policy = "DELETE"
 }
 
+resource "time_sleep" "wait_120_seconds" {
+  depends_on = [google_project.acceptance]
+  create_duration = "120s"
+}
+
 resource "google_app_engine_application" "acceptance" {
   project     = google_project.acceptance.project_id
-  location_id = "us-central"
+  depends_on = [time_sleep.wait_120_seconds]
+	location_id = "us-central"
   ssl_policy  = "MODERN"
 }
 `, pid, pid, org, billingAccount)

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
@@ -18,7 +18,6 @@ import (
 )
 
 func TestAccAppEngineFlexibleAppVersion_update(t *testing.T) {
-	t.Skip("https://github.com/hashicorp/terraform-provider-google/issues/18239")
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -112,8 +111,14 @@ resource "google_project_iam_member" "gae_api" {
   member  = "serviceAccount:service-${google_project.my_project.number}@gae-api-prod.google.com.iam.gserviceaccount.com"
 }
 
+resource "time_sleep" "wait_120_seconds" {
+  depends_on = [google_project_iam_member.gae_api]
+  create_duration = "120s"
+}
+
 resource "google_app_engine_standard_app_version" "foo" {
   provider = google-beta
+  depends_on = [time_sleep.wait_120_seconds]
   project    = google_project_iam_member.gae_api.project
   version_id = "v1"
   service    = "default"
@@ -299,8 +304,14 @@ resource "google_project_iam_member" "gae_api" {
   member  = "serviceAccount:service-${google_project.my_project.number}@gae-api-prod.google.com.iam.gserviceaccount.com"
 }
 
+resource "time_sleep" "wait_120_seconds" {
+  depends_on = [google_project_iam_member.gae_api]
+  create_duration = "120s"
+}
+
 resource "google_app_engine_standard_app_version" "foo" {
   provider = google-beta
+  depends_on = [time_sleep.wait_120_seconds]
   project    = google_project_iam_member.gae_api.project
   version_id = "v1"
   service    = "default"


### PR DESCRIPTION
This PR addresses transient deployment failures in App Engine tests and documentation samples caused by IAM propagation latency. 

By introducing a 120-second delay using the `time_sleep` resource immediately following project creation and IAM role assignments, we ensure that necessary permissions are fully propagated across Google's global infrastructure before App Engine resources attempt to deploy.

Additionally, this change re-enables the flexible app version acceptance test and its corresponding sample test, which were previously skipped or excluded due to these propagation issues.

release-note:none