### PR TITLE
accesscontextmanager: support multiple enforced and dry-run access levels

### DIFF
--- a/mmv1/products/accesscontextmanager/GcpUserAccessBinding.yaml
+++ b/mmv1/products/accesscontextmanager/GcpUserAccessBinding.yaml
@@ -86,11 +86,10 @@ properties:
   - name: accessLevels
     type: Array
     description: |
-      Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted"
+      Optional. Access levels that a user can satisfy to be granted access. Multiple access levels are logically ORed. Example: "accessPolicies/9522/accessLevels/device_trusted"
     item_type:
       type: String
     min_size: 1
-    max_size: 1
   - name: sessionSettings
     type: NestedObject
     description: |
@@ -162,7 +161,7 @@ properties:
               item_type:
                 type: String
               description: |
-                Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted"
+                Optional. Access levels that a user can satisfy to be granted access. Multiple access levels are logically ORed. Example: "accessPolicies/9522/accessLevels/device_trusted"
             - name: sessionSettings
               type: NestedObject
               description: |
@@ -204,21 +203,19 @@ properties:
               item_type:
                 type: String
               description: |
-                Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted"
+                Optional. Dry-run access levels that are evaluated but not enforced. Multiple access levels are logically ORed. Example: "accessPolicies/9522/accessLevels/device_trusted"
               min_size: 1
-              max_size: 1
 
   - name: dryRunAccessLevels
     type: Array
     description: |
-      Optional. Dry run access level that will be evaluated but will not be enforced. The
-      access denial based on dry run policy will be logged. Only one access
-      level is supported, not multiple. This list must have exactly one element.
+      Optional. Dry-run access levels that are evaluated but not enforced.
+      Access denials based on the dry-run policy are logged. Multiple access
+      levels are logically ORed.
       Example: "accessPolicies/9522/accessLevels/device_trusted"
     item_type:
       type: String
     min_size: 1
-    max_size: 1
 
   - name: principal
     type: NestedObject

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	sdkterraform "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
@@ -18,6 +19,36 @@ import (
 
 // Since each test here is acting on the same organization and only one AccessPolicy
 // can exist, they need to be run serially. See AccessPolicy for the test runner.
+
+func TestAccessContextManagerGcpUserAccessBinding_multipleAccessLevels(t *testing.T) {
+	t.Parallel()
+
+	accessLevels := []interface{}{
+		"accessPolicies/123/accessLevels/corporate_network",
+		"accessPolicies/123/accessLevels/trusted_device",
+	}
+
+	config := sdkterraform.NewResourceConfigRaw(map[string]interface{}{
+		"organization_id":       "123",
+		"group_key":             "test-group",
+		"access_levels":         accessLevels,
+		"dry_run_access_levels": accessLevels,
+		"scoped_access_settings": []interface{}{
+			map[string]interface{}{
+				"active_settings": []interface{}{
+					map[string]interface{}{"access_levels": accessLevels},
+				},
+				"dry_run_settings": []interface{}{
+					map[string]interface{}{"access_levels": accessLevels},
+				},
+			},
+		},
+	})
+
+	if diagnostics := accesscontextmanager.ResourceAccessContextManagerGcpUserAccessBinding().Validate(config); diagnostics.HasError() {
+		t.Fatalf("multiple enforced and dry-run access levels should pass provider validation: %v", diagnostics)
+	}
+}
 
 func testAccAccessContextManagerGcpUserAccessBinding_basicTest(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
### Why

- [Google's Context-Aware Access guide](https://docs.cloud.google.com/access-context-manager/docs/securing-console-and-apis#bind_google_groups_to_access_levels) documents multiple access levels with logical OR semantics, and the [gcloud access-binding command](https://docs.cloud.google.com/sdk/gcloud/reference/access-context-manager/cloud-bindings/create) accepts lists for both `--level` and `--dry-run-level`.
- The provider currently rejects those configurations during planning because several access-level lists have `MaxItems: 1`. The [REST field reference](https://docs.cloud.google.com/access-context-manager/docs/reference/rest/v1/organizations.gcpUserAccessBindings) still describes a one-level limit, so this change aligns provider-side validation with Google's CLI and allows the API to apply its current server-side validation.

### What

- Remove the one-item maximum from global enforced levels, global dry-run levels, and scoped dry-run levels; preserve existing minimum-size validation.
- Update global and scoped enforced/dry-run descriptions and add an offline regression test covering all four access-level fields.

### Validation

- `go test ./...` in `mmv1`.
- Regenerated both the `google` and `google-beta` providers.
- `env TF_ACC= go test ./google/services/accesscontextmanager` and `env TF_ACC= go test ./google-beta/services/accesscontextmanager`.
- Confirmed the new regression test fails against the unmodified provider and passes against both regenerated providers.

```release-note:enhancement
accesscontextmanager: allowed multiple enforced and dry-run access levels in `google_access_context_manager_gcp_user_access_binding`
```
