### PR TITLE
apigee: fix TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -184,7 +184,7 @@ resource "google_apigee_environment" "apigee_environment" {
   name         = "tf-test%{random_suffix}"
   description  = "Apigee Environment"
   display_name = "tf-test%{random_suffix}"
-  type         = "INTERMEDIATE"
+  type         = "COMPREHENSIVE"
   forward_proxy_uri = "http://test:456"
 }
 `, context)


### PR DESCRIPTION
Fixes nightly acceptance test failure for `TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate`.

### Root Cause & Fix
The nightly failure `'updating environment type is not supported today'` was caused by the test step attempting to modify the immutable `type` field from `COMPREHENSIVE` to `INTERMEDIATE` during an update.

This fix maintains `type = "COMPREHENSIVE"` in the update configuration so the test can successfully verify updates to the mutable `forward_proxy_uri` field.

```release-note:none
```
