### PR TITLE
vertexai: promote agent_gateway_config to GA on reasoning_engine

### DIFF
--- a/mmv1/products/compute/NetworkAttachment.yaml
+++ b/mmv1/products/compute/NetworkAttachment.yaml
@@ -38,6 +38,7 @@ collection_url_key: 'items'
 custom_code:
 # excluding identity due to region value inconsistency
 exclude_identity_generation: true
+error_retry_predicates: ['transport_tpg.IsNetworkAttachmentConnectedEndpointsError']
 samples:
   - name: 'network_attachment_basic'
     primary_resource_id: 'default'

--- a/mmv1/products/networkservices/AgentGateway.yaml
+++ b/mmv1/products/networkservices/AgentGateway.yaml
@@ -38,6 +38,7 @@ async:
   result:
     resource_inside_response: true
 autogen_async: true
+error_retry_predicates: ['transport_tpg.IsAgentGatewayInUseError']
 samples:
   - name: network_services_agent_gateway_full
     primary_resource_id: default

--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -677,7 +677,6 @@ properties:
               - 'EXPERIMENTAL'
           - name: 'agentGatewayConfig'
             type: NestedObject
-            min_version: 'beta'
             description: |-
               Optional. Agent Gateway configuration for a Reasoning Engine deployment.
             properties:

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -1168,6 +1168,203 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 }
 {{- end }}
 
