### PR TITLE
Add enable_ssh to Dataproc Cluster IdentityConfig

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -1989,10 +1989,24 @@ by Dataproc`,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"user_service_account_mapping": {
-													Type:        schema.TypeMap,
-													Required:    true,
+													Type:     schema.TypeMap,
+													Optional: true,
+													AtLeastOneOf: []string{
+														"cluster_config.0.security_config.0.identity_config.0.user_service_account_mapping",
+														"cluster_config.0.security_config.0.identity_config.0.enable_ssh",
+													},
 													Elem:        &schema.Schema{Type: schema.TypeString},
 													Description: `User to service account mappings for multi-tenancy.`,
+												},
+												"enable_ssh": {
+													Type:     schema.TypeBool,
+													Optional: true,
+													Computed: true,
+													AtLeastOneOf: []string{
+														"cluster_config.0.security_config.0.identity_config.0.user_service_account_mapping",
+														"cluster_config.0.security_config.0.identity_config.0.enable_ssh",
+													},
+													Description: `Whether to enable SSH access for the cluster. The default is true for image versions prior to 3.1 and false for image versions 3.1 and later. The default behavior can be changed when creating clusters using image versions 2.3.30 and later.`,
 												},
 											},
 										},
@@ -2726,7 +2740,7 @@ func expandClusterConfig(d *schema.ResourceData, config *transport_tpg.Config) (
 	conf.GceClusterConfig = c
 
 	if cfg, ok := configOptions(d, "cluster_config.0.security_config"); ok {
-		conf.SecurityConfig = expandSecurityConfig(cfg)
+		conf.SecurityConfig = expandSecurityConfig(d, cfg)
 	}
 
 	if cfg, ok := configOptions(d, "cluster_config.0.software_config"); ok {
@@ -2943,7 +2957,7 @@ func expandGceClusterConfig(d *schema.ResourceData, config *transport_tpg.Config
 	return conf, nil
 }
 
-func expandSecurityConfig(cfg map[string]interface{}) *dataproc.SecurityConfig {
+func expandSecurityConfig(d *schema.ResourceData, cfg map[string]interface{}) *dataproc.SecurityConfig {
 	conf := &dataproc.SecurityConfig{}
 	if kfg, ok := cfg["kerberos_config"]; ok {
 		k := kfg.([]interface{})
@@ -2954,13 +2968,13 @@ func expandSecurityConfig(cfg map[string]interface{}) *dataproc.SecurityConfig {
 	if ifg, ok := cfg["identity_config"]; ok {
 		i := ifg.([]interface{})
 		if len(i) > 0 {
-			conf.IdentityConfig = expandIdentityConfig(i[0].(map[string]interface{}))
+			conf.IdentityConfig = expandIdentityConfig(d, i[0].(map[string]interface{}))
 		}
 	}
 	return conf
 }
 
-func expandIdentityConfig(cfg map[string]interface{}) *dataproc.IdentityConfig {
+func expandIdentityConfig(d *schema.ResourceData, cfg map[string]interface{}) *dataproc.IdentityConfig {
 	conf := &dataproc.IdentityConfig{}
 	if v, ok := cfg["user_service_account_mapping"]; ok {
 		m := make(map[string]string)
@@ -2968,6 +2982,13 @@ func expandIdentityConfig(cfg map[string]interface{}) *dataproc.IdentityConfig {
 			m[k] = val.(string)
 		}
 		conf.UserServiceAccountMapping = m
+	}
+	// enable_ssh is Optional+Computed and the API default varies by image version, so only
+	// transmit it when the practitioner set it explicitly. GetOkExists distinguishes an
+	// unset field from an explicit false, which d.Get and the block map cannot.
+	if v, ok := d.GetOkExists("cluster_config.0.security_config.0.identity_config.0.enable_ssh"); ok {
+		conf.EnableSsh = v.(bool)
+		conf.ForceSendFields = append(conf.ForceSendFields, "EnableSsh")
 	}
 	return conf
 }
@@ -3726,6 +3747,7 @@ func flattenIdentityConfig(d *schema.ResourceData, ifg *dataproc.IdentityConfig)
 	}
 	data := map[string]interface{}{
 		"user_service_account_mapping": d.Get("cluster_config.0.security_config.0.identity_config.0.user_service_account_mapping").(map[string]interface{}),
+		"enable_ssh":                   ifg.EnableSsh,
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_meta.yaml
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_meta.yaml
@@ -128,6 +128,7 @@ fields:
   - field: 'cluster_config.security_config.kerberos_config.truststore_password_uri'
   - field: 'cluster_config.security_config.kerberos_config.truststore_uri'
   - field: 'cluster_config.security_config.identity_config.user_service_account_mapping'
+  - field: 'cluster_config.security_config.identity_config.enable_ssh'
   - field: 'cluster_config.software_config.image_version'
   - field: 'cluster_config.software_config.optional_components'
   - field: 'cluster_config.software_config.override_properties'

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
@@ -1335,6 +1335,33 @@ func TestAccDataprocCluster_withKerberos(t *testing.T) {
 	})
 }
 
+// enable_ssh may be set without user_service_account_mapping, and an explicit false must
+// survive a plan/apply round trip rather than being silently replaced by the API default.
+func TestAccDataprocCluster_withIdentityConfigEnableSsh(t *testing.T) {
+	t.Parallel()
+
+	rnd := acctest.RandString(t, 10)
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
+	var cluster dataproc.Cluster
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataprocCluster_withIdentityConfigEnableSsh(rnd, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.identity_config_enable_ssh", &cluster),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.identity_config_enable_ssh", "cluster_config.0.security_config.0.identity_config.0.enable_ssh", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataprocCluster_withIdentityConfig(t *testing.T) {
 	t.Parallel()
 
@@ -3495,6 +3522,29 @@ resource "google_dataproc_cluster" "identity_config" {
         user_service_account_mapping = {
           "bob@company.com" = "bob-sa@iam.gserviceaccouts.com"
         }
+      }
+    }
+  }
+}
+`, rnd, subnetworkName)
+}
+
+func testAccDataprocCluster_withIdentityConfigEnableSsh(rnd, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_dataproc_cluster" "identity_config_enable_ssh" {
+  name   = "tf-test-dataproc-identity-ssh-%s"
+  region = "us-central1"
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+    software_config {
+      # Overriding the SSH default requires image version 2.3.30 or later.
+      image_version = "2.3-debian12"
+    }
+    security_config {
+      identity_config {
+        enable_ssh = false
       }
     }
   }

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -844,6 +844,7 @@ cluster_config {
       user_service_account_mapping = {
         "user@company.com" = "service-account@iam.gserviceaccounts.com"
       }
+      enable_ssh = false
     }
   }
 }
