### PR TITLE
apigee: fix TestAccApigeeInstance_updateConsumerAcceptList

### DIFF
--- a/mmv1/templates/terraform/constants/apigee_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/apigee_instance.go.tmpl
@@ -1,24 +1,55 @@
 // Suppress diffs when the lists of project have the same number of entries to handle the case that
 // API does not return what the user originally provided. Instead, API does some transformation.
 // For example, user provides a list of project number, but API returns a list of project Id.
-func projectListDiffSuppress(_, _, _ string, d *schema.ResourceData) bool {
-    return ProjectListDiffSuppressFunc(d)
+func projectListDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return ProjectListDiffSuppressFunc(d)
 }
 
 func ProjectListDiffSuppressFunc(d tpgresource.TerraformResourceDataChange) bool {
-	kLength := "consumer_accept_list.#"
-	oldLength, newLength := d.GetChange(kLength)
-
-	oldInt, ok := oldLength.(int)
-	if !ok {
+	old, new := d.GetChange("consumer_accept_list")
+	oldList, ok1 := old.([]interface{})
+	newList, ok2 := new.([]interface{})
+	if !ok1 || !ok2 {
+		// Fallback to list length property check
+		kLength := "consumer_accept_list.#"
+		oldLength, newLength := d.GetChange(kLength)
+		oldInt, okOld := oldLength.(int)
+		newInt, okNew := newLength.(int)
+		if okOld && okNew {
+			return oldInt == newInt
+		}
 		return false
 	}
 
-	newInt, ok := newLength.(int)
-	if !ok {
+	// We only suppress if the non-tenant projects in the state match the configured projects
+	// Since user might provide project numbers OR project IDs, we first check if they exactly match.
+	// If they exactly match after removing tenant projects, we suppress.
+	var oldNonTp []string
+	for _, v := range oldList {
+		if s, ok := v.(string); ok {
+			if len(s) > 3 && s[len(s)-3:] == "-tp" {
+				continue
+			}
+			oldNonTp = append(oldNonTp, s)
+		}
+	}
+
+	var newStrs []string
+	for _, v := range newList {
+		if s, ok := v.(string); ok {
+			newStrs = append(newStrs, s)
+		}
+	}
+
+	// If the lengths are different, there's definitely a change the user wants
+	if len(oldNonTp) != len(newStrs) {
 		return false
 	}
-	log.Printf("[DEBUG] - suppressing diff with oldInt %d, newInt %d", oldInt, newInt)
 
-	return oldInt == newInt
+	// We can't strictly compare elements because users might provide project numbers 
+	// while API returns project IDs. So if the counts of non-tenant projects match,
+	// we assume they correspond to the same projects, consistent with the original
+	// implementation's length-based heuristic, BUT ignoring tenant projects.
+	return true
 }
+

--- a/mmv1/templates/terraform/constants/apigee_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/apigee_instance.go.tmpl
@@ -27,7 +27,7 @@ func ProjectListDiffSuppressFunc(d tpgresource.TerraformResourceDataChange) bool
 	var oldNonTp []string
 	for _, v := range oldList {
 		if s, ok := v.(string); ok {
-			if len(s) > 3 && s[len(s)-3:] == "-tp" {
+			if strings.HasSuffix(s, "-tp") {
 				continue
 			}
 			oldNonTp = append(oldNonTp, s)

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_instance_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_instance_test.go
@@ -1,6 +1,7 @@
 package apigee_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/services/apigee"
@@ -23,13 +24,15 @@ type ApigeeInstanceDiffSuppressTestCase struct {
 var apigeeInstanceDiffSuppressTestCases = []ApigeeInstanceDiffSuppressTestCase{
 	{
 		Name:           "projects with the same length and one project entry is converted to project id",
-		KeysToSuppress: []string{"consumer_accept_list.0"},
+		KeysToSuppress: []string{"consumer_accept_list", "consumer_accept_list.0"},
 		Before: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"45796856818", "12345"},
 			"consumer_accept_list.#": 2,
 			"consumer_accept_list.0": "45796856818",
 			"consumer_accept_list.1": "12345",
 		},
 		After: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"tf-test8v1bd04pxa", "12345"},
 			"consumer_accept_list.#": 2,
 			"consumer_accept_list.0": "tf-test8v1bd04pxa",
 			"consumer_accept_list.1": "12345",
@@ -39,11 +42,13 @@ var apigeeInstanceDiffSuppressTestCases = []ApigeeInstanceDiffSuppressTestCase{
 		Name:           "projects with the same length and no project conversion",
 		KeysToSuppress: []string{},
 		Before: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"tf-test8v1bd04pxa", "12345"},
 			"consumer_accept_list.#": 2,
 			"consumer_accept_list.0": "tf-test8v1bd04pxa",
 			"consumer_accept_list.1": "12345",
 		},
 		After: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"tf-test8v1bd04pxa", "12345"},
 			"consumer_accept_list.#": 2,
 			"consumer_accept_list.0": "tf-test8v1bd04pxa",
 			"consumer_accept_list.1": "12345",
@@ -60,9 +65,113 @@ var apigeeInstanceDiffSuppressTestCases = []ApigeeInstanceDiffSuppressTestCase{
 		KeysToSuppress: []string{},
 		Before:         map[string]interface{}{},
 		After: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"tf-test8v1bd04pxa", "12345"},
 			"consumer_accept_list.#": 2,
 			"consumer_accept_list.0": "tf-test8v1bd04pxa",
 			"consumer_accept_list.1": "12345",
+		},
+	},
+	{
+		Name:           "positive case: state contains configured projects plus auto-injected tenant project",
+		KeysToSuppress: []string{"consumer_accept_list", "consumer_accept_list.#", "consumer_accept_list.1"},
+		Before: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"my-project", "f0d55e5054793ca7d-tp"},
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "my-project",
+			"consumer_accept_list.1": "f0d55e5054793ca7d-tp",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"my-project"},
+			"consumer_accept_list.#": 1,
+			"consumer_accept_list.0": "my-project",
+		},
+	},
+	{
+		Name:           "positive case: state contains transformed project ID plus auto-injected tenant project",
+		KeysToSuppress: []string{"consumer_accept_list", "consumer_accept_list.#", "consumer_accept_list.0", "consumer_accept_list.2"},
+		Before: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"proj-1-id", "proj-2", "auto-injected-tp"},
+			"consumer_accept_list.#": 3,
+			"consumer_accept_list.0": "proj-1-id",
+			"consumer_accept_list.1": "proj-2",
+			"consumer_accept_list.2": "auto-injected-tp",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"1234567890", "proj-2"},
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "1234567890",
+			"consumer_accept_list.1": "proj-2",
+		},
+	},
+	{
+		Name:           "negative case: state contains different numbers of non-tenant projects",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"project-1", "tenant-tp"},
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "project-1",
+			"consumer_accept_list.1": "tenant-tp",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"project-1", "project-2"},
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "project-1",
+			"consumer_accept_list.1": "project-2",
+		},
+	},
+	{
+		Name:           "negative case: state contains non-tenant project and tenant project vs empty config",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"project-1", "tenant-tp"},
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "project-1",
+			"consumer_accept_list.1": "tenant-tp",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{},
+			"consumer_accept_list.#": 0,
+		},
+	},
+	{
+		Name:           "negative case: state contains only tenant project vs 1 configured project",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"tenant-tp"},
+			"consumer_accept_list.#": 1,
+			"consumer_accept_list.0": "tenant-tp",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list":   []interface{}{"project-1"},
+			"consumer_accept_list.#": 1,
+			"consumer_accept_list.0": "project-1",
+		},
+	},
+	{
+		Name:           "fallback: same length without slice",
+		KeysToSuppress: []string{"consumer_accept_list.0"},
+		Before: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "45796856818",
+			"consumer_accept_list.1": "12345",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "tf-test8v1bd04pxa",
+			"consumer_accept_list.1": "12345",
+		},
+	},
+	{
+		Name:           "fallback: different length without slice",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"consumer_accept_list.#": 1,
+			"consumer_accept_list.0": "project-1",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "project-1",
+			"consumer_accept_list.1": "project-2",
 		},
 	},
 }
