### PR TITLE
apigee: fix TestAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTest…

### DIFF
--- a/mmv1/templates/terraform/samples/services/apigee/apigee_endpoint_attachment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/apigee/apigee_endpoint_attachment_basic.tf.tmpl
@@ -104,9 +104,9 @@ resource "google_apigee_organization" "apigee_org" {
   ]
 }
 
-resource "google_apigee_endpoint_attachment" "apigee_endpoint_attachment"" {
+resource "google_apigee_endpoint_attachment" "apigee_endpoint_attachment" {
   org_id                 = google_apigee_organization.apigee_org.id
-  endpoint_attachment_id = "tf-test%{random_suffix}
+  endpoint_attachment_id = "tf-test%{random_suffix}"
   location               = "{{index $.ResourceIdVars "location"}}"
   service_attachment     = google_compute_service_attachment.psc_ilb_service_attachment.id
 }

--- a/mmv1/templates/terraform/samples/services/apigee/apigee_endpoint_attachment_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/apigee/apigee_endpoint_attachment_basic_test.tf.tmpl
@@ -137,7 +137,7 @@ resource "google_apigee_organization" "apigee_org" {
 
 resource "google_apigee_endpoint_attachment" "{{$.PrimaryResourceId}}" {
   org_id                 = google_apigee_organization.apigee_org.id
-  endpoint_attachment_id = "tf-test%{random_suffix}
+  endpoint_attachment_id = "tf-test%{random_suffix}"
   location               = "{{index $.TestEnvVars "location"}}"
   service_attachment     = google_compute_service_attachment.psc_ilb_service_attachment.id
 }


### PR DESCRIPTION
The problem was caused by a missing double-quote and an extra double-quote in the .tf.tmpl files which resulted in an "Invalid multi-line string" / "Unterminated template string" error during terraform plan, causing the test to fail almost instantly.

```release-note:none

```
