### PR TITLE
Minor fixes to firestore provider examples

### DIFF
--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -128,7 +128,7 @@ samples:
       - name: 'firestore_index_deletion_policy'
         resource_id_vars:
           database_id: 'database-id-deletion-policy'
-          deletion_policy: '"PREVENT"'
+          deletion_policy: PREVENT
         test_env_vars:
           project_id: 'PROJECT_NAME'
         # Example will show delete_protection as true, but in test we will actually set to false

--- a/mmv1/templates/terraform/samples/services/firestore/firestore_field_timestamp.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/firestore/firestore_field_timestamp.tf.tmpl
@@ -11,7 +11,7 @@ resource "google_firestore_database" "database" {
 resource "google_firestore_field" "{{$.PrimaryResourceId}}" {
   project    = "{{index $.TestEnvVars "project_id"}}"
   database   = google_firestore_database.database.name
-  collection = "chatrooms"
+  collection = "chatrooms_%{random_suffix}"
   field      = "timestamp"
 
   # Enable a TTL policy with no expiration offset for the collection based on

--- a/mmv1/templates/terraform/samples/services/firestore/firestore_field_timestamp_enterprise.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/firestore/firestore_field_timestamp_enterprise.tf.tmpl
@@ -12,7 +12,7 @@ resource "google_firestore_database" "database" {
 resource "google_firestore_field" "{{$.PrimaryResourceId}}" {
   project    = "{{index $.TestEnvVars "project_id"}}"
   database   = google_firestore_database.database.name
-  collection = "chatrooms"
+  collection = "chatrooms_%{random_suffix}"
   field      = "timestamp"
 
   # Enable a TTL policy with no expiration offset for the collection based on

--- a/mmv1/templates/terraform/samples/services/firestore/firestore_field_timestamp_with_ttl_offset.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/firestore/firestore_field_timestamp_with_ttl_offset.tf.tmpl
@@ -11,7 +11,7 @@ resource "google_firestore_database" "database" {
 resource "google_firestore_field" "{{$.PrimaryResourceId}}" {
   project    = "{{index $.TestEnvVars "project_id"}}"
   database   = google_firestore_database.database.name
-  collection = "chatrooms"
+  collection = "chatrooms_%{random_suffix}"
   field      = "timestamp"
 
   # Enable a TTL policy for the collection based on timestamp values in the field.

--- a/mmv1/templates/terraform/samples/services/firestore/firestore_field_timestamp_with_ttl_offset_enterprise.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/firestore/firestore_field_timestamp_with_ttl_offset_enterprise.tf.tmpl
@@ -12,7 +12,7 @@ resource "google_firestore_database" "database" {
 resource "google_firestore_field" "{{$.PrimaryResourceId}}" {
   project    = "{{index $.TestEnvVars "project_id"}}"
   database   = google_firestore_database.database.name
-  collection = "chatrooms"
+  collection = "chatrooms_%{random_suffix}"
   field      = "timestamp"
 
   # Enable a TTL policy for the collection based on timestamp values in the field.


### PR DESCRIPTION
* Remove double quotes around the deletion_policy example, seen [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/firestore_index#example-usage---firestore-index-deletion-policy), which previously looked like ""PREVENT""
    * This now matches how other similar fields like [delete_protection_state](https://github.com/GoogleCloudPlatform/magic-modules/blob/d57784406a440397f4edea072ae4f606a57e172d/mmv1/products/firestore/Field.yaml#L71) work
* Consistently apply the random_suffix to the chatrooms collection, which is the way it's done in our other examples.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

No release notes for these minor fixes.

```release-note:none
```