### PR TITLE
Revert "[Filestore] Enable regional endpoint (REP) support"

### DIFF
--- a/mmv1/products/filestore/product.yaml
+++ b/mmv1/products/filestore/product.yaml
@@ -25,7 +25,5 @@ scopes:
 versions:
   - name: ga
     base_url: https://file.googleapis.com/v1/
-    rep_url: https://file.{{location}}.rep.googleapis.com/v1/
   - name: beta
     base_url: https://file.googleapis.com/v1beta1/
-    rep_url: https://file.{{location}}.rep.googleapis.com/v1beta1/

--- a/mmv1/templates/terraform/constants/filestore_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/filestore_instance.go.tmpl
@@ -16,9 +16,8 @@ func ModifyFilestoreInstanceReplica(config *transport_tpg.Config, d *schema.Reso
 		return fmt.Errorf("Unable to %q google_filestore_instance %q: %s", method, d.Id(), err)
 	}
 
-	location := tpgresource.LocationFromId(d.Id())
 	err = FilestoreOperationWaitTime(
-		config, res, project, location, "Modifying Filestore Instance Replica", userAgent,
+		config, res, project, "Modifying Filestore Instance Replica", userAgent,
 		d.Timeout(schema.TimeoutUpdate))
 
 	if err != nil {


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#18605
The decision for making these changes is still under review, that is why reverting the PR.
```release-note:none
```