+func TestAccVertexAIReasoningEngine_agentGatewayConfig(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIReasoningEngine_agentGatewayConfig(context),
+			},
+			{
+				ResourceName:            "google_vertex_ai_reasoning_engine.reasoning_engine",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "location", "region", "labels", "terraform_labels", "spec.0.effective_identity"},
+			},
+			{
+				Config: testAccVertexAIReasoningEngine_agentGatewayConfigUpdate(context),
+			},
+			{
+				ResourceName:            "google_vertex_ai_reasoning_engine.reasoning_engine",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag", "location", "region", "labels", "terraform_labels", "spec.0.effective_identity"},
+			},
+		},
+	})
+}
+
+func testAccVertexAIReasoningEngine_agentGatewayConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_compute_network" "default" {
+  name                    = "tf-test-net-%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "tf-test-subnet-%{random_suffix}"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+  ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_network_attachment" "default" {
+  name                  = "tf-test-na-%{random_suffix}"
+  region                = "us-central1"
+  connection_preference = "ACCEPT_AUTOMATIC"
+  subnetworks           = [google_compute_subnetwork.default.self_link]
+}
+
+resource "google_network_services_agent_gateway" "agent_to_anywhere" {
+  name     = "tf-test-ag-a2a-%{random_suffix}"
+  location = "us-central1"
+  protocols = ["MCP"]
+  google_managed {
+    governed_access_path = "AGENT_TO_ANYWHERE"
+  }
+  registries = [
+    "//agentregistry.googleapis.com/projects/${data.google_project.project.project_id}/locations/us-central1"
+  ]
+  network_config {
+    egress {
+      network_attachment = google_compute_network_attachment.default.id
+    }
+  }
+}
+
+resource "google_network_services_agent_gateway" "client_to_agent" {
+  name     = "tf-test-ag-c2a-%{random_suffix}"
+  location = "us-central1"
+  protocols = ["MCP"]
+  google_managed {
+    governed_access_path = "CLIENT_TO_AGENT"
+  }
+  registries = [
+    "//agentregistry.googleapis.com/projects/${data.google_project.project.project_id}/locations/us-central1"
+  ]
+  network_config {
+    egress {
+      network_attachment = google_compute_network_attachment.default.id
+    }
+  }
+}
+
+resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
+  display_name = "tf-test-agent-gw-%{random_suffix}"
+  description  = "Reasoning engine testing agent gateway config"
+  region       = "us-central1"
+
+  spec {
+    identity_type = "AGENT_IDENTITY"
+    container_spec {
+      image_uri = "us-docker.pkg.dev/cloudrun/container/hello"
+      port      = 8000
+    }
+    deployment_spec {
+      agent_gateway_config {
+        client_to_agent_config {
+          agent_gateway = google_network_services_agent_gateway.client_to_agent.id
+        }
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccVertexAIReasoningEngine_agentGatewayConfigUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_compute_network" "default" {
+  name                    = "tf-test-net-%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "tf-test-subnet-%{random_suffix}"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+  ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_network_attachment" "default" {
+  name                  = "tf-test-na-%{random_suffix}"
+  region                = "us-central1"
+  connection_preference = "ACCEPT_AUTOMATIC"
+  subnetworks           = [google_compute_subnetwork.default.self_link]
+}
+
+resource "google_network_services_agent_gateway" "agent_to_anywhere" {
+  name     = "tf-test-ag-a2a-%{random_suffix}"
+  location = "us-central1"
+  protocols = ["MCP"]
+  google_managed {
+    governed_access_path = "AGENT_TO_ANYWHERE"
+  }
+  registries = [
+    "//agentregistry.googleapis.com/projects/${data.google_project.project.project_id}/locations/us-central1"
+  ]
+  network_config {
+    egress {
+      network_attachment = google_compute_network_attachment.default.id
+    }
+  }
+}
+
+resource "google_network_services_agent_gateway" "client_to_agent" {
+  name     = "tf-test-ag-c2a-%{random_suffix}"
+  location = "us-central1"
+  protocols = ["MCP"]
+  google_managed {
+    governed_access_path = "CLIENT_TO_AGENT"
+  }
+  registries = [
+    "//agentregistry.googleapis.com/projects/${data.google_project.project.project_id}/locations/us-central1"
+  ]
+  network_config {
+    egress {
+      network_attachment = google_compute_network_attachment.default.id
+    }
+  }
+}
+
+resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
+  display_name = "tf-test-agent-gw-updated-%{random_suffix}"
+  description  = "Updated reasoning engine testing agent gateway config"
+  region       = "us-central1"
+
+  spec {
+    identity_type = "AGENT_IDENTITY"
+    container_spec {
+      image_uri = "us-docker.pkg.dev/cloudrun/container/hello"
+      port      = 8000
+    }
+    deployment_spec {
+      agent_gateway_config {
+        client_to_agent_config {
+          agent_gateway = google_network_services_agent_gateway.client_to_agent.id
+        }
+        agent_to_anywhere_config {
+          agent_gateway = google_network_services_agent_gateway.agent_to_anywhere.id
+        }
+      }
+    }
+  }
+}
+`, context)
+}
+
 func TestAccVertexAIReasoningEngine_apiParityExternal(t *testing.T) {
 	t.Skip("Skipping agent_gateway and runtime_revision_name due to external infrastructure dependencies")
 	t.Parallel()

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -715,3 +715,29 @@ func Is409SyncMutateCannotBeQueuedError(err error) (bool, string) {
 	}
 	return false, ""
 }
+
+// Retry on Agent Gateway 400 error when the gateway is still in use by a dependent resource being deleted.
+func IsAgentGatewayInUseError(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 400 && strings.Contains(gerr.Body, "is already being used by resource") {
+			return true, "Agent Gateway is still being used by another resource"
+		}
+	}
+	if err != nil && strings.Contains(err.Error(), "is already being used by resource") {
+		return true, "Agent Gateway is still being used by another resource"
+	}
+	return false, ""
+}
+
+// Retry on Network Attachment 412 error when the attachment still has connected endpoints being deleted.
+func IsNetworkAttachmentConnectedEndpointsError(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 412 && strings.Contains(gerr.Body, "Network Attachment with connected endpoints cannot be deleted") {
+			return true, "Network Attachment still has connected endpoints"
+		}
+	}
+	if err != nil && strings.Contains(err.Error(), "Network Attachment with connected endpoints cannot be deleted") {
+		return true, "Network Attachment still has connected endpoints"
+	}
+	return false, ""
+}


### PR DESCRIPTION
Promote `spec.deployment_spec.agent_gateway_config` to GA on `google_vertex_ai_reasoning_engine`.

Also adds a test because there wasn't one before

```release-note:enhancement
vertexai: added `spec.deployment_spec.agent_gateway_config` field to `google_vertex_ai_reasoning_engine` (ga)
```
