### PR TITLE
cloudrunv2: add sandbox_launcher to worker_pool

### DIFF
--- a/mmv1/products/cloudrunv2/WorkerPool.yaml
+++ b/mmv1/products/cloudrunv2/WorkerPool.yaml
@@ -504,6 +504,9 @@ properties:
                   description: |-
                     Only memory, CPU, and nvidia.com/gpu are supported. Use key `cpu` for CPU limit, `memory` for memory limit, `nvidia.com/gpu` for gpu limit. Note: The only supported values for CPU are '1', '2', '4', '6', and '8'. Setting 4 CPU requires at least 2Gi of memory, setting 6 or more CPU requires at least 4Gi of memory. The values of the map is string form of the 'quantity' k8s type: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
                   default_from_api: true
+            - name: 'sandboxLauncher'
+              type: Boolean
+              description: Indicates that this container can act as a sandbox supervisor and launch sandboxes.
             - name: 'volumeMounts'
               type: Array
               description: |-

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
@@ -51,6 +51,7 @@ resource "google_cloud_run_v2_worker_pool" "default" {
   name     = "tf-test-cloudrun-worker-pool%{random_suffix}"
   description = "description creating"
   location = "us-central1"
+  launch_stage = "BETA"
   annotations = {
     generated-by = "magic-modules"
   }
@@ -73,6 +74,7 @@ resource "google_cloud_run_v2_worker_pool" "default" {
     containers {
       name = "container-1"
       image = "us-docker.pkg.dev/cloudrun/container/worker-pool"
+      sandbox_launcher = true
       env {
         name = "SOURCE"
         value = "remote"
@@ -103,6 +105,7 @@ resource "google_cloud_run_v2_worker_pool" "default" {
   name     = "tf-test-cloudrun-worker-pool%{random_suffix}"
   description = "description updating"
   location = "us-central1"
+  launch_stage = "BETA"
   deletion_protection = false
   
   annotations = {
@@ -133,6 +136,7 @@ resource "google_cloud_run_v2_worker_pool" "default" {
     containers {
       name = "container-update"
       image = "us-docker.pkg.dev/cloudrun/container/worker-pool"
+      sandbox_launcher = true
       args    = ["arg1", "arg2"]
       command = ["/bin/sh", "-c"]
       env {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
@@ -39,7 +39,7 @@ func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolFullUpdate(t *testing.T) {
 				ResourceName:            "google_cloud_run_v2_worker_pool.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
 			},
 		},
 	})
@@ -105,7 +105,6 @@ resource "google_cloud_run_v2_worker_pool" "default" {
   name     = "tf-test-cloudrun-worker-pool%{random_suffix}"
   description = "description updating"
   location = "us-central1"
-  launch_stage = "BETA"
   deletion_protection = false
   
   annotations = {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
@@ -136,7 +136,7 @@ resource "google_cloud_run_v2_worker_pool" "default" {
     containers {
       name = "container-update"
       image = "us-docker.pkg.dev/cloudrun/container/worker-pool"
-      sandbox_launcher = true
+      sandbox_launcher = false
       args    = ["arg1", "arg2"]
       command = ["/bin/sh", "-c"]
       env {


### PR DESCRIPTION
Add support for `template.containers.sandbox_launcher` in `google_cloud_run_v2_worker_pool`.

```release-note:enhancement
cloudrunv2: added `template.containers.sandbox_launcher` field to `google_cloud_run_v2_worker_pool` resource
```
