### PR TITLE
docs: add missing version 8 upgrade guide entries

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
@@ -231,6 +231,16 @@ The deprecated top-level `reservation_block_count` attribute has been removed. U
 
 `consumer_reject_lists` has been converted from a `list` to a `set` to resolve perpetual diffs caused by non-deterministic API ordering. References that use list indexing (for example, `google_compute_service_attachment.<name>.consumer_reject_lists[0]`) should be updated to use `tolist(google_compute_service_attachment.<name>.consumer_reject_lists)[0]` or `for` expressions.
 
+### `consumer_accept_lists` fields now default to empty strings
+
+`project_id_or_num`, `network_url`, and `endpoint_url` within `consumer_accept_lists` now default to an empty string `""` instead of `null` to prevent perpetual diffs caused by API responses omitting unpopulated attributes.
+
+## Resource: `google_container_cluster`
+
+### `logging_config.enable_components` and `monitoring_config.enable_components` are now sets
+
+`enable_components` within `logging_config` and `monitoring_config` have been converted from `list` to `set` to resolve perpetual diffs caused by non-deterministic API ordering. References using list indexing (for example, `google_container_cluster.<name>.logging_config[0].enable_components[0]`) should be updated to use `tolist()` or `for` expressions.
+
 ## Resource: `google_container_node_pool` and `google_container_cluster`
 
 ### `name_prefix` max length has been extended from 14 to 31 characters
@@ -244,6 +254,12 @@ In 8.0.0, providing a `name_prefix` larger than 14 characters will prompt the pr
 ### `actions.publish_findings_to_cloud_data_catalog` is now removed
 
 The `actions.publish_findings_to_cloud_data_catalog` field has been removed from this resource. It was previously deprecated in favor of `actions.publish_findings_to_dataplex_catalog`. When upgrading to version 8.0.0, remove any usage of `actions.publish_findings_to_cloud_data_catalog` from your `google_data_loss_prevention_job_trigger` configurations. You should use the `publish_findings_to_dataplex_catalog` field instead for specifying the action to publish findings to Dataplex.
+
+## Resource: `google_iam_workforce_pool_provider_scim_tenant`
+
+### `claim_mapping` is now required on create
+
+`claim_mapping` is now marked as `Required` when creating new Workforce Pool Provider SCIM Tenants, matching backend API requirements. Configurations creating this resource must provide a `claim_mapping` block.
 
 ## Resource: `google_iap_brand` and `google_iap_client` are now removed
 
@@ -260,6 +276,12 @@ The `run_as_service_account` argument has been removed from `google_integrations
 ## Resource: `google_ml_engine_model` is now removed
 
 `google_ml_engine_model` has been removed as the underlying Cloud ML Engine (AI Platform Prediction) API has been deprecated. Migrate your machine learning deployments to Vertex AI resources (such as [`google_vertex_ai_endpoint`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_endpoint) and Vertex AI Model Garden resources) and remove `google_ml_engine_model` from your configuration.
+
+## Resource: `google_monitoring_uptime_check_config`
+
+### `http_check.0.auth_info.0.password` and `http_check.0.auth_info.0.password_wo` now require exactly one to be set
+
+The constraint between `http_check.0.auth_info.0.password` and `http_check.0.auth_info.0.password_wo` is now `ExactlyOneOf`. Configurations that set both fields must be updated to set only one.
 
 ## Resource: `google_netapp_storage_pool`
 
@@ -278,12 +300,6 @@ The `scale_tier` argument has been removed from this resource. It was previously
 ## Resource: `google_notebooks_runtime` is now removed
 
 `google_notebooks_runtime` and its IAM resources (`google_notebooks_runtime_iam_policy`, `google_notebooks_runtime_iam_binding`, and `google_notebooks_runtime_iam_member`) have been removed. The underlying Vertex AI Workbench Google-Managed Notebooks product has reached End of Life. Migrate to [`google_workbench_instance`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/workbench_instance) and remove these resources from your configuration.
-
-## Resource: `google_monitoring_uptime_check_config`
-
-### `http_check.0.auth_info.0.password` and `http_check.0.auth_info.0.password_wo` now require exactly one to be set
-
-The constraint between `http_check.0.auth_info.0.password` and `http_check.0.auth_info.0.password_wo` is now `ExactlyOneOf`. Configurations that set both fields must be updated to set only one.
 
 ## Resource: `google_secret_manager_secret_version`
 

--- a/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_8_upgrade.html.markdown
@@ -281,7 +281,7 @@ The `run_as_service_account` argument has been removed from `google_integrations
 
 ### `http_check.0.auth_info.0.password` and `http_check.0.auth_info.0.password_wo` now require exactly one to be set
 
-The constraint between `http_check.0.auth_info.0.password` and `http_check.0.auth_info.0.password_wo` is now `ExactlyOneOf`. Configurations that set both fields must be updated to set only one.
+Updated `http_check.0.auth_info.0.password` and `http_check.0.auth_info.0.password_wo` to be `ExactlyOneOf`. Configurations that set both fields prior to this version must be updated to set only one of them.
 
 ## Resource: `google_netapp_storage_pool`
 


### PR DESCRIPTION
This PR adds missing entries to the Version 8 Upgrade Guide (`version_8_upgrade.html.markdown`) and ensures strict alphabetical ordering across all resource sections:
- **`google_container_cluster`**: Document `logging_config.enable_components` and `monitoring_config.enable_components` TypeSet conversion (#18262).
- **`google_compute_service_attachment`**: Document `consumer_accept_lists` fields defaulting to empty strings `""` (#18276).
- **`google_iam_workforce_pool_provider_scim_tenant`**: Document `claim_mapping` marked as `Required` on create (#18348).
- **Alphabetical re-order**

**Release Note:**
```release-note:none

```