### PR TITLE
ces: add vpc_sc_settings to app

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -644,3 +644,17 @@ properties:
         description: |-
           The passphrase to decrypt the private key.
           Should be left unset if the private key is not encrypted.
+  - name: vpcScSettings
+    type: NestedObject
+    description: VPC-SC settings for the app.
+    properties:
+      - name: allowedOrigins
+        type: Array
+        description: |-
+          The allowed HTTP(s) origins that OpenAPI tools in the App are
+          able to directly call when VPC Service Controls are enabled. These strings
+          must match the origin exactly, including the port if specified. For
+          example, "https://example.com" or "https://example.com:443". This list does
+          not yet apply to Python tools that may make direct HTTP calls.
+        item_type:
+          type: String

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -1024,6 +1024,22 @@ properties:
                   The passphrase to decrypt the private key.
                   Should be left unset if the private key is not encrypted.
                 output: true
+          - name: vpcScSettings
+            type: NestedObject
+            description: VPC-SC settings for the app.
+            output: true
+            properties:
+              - name: allowedOrigins
+                type: Array
+                description: |-
+                  The allowed HTTP(s) origins that OpenAPI tools in the App are
+                  able to directly call when VPC Service Controls are enabled. These strings
+                  must match the origin exactly, including the port if specified. For
+                  example, "https://example.com" or "https://example.com:443". This list does
+                  not yet apply to Python tools that may make direct HTTP calls.
+                output: true
+                item_type:
+                  type: String
       - name: examples
         type: Array
         description: List of examples in the app.

--- a/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
@@ -179,5 +179,9 @@ variable_declarations {
     private_key = google_secret_manager_secret_version.fake_secret_version.name
   }
 
+  vpc_sc_settings {
+    allowed_origins = ["https://example.com"]
+  }
+
   # Root agent should not be specified when creating an app
 }

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -235,6 +235,9 @@ resource "google_ces_app" "ces_app_basic" {
     private_key = google_secret_manager_secret_version.fake_secret_version.name
   }
 
+  vpc_sc_settings {
+    allowed_origins = ["https://example.com"]
+  }
 
   # Root agent should not be specified when creating an app
 }
@@ -424,6 +427,10 @@ resource "google_ces_app" "ces_app_basic" {
   client_certificate_settings {
     tls_certificate = file("test-fixtures/cert.pem")
     private_key = google_secret_manager_secret_version.fake_secret_version.name
+  }
+
+  vpc_sc_settings {
+    allowed_origins = ["https://example.com", "https://example.org:443"]
   }
 
   # Root agent should not be specified when creating an app


### PR DESCRIPTION
Add support for `vpc_sc_settings.allowed_origins` in `google_ces_app`.

```release-note:enhancement
ces: added `vpc_sc_settings` field to `google_ces_app` resource
```