@@ -901,8 +902,15 @@ cluster_config {
 * `identity_config` (Optional) Identity Configuration. At least one of `identity_config`
        or `kerberos_config` is required.
 
-    * `user_service_account_mapping` - (Required) The end user to service account mappings
-       in a service account based multi-tenant cluster
+    * `user_service_account_mapping` - (Optional) The end user to service account mappings
+       in a service account based multi-tenant cluster. At least one of
+       `user_service_account_mapping` or `enable_ssh` is required.
+
+    * `enable_ssh` - (Optional) Whether to enable SSH access for the cluster. The default is
+       `true` for image versions prior to 3.1 and `false` for image versions 3.1 and later.
+       The default behavior can be changed when creating clusters using image versions
+       2.3.30 and later. At least one of `user_service_account_mapping` or `enable_ssh` is
+       required.
 
 - - -
 


### PR DESCRIPTION
This PR adds the optional `enable_ssh` field to `google_dataproc_cluster`'s `identity_config`, allowing practitioners to enable or disable SSH access for a cluster.

Recreates #18200, which the stale bot closed on 2026-08-19. That PR's VCR run failed to build the `dataproc` package because the provider pinned `google.golang.org/api v0.286.0`, whose `dataproc.IdentityConfig` had no `EnableSsh` field. `main` now pins `v0.293.0`, which includes it, so this branch compiles. Verified locally with `go build` and `go vet` against a freshly generated GA provider.

### Changes

- Adds `enable_ssh` to the `identity_config` schema, plus `resource_dataproc_cluster_meta.yaml`.
- Threads `*schema.ResourceData` through `expandSecurityConfig` / `expandIdentityConfig` so `GetOkExists` can distinguish an unset field from an explicit `false`.
- Makes `user_service_account_mapping` `Optional` with `AtLeastOneOf`, so `identity_config` can be used for SSH configuration alone.
- Documents both fields and adds an acceptance test covering `enable_ssh = false` without a mapping.

### Notes for reviewers

Two deliberate choices worth a look:

**`Optional + Computed`, and only sent when explicitly set.** The API default for `enableSsh` varies by image version — `true` before 3.1, `false` from 3.1 on. A plain `Optional` bool would send `enableSsh: false` for every existing `identity_config` user, because SDKv2 populates absent nested-block keys with the zero value; that would silently disable SSH on pre-3.1 clusters. It would also cause a perpetual diff, since flatten writes the API's `true` to state while the config yields `false`. `Computed` plus a `GetOkExists` guard avoids both while still allowing an explicit `false`.

**`user_service_account_mapping` relaxed from `Required` to `Optional`.** The discovery doc still annotates `userServiceAccountMapping` as `Required`, but the API does accept an `identityConfig` containing only `enableSsh`. `AtLeastOneOf` keeps an empty `identity_config {}` invalid at plan time.

The acceptance test pins `image_version = "2.3-debian12"`, since overriding the SSH default requires 2.3.30 or later.

Not addressed here: `identity_config` is absent from the update `updMask` and nothing in the block is `ForceNew`, so changing `enable_ssh` on an existing cluster produces a diff that never applies. That wart predates this PR and already affects `user_service_account_mapping`; happy to fix it here if you'd prefer.

```release-note:enhancement
dataproc: added `enable_ssh` field to `identity_config` in `google_dataproc_cluster` resource
```