### PR TITLE
ces: add retention_window to conversation_logging_settings

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -404,6 +404,12 @@ properties:
           - name: disableConversationLogging
             type: Boolean
             description: Whether to disable conversation logging for the sessions.
+          - name: retentionWindow
+            type: String
+            default_from_api: true
+            description: |-
+              Controls the retention window for the conversation.
+              If not set, the conversation will be retained for 365 days.
       - name: redactionConfig
         type: NestedObject
         description: Configuration to instruct how sensitive data should be handled.

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -794,6 +794,12 @@ properties:
                     type: Boolean
                     description: Whether to disable conversation logging for the sessions.
                     output: true
+                  - name: retentionWindow
+                    type: String
+                    description: |-
+                      Controls the retention window for the conversation.
+                      If not set, the conversation will be retained for 365 days.
+                    output: true
               - name: redactionConfig
                 type: NestedObject
                 description: Configuration to instruct how sensitive data should be handled.

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -136,6 +136,7 @@ resource "google_ces_app" "ces_app_basic" {
 
     conversation_logging_settings {
       disable_conversation_logging = true
+      retention_window = "86400s"
     }
   }
 
@@ -328,6 +329,7 @@ resource "google_ces_app" "ces_app_basic" {
 
     conversation_logging_settings {
       disable_conversation_logging = true
+      retention_window = "172800s"
     }
   }
 


### PR DESCRIPTION
Add support for `logging_settings.conversation_logging_settings.retention_window` in `google_ces_app`.

```release-note:enhancement
ces: added `retention_window` field to `google_ces_app` resource
```