@@ -79,7 +188,7 @@ func (tc *ApigeeInstanceDiffSuppressTestCase) Test(t *testing.T) {
 		val2, ok := tc.After[key]
 		if !ok {
 			keysHavingDiff[key] = true
-		} else if val1 != val2 {
+		} else if !reflect.DeepEqual(val1, val2) {
 			keysHavingDiff[key] = true
 		}
 	}
@@ -88,7 +197,7 @@ func (tc *ApigeeInstanceDiffSuppressTestCase) Test(t *testing.T) {
 		val2, ok := tc.Before[key]
 		if !ok {
 			keysHavingDiff[key] = true
-		} else if val1 != val2 {
+		} else if !reflect.DeepEqual(val1, val2) {
 			keysHavingDiff[key] = true
 		}
 	}
@@ -108,7 +217,13 @@ func (tc *ApigeeInstanceDiffSuppressTestCase) Test(t *testing.T) {
 	for key := range keysHavingDiff {
 		actual := apigee.ProjectListDiffSuppressFunc(mockResourceDiff)
 		if actual != keySuppressionMap[key] {
-			t.Errorf("Test %s: expected key `%s` to be suppressed", tc.Name, key)
+			var expectation string
+			if keySuppressionMap[key] {
+				expectation = "be"
+			} else {
+				expectation = "not be"
+			}
+			t.Errorf("Test %s: expected key `%s` to %s suppressed", tc.Name, key, expectation)
 		}
 	}
 }


### PR DESCRIPTION
Fixes nightly acceptance test failure for `TestAccApigeeInstance_updateConsumerAcceptList`.

### Root Cause & Fix
The Apigee API silently auto-injects a tenant project (ending in `-tp`) into the instance's `consumer_accept_list`. Previously, `ProjectListDiffSuppressFunc` compared raw list lengths, causing a persistent non-empty plan / diff during acceptance tests because the state list included the unexpected tenant project.

This fix updates `ProjectListDiffSuppressFunc` in `mmv1/templates/terraform/constants/apigee_instance.go.tmpl` to ignore tenant projects (`-tp`) when matching the configured projects against state, resolving the false drift without interfering with project ID/number normalization.

```release-note:none
```
