### PR TITLE
ces: add whatsapp_config to ces_app

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -250,6 +250,33 @@ properties:
           - name: webWidgetTitle
             type: String
             description: The title of the web widget.
+      - name: whatsappConfig
+        type: NestedObject
+        description: Configuration specific to WhatsApp deployments.
+        properties:
+          - name: wabaId
+            type: String
+            required: true
+            description: The WhatsApp Business Account ID.
+          - name: phoneNumberId
+            type: String
+            required: true
+            description: The Meta phone number ID.
+          - name: phoneNumber
+            type: String
+            description: The phone number in E.164 format.
+          - name: displayName
+            type: String
+            description: The fetched Meta business page name.
+            output: true
+          - name: thumbnailUrl
+            type: String
+            description: The fetched Meta business profile thumbnail URL.
+            output: true
+          - name: description
+            type: String
+            description: The description of the Meta business page or profile.
+            output: true
   - name: deploymentCount
     type: Integer
     description: Number of deployments in the app.

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -614,6 +614,35 @@ properties:
                     type: String
                     description: The title of the web widget.
                     output: true
+              - name: whatsappConfig
+                type: NestedObject
+                description: Configuration specific to WhatsApp deployments.
+                output: true
+                properties:
+                  - name: wabaId
+                    type: String
+                    description: The WhatsApp Business Account ID.
+                    output: true
+                  - name: phoneNumberId
+                    type: String
+                    description: The Meta phone number ID.
+                    output: true
+                  - name: phoneNumber
+                    type: String
+                    description: The phone number in E.164 format.
+                    output: true
+                  - name: displayName
+                    type: String
+                    description: The fetched Meta business page name.
+                    output: true
+                  - name: thumbnailUrl
+                    type: String
+                    description: The fetched Meta business profile thumbnail URL.
+                    output: true
+                  - name: description
+                    type: String
+                    description: The description of the Meta business page or profile.
+                    output: true
           - name: deploymentCount
             type: Integer
             description: Number of deployments in the app.

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -411,6 +411,11 @@ resource "google_ces_app" "ces_app_basic" {
       theme    = "LIGHT"
       web_widget_title = "Help Assistant"
     }
+    whatsapp_config {
+      waba_id = "123456789012345"
+      phone_number_id = "987654321098765"
+      phone_number = "+15551234567"
+    }
   }
 
   metadata = {


### PR DESCRIPTION
Add support for `default_channel_profile.whatsapp_config` in `google_ces_app` (and output-only `whatsapp_config` in `google_ces_app_version`).

```release-note:enhancement
ces: added `whatsapp_config` field to `google_ces_app` resource
```
