### PR TITLE
container: support concurrent cluster master upgrades with node pool operations by switching to server side validation

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -8775,11 +8775,6 @@ func flattenRBACBindingConfig(c *container.RBACBindingConfig) []map[string]inter
 func resourceContainerClusterStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
-	if err != nil {
-		return nil, err
-	}
-
 	if err := tpgresource.ParseImportId([]string{"projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/clusters/(?P<name>[^/]+)", "(?P<project>[^/]+)/(?P<location>[^/]+)/(?P<name>[^/]+)", "(?P<location>[^/]+)/(?P<name>[^/]+)"}, d, config); err != nil {
 		return nil, err
 	}
@@ -8801,10 +8796,6 @@ func resourceContainerClusterStateImporter(d *schema.ResourceData, meta interfac
 
 	if err := d.Set("deletion_protection", true); err != nil {
 		return nil, fmt.Errorf("Error setting deletion_protection: %s", err)
-	}
-
-	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, userAgent, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return nil, err
 	}
 
 	d.SetId(containerClusterFullName(project, location, clusterName))

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -4095,6 +4095,13 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
+func isClusterUpdateRetryableError(apiErr error) bool {
+	return tpgresource.IsFailedPreconditionError(apiErr) ||
+		tpgresource.IsQuotaError(apiErr) ||
+		tpgresource.IsConflictError(apiErr) ||
+		transport_tpg.IsGoogleApiErrorWithCode(apiErr, 503)
+}
+
 func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 
     if tpgresource.DeletionPolicyPreUpdate(d, ResourceContainerCluster) {
@@ -4119,27 +4126,52 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	clusterName := d.Get("name").(string)
 
-	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, userAgent, d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return err
-	}
-
 	d.Partial(true)
 
-	lockKey := containerClusterMutexKey(project, location, clusterName)
+	startTime := time.Now()
+	timeout := d.Timeout(schema.TimeoutUpdate)
+
+	runClusterOperation := func(doCall func() (*container.Operation, error), updateDescription string) error {
+		var op *container.Operation
+
+		remaining := timeout - time.Since(startTime)
+		if remaining <= 0 {
+			return fmt.Errorf("timeout exhausted before starting %s", updateDescription)
+		}
+
+		err := retry.RetryContext(config.Context, remaining, func() *retry.RetryError {
+			var apiErr error
+			op, apiErr = doCall()
+			if apiErr != nil {
+				if isClusterUpdateRetryableError(apiErr) {
+					log.Printf("[DEBUG] Cluster %s busy or unavailable, retrying %s: %v", clusterName, updateDescription, apiErr)
+					return retry.RetryableError(apiErr)
+				}
+				return retry.NonRetryableError(apiErr)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		remainingWait := timeout - time.Since(startTime)
+		if remainingWait <= 0 {
+			return fmt.Errorf("timeout exhausted while waiting for %s", updateDescription)
+		}
+		return ContainerOperationWait(config, op, project, location, updateDescription, userAgent, remainingWait)
+	}
 
 	updateFunc := func(req *container.UpdateClusterRequest, updateDescription string) func() error {
 		return func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, updateDescription, userAgent, d.Timeout(schema.TimeoutUpdate))
+			return runClusterOperation(func() (*container.Operation, error) {
+				clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
+				if config.UserProjectOverride {
+					clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
+				}
+				return clusterUpdateCall.Do()
+			}, updateDescription)
 		}
 	}
 
@@ -4157,7 +4189,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		updateF := updateFunc(req, "updating GKE control plane endpoints config")
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s control plane endpoints config has been updated", d.Id())
@@ -4174,7 +4206,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating default enable private nodes")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4191,7 +4223,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE cluster stack type")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 
@@ -4209,7 +4241,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE cluster addons")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 
@@ -4225,7 +4257,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE cluster autoscaling")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4241,7 +4273,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE cluster DNSConfig")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4260,7 +4292,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	    updateF := updateFunc(req, "updating net admin for GKE autopilot workload policy config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 		    return err
 	    }
 
@@ -4285,7 +4317,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	    updateF := updateFunc(req, "updating privileged admission for GKE autopilot workload policy config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 		    return err
 	    }
 
@@ -4301,7 +4333,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE binary authorization")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4321,7 +4353,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE shielded nodes")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4334,26 +4366,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				DesiredReleaseChannel: expandReleaseChannel(d.Get("release_channel")),
 			},
 		}
-		updateF := func() error {
-			log.Println("[DEBUG] updating release_channel")
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating Release Channel", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating release_channel")
-			return err
-		}
-
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating Release Channel")
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4366,26 +4380,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				GkeAutoUpgradeConfig: expandGkeAutoUpgradeConfig(d.Get("gke_auto_upgrade_config")),
 			},
 		}
-		updateF := func() error {
-			log.Println("[DEBUG] updating gke_auto_upgrade_config")
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating GKE Auto Upgrade Config", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating gke_auto_upgrade_config")
-			return err
-		}
-
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating GKE Auto Upgrade Config")
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4402,26 +4398,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				},
 			},
 		}
-		updateF := func() error {
-			log.Println("[DEBUG] updating enable_intranode_visibility")
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating GKE Intra Node Visibility", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating enable_intranode_visibility")
-			return err
-		}
-
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating GKE Intra Node Visibility")
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4434,26 +4412,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				DesiredPrivateIpv6GoogleAccess: d.Get("private_ipv6_google_access").(string),
 			},
 		}
-		updateF := func() error {
-			log.Println("[DEBUG] updating private_ipv6_google_access")
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating GKE Private IPv6 Google Access", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating private_ipv6_google_access")
-			return err
-		}
-
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating GKE Private IPv6 Google Access")
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4471,26 +4431,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				},
 			},
 		}
-		updateF := func() error {
-			log.Println("[DEBUG] updating enable_l4_ilb_subsetting")
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating L4", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating enable_l4_ilb_subsetting")
-			return err
-		}
-
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating L4")
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4505,26 +4447,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				ForceSendFields:                          []string{"DesiredDisableL4LbFirewallReconciliation"},
 			},
 		}
-		updateF := func() error {
-			log.Println("[DEBUG] updating disable_l4_lb_firewall_reconciliation")
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating Disable L4 LB Firewall Reconciliation", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating disable_l4_lb_firewall_reconciliation")
-			return err
-		}
-
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating Disable L4 LB Firewall Reconciliation")
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4539,26 +4463,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				ForceSendFields:                          []string{"DesiredInTransitEncryptionConfig"},
 			},
 		}
-		updateF := func() error {
-			log.Println("[DEBUG] updating in_transit_encryption_config")
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating In-Transit Encryption Config", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating in_transit_encryption_config")
-			return err
-		}
-
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating In-Transit Encryption Config")
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4575,7 +4481,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating multi networking")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4591,7 +4497,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating fqdn network policy")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4608,7 +4514,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating cilium clusterwide network policy")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4625,7 +4531,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating cost management config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4640,7 +4546,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating GKE cluster authenticator groups config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4653,26 +4559,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				DesiredDefaultSnatStatus: expandDefaultSnatStatus(d.Get("default_snat_status")),
 			},
 		}
-		updateF := func() error {
-			log.Println("[DEBUG] updating default_snat_status")
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating GKE Default SNAT status", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating default_snat_status")
-			return err
-		}
-
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating GKE Default SNAT status")
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4702,7 +4590,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE cluster node locations")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4718,7 +4606,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE cluster node locations")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 		}
@@ -4734,25 +4622,18 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		updateF := func() error {
-			log.Println("[DEBUG] updating enable_legacy_abac")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterSetLegacyAbacCall := NewClient(config, userAgent).Projects.Locations.Clusters.SetLegacyAbac(name, req)
-			if config.UserProjectOverride {
-				clusterSetLegacyAbacCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterSetLegacyAbacCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating GKE legacy ABAC", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating enable_legacy_abac")
-			return err
+			return runClusterOperation(func() (*container.Operation, error) {
+				clusterSetLegacyAbacCall := NewClient(config, userAgent).Projects.Locations.Clusters.SetLegacyAbac(name, req)
+				if config.UserProjectOverride {
+					clusterSetLegacyAbacCall.Header().Add("X-Goog-User-Project", project)
+				}
+				return clusterSetLegacyAbacCall.Do()
+			}, "updating GKE legacy ABAC")
 		}
 
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4770,7 +4651,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE master emulated version")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 			log.Printf("[INFO] GKE cluster %s: master emulated version has been updated to %s", d.Id(), emulatedVersion)
@@ -4781,29 +4662,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		logging := d.Get("logging_service").(string)
 		monitoring := d.Get("monitoring_service").(string)
 
-		updateF := func() error {
-			name := containerClusterFullName(project, location, clusterName)
-			req := &container.UpdateClusterRequest{
-				Update: &container.ClusterUpdate{
-					DesiredMonitoringService: monitoring,
-					DesiredLoggingService:    logging,
-				},
-			}
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, "updating GKE logging+monitoring service", userAgent, d.Timeout(schema.TimeoutUpdate))
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredMonitoringService: monitoring,
+				DesiredLoggingService:    logging,
+			},
 		}
-
+		updateF := updateFunc(req, "updating GKE logging+monitoring service")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4817,25 +4684,18 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		updateF := func() error {
-			log.Println("[DEBUG] updating network_policy")
 			name := containerClusterFullName(project, location, clusterName)
-			clusterSetNetworkPolicyCall := NewClient(config, userAgent).Projects.Locations.Clusters.SetNetworkPolicy(name, req)
-			if config.UserProjectOverride {
-				clusterSetNetworkPolicyCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterSetNetworkPolicyCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating GKE cluster network policy", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating network_policy")
-			return err
+			return runClusterOperation(func() (*container.Operation, error) {
+				clusterSetNetworkPolicyCall := NewClient(config, userAgent).Projects.Locations.Clusters.SetNetworkPolicy(name, req)
+				if config.UserProjectOverride {
+					clusterSetNetworkPolicyCall.Header().Add("X-Goog-User-Project", project)
+				}
+				return clusterSetNetworkPolicyCall.Do()
+			}, "updating GKE cluster network policy")
 		}
 
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4881,7 +4741,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating AdditionalPodRangesConfig")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4905,7 +4765,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating AdditionalIpRangesConfig")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4920,7 +4780,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		updateF := updateFunc(req, "updating AutoIpamConfig")
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4938,7 +4798,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating NetworkTierConfig")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -4993,7 +4853,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE master version")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 			log.Printf("[INFO] GKE cluster %s: master has been updated to %s", d.Id(), ver)
@@ -5017,7 +4877,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 					}
 					updateF := updateFunc(req, "updating GKE default node pool node version")
 					// Call update serially.
-					if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+					if err := updateF(); err != nil {
 						return err
 					}
 					log.Printf("[INFO] GKE cluster %s: default node pool has been updated to %s", d.Id(),
@@ -5040,22 +4900,17 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			clusterSetMaintenancePolicyCall := NewClient(config, userAgent).Projects.Locations.Clusters.SetMaintenancePolicy(name, req)
-			if config.UserProjectOverride {
-				clusterSetMaintenancePolicyCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterSetMaintenancePolicyCall.Do()
-
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, "updating GKE cluster maintenance policy", userAgent, d.Timeout(schema.TimeoutUpdate))
+			return runClusterOperation(func() (*container.Operation, error) {
+				clusterSetMaintenancePolicyCall := NewClient(config, userAgent).Projects.Locations.Clusters.SetMaintenancePolicy(name, req)
+				if config.UserProjectOverride {
+					clusterSetMaintenancePolicyCall.Header().Add("X-Goog-User-Project", project)
+				}
+				return clusterSetMaintenancePolicyCall.Do()
+			}, "updating GKE cluster maintenance policy")
 		}
 
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5082,26 +4937,9 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				DesiredNotificationConfig: expandNotificationConfig(d.Get("notification_config")),
 			},
 		}
-		updateF := func() error {
-			log.Println("[DEBUG] updating notification_config")
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating Notification Config", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating notification_config")
-			return err
-		}
-
+		updateF := updateFunc(req, "updating Notification Config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5118,7 +4956,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE cluster vertical pod autoscaling")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 
@@ -5134,20 +4972,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			},
 		}
 
-		updateF := func() error {
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, "updating GKE cluster service externalips config", userAgent, d.Timeout(schema.TimeoutUpdate))
-		}
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating GKE cluster service externalips config")
+		if err := updateF(); err != nil {
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s service externalips config  has been updated", d.Id())
@@ -5161,20 +4987,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			},
 		}
 
-		updateF := func() error {
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, "updating GKE cluster mesh certificates config", userAgent, d.Timeout(schema.TimeoutUpdate))
-		}
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating GKE cluster mesh certificates config")
+		if err := updateF(); err != nil {
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s mesh certificates config has been updated", d.Id())
@@ -5188,20 +5002,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			},
 		}
 
-		updateF := func() error {
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, "updating GKE cluster database encryption config", userAgent, d.Timeout(schema.TimeoutUpdate))
-		}
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating GKE cluster database encryption config")
+		if err := updateF(); err != nil {
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s database encryption config has been updated", d.Id())
@@ -5216,20 +5018,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			},
 		}
 
-		updateF := func() error {
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, "updating GKE cluster pod security policy config", userAgent, d.Timeout(schema.TimeoutUpdate))
-		}
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating GKE cluster pod security policy config")
+		if err := updateF(); err != nil {
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s pod security policy config has been updated", d.Id())
@@ -5244,20 +5034,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			},
 		}
 
-		updateF := func() error {
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, "updating Horizontal pod Autoscaling profile", userAgent, d.Timeout(schema.TimeoutUpdate))
-		}
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating Horizontal pod Autoscaling profile")
+		if err := updateF(); err != nil {
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s horizontal pod autoscaling profile has been updated", d.Id())
@@ -5271,20 +5049,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			},
 		}
 
-		updateF := func() error {
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, "updating secret manager csi driver config", userAgent, d.Timeout(schema.TimeoutUpdate))
-		}
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating secret manager csi driver config")
+		if err := updateF(); err != nil {
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s secret manager csi add-on has been updated", d.Id())
@@ -5305,8 +5071,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating GKE secret sync add-on")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-		return err
+		if err := updateF(); err != nil {
+			return err
 		}
 	}
 
@@ -5330,7 +5096,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE cluster workload identity config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5353,7 +5119,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE cluster identity service config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5368,7 +5134,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating GKE cluster logging config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5383,7 +5149,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating GKE cluster monitoring config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5399,7 +5165,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating GKE cluster managed machine learning diagnostics config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5416,7 +5182,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating GKE cluster managed opentelemetry config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5433,21 +5199,17 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)
-			clusterSetResourceLabelsCall := NewClient(config, userAgent).Projects.Locations.Clusters.SetResourceLabels(name, req)
-			if config.UserProjectOverride {
-				clusterSetResourceLabelsCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterSetResourceLabelsCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, "updating GKE resource labels", userAgent, d.Timeout(schema.TimeoutUpdate))
+			return runClusterOperation(func() (*container.Operation, error) {
+				clusterSetResourceLabelsCall := NewClient(config, userAgent).Projects.Locations.Clusters.SetResourceLabels(name, req)
+				if config.UserProjectOverride {
+					clusterSetResourceLabelsCall.Header().Add("X-Goog-User-Project", project)
+				}
+				return clusterSetResourceLabelsCall.Do()
+			}, "updating GKE resource labels")
 		}
 
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 	}
@@ -5480,20 +5242,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			},
 		}
 
-		updateF := func() error {
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-			// Wait until it's updated
-			return ContainerOperationWait(config, op, project, location, "updating GKE cluster resource usage export config", userAgent, d.Timeout(schema.TimeoutUpdate))
-		}
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating GKE cluster resource usage export config")
+		if err := updateF(); err != nil {
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s resource usage export config has been updated", d.Id())
@@ -5509,7 +5259,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE Network Performance Config")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 
@@ -5527,7 +5277,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE Gateway API")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 
@@ -5553,7 +5303,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating GKE cluster fleet config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
@@ -5589,7 +5339,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating enabled Kubernetes Beta APIs")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 
@@ -5611,7 +5361,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE cluster desired node pool insecure kubelet readonly port configuration defaults.")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 
@@ -5634,7 +5384,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE cluster desired node pool logging configuration defaults.")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 
@@ -5655,7 +5405,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			updateF := updateFunc(req, "updating GKE cluster desired gcfs config.")
 			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 
@@ -5670,7 +5420,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			},
 		}
 		updateF := updateFunc(req, "updating GKE cluster master Security Posture Config")
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5685,7 +5435,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				},
 			}
 			updateF := updateFunc(req, "updating GKE cluster containerd config")
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 			log.Printf("[INFO] GKE cluster %s containerd config has been updated to %#v", d.Id(), req.Update.DesiredContainerdConfig)
@@ -5703,7 +5453,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE cluster node pool auto config node_kubelet_config parameters")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5724,7 +5474,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE cluster node pool auto config network tags")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5742,7 +5492,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE cluster node pool auto config resource manager tags")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5760,7 +5510,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		updateF := updateFunc(req, "updating GKE cluster node pool auto config linux node config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5777,7 +5527,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating GKE cluster Enterprise Config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5794,7 +5544,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating anonymous authentication config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 	}
@@ -5809,7 +5559,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		updateF := updateFunc(req, "updating node creation config")
 		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 	}
@@ -5823,7 +5573,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
     updateF := updateFunc(req, "updating GKE cluster RBAC binding config")
     // Call update serially.
-    if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+    if err := updateF(); err != nil {
       return err
     }
 
@@ -5838,7 +5588,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				},
 			}
 			updateF := updateFunc(req, "updating autopilot_cluster_policy_config")
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			if err := updateF(); err != nil {
 				return err
 			}
 			log.Printf("[INFO] GKE cluster %s autopilot_cluster_policy_config has been updated", d.Id())
@@ -5854,26 +5604,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				DesiredClusterTelemetry: expandClusterTelemetry(d.Get("cluster_telemetry")),
 			},
 		}
-		updateF := func() error {
-			log.Println("[DEBUG] updating cluster_telemetry")
-			name := containerClusterFullName(project, location, clusterName)
-			clusterUpdateCall := NewClient(config, userAgent).Projects.Locations.Clusters.Update(name, req)
-			if config.UserProjectOverride {
-				clusterUpdateCall.Header().Add("X-Goog-User-Project", project)
-			}
-			op, err := clusterUpdateCall.Do()
-			if err != nil {
-				return err
-			}
-
-			// Wait until it's updated
-			err = ContainerOperationWait(config, op, project, location, "updating Cluster Telemetry", userAgent, d.Timeout(schema.TimeoutUpdate))
-			log.Println("[DEBUG] done updating cluster_telemetry")
-			return err
-		}
-
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		updateF := updateFunc(req, "updating Cluster Telemetry")
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5881,9 +5613,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 {{- end }}
 
-	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, userAgent, d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return err
-	}
 
 {{ if ne $.TargetVersionName `ga` -}}
 	if d.HasChange("protect_config") {
@@ -5893,7 +5622,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			},
 		}
 		updateF := updateFunc(req, "updating GKE cluster master protect_config")
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5909,7 +5638,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		updateF := updateFunc(req, "updating GKE cluster WorkloadALTSConfig")
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 
@@ -5925,7 +5654,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		updateF := updateFunc(req, "updating user managed keys config")
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+		if err := updateF(); err != nil {
 			return err
 		}
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -4134,6 +4134,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	runClusterOperation := func(doCall func() (*container.Operation, error), updateDescription string) error {
 		var op *container.Operation
 
+		// TODO: remove this when we switch to Context CRUD methods
 		remaining := timeout - time.Since(startTime)
 		if remaining <= 0 {
 			return fmt.Errorf("timeout exhausted before starting %s", updateDescription)

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -1,15 +1,20 @@
 package container
 
 import (
+	"context"
+	"errors"
 {{ if ne $.TargetVersionName `ga` -}}
 	"strings"
 {{- end }}
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/googleapi"
 
 {{ if eq $.TargetVersionName `ga` }}
 	"google.golang.org/api/container/v1"
@@ -861,3 +866,122 @@ func TestContainerClusterApiDictatedPrivateEndpointField(t *testing.T) {
 		})
 	}
 }
+
+func TestContainerCluster_IsClusterUpdateRetryableError(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		err      error
+		expected bool
+	}{
+		"400 failedPrecondition in error items - retryable": {
+			err: &googleapi.Error{
+				Code:    400,
+				Message: "Operation cannot be completed because cluster is busy",
+				Errors: []googleapi.ErrorItem{
+					{Reason: "failedPrecondition", Message: "cluster is undergoing changes"},
+				},
+			},
+			expected: true,
+		},
+		"400 invalidArgument - non-retryable": {
+			err: &googleapi.Error{
+				Code:    400,
+				Message: "invalidArgument: invalid node pool name",
+				Errors: []googleapi.ErrorItem{
+					{Reason: "invalidArgument", Message: "invalid node pool name"},
+				},
+			},
+			expected: false,
+		},
+		"400 bad request without failedPrecondition - non-retryable": {
+			err:      &googleapi.Error{Code: 400, Message: "bad request"},
+			expected: false,
+		},
+		"409 conflict - retryable": {
+			err:      &googleapi.Error{Code: 409, Message: "conflict: resource already in use"},
+			expected: true,
+		},
+		"412 precondition failed - retryable": {
+			err:      &googleapi.Error{Code: 412, Message: "precondition failed"},
+			expected: true,
+		},
+		"429 quota exceeded - retryable": {
+			err:      &googleapi.Error{Code: 429, Message: "Resource exhausted: rateLimitExceeded"},
+			expected: true,
+		},
+		"503 service unavailable - retryable": {
+			err:      &googleapi.Error{Code: 503, Message: "service unavailable"},
+			expected: true,
+		},
+		"404 not found - non-retryable": {
+			err:      &googleapi.Error{Code: 404, Message: "cluster not found"},
+			expected: false,
+		},
+		"500 internal server error - non-retryable": {
+			err:      &googleapi.Error{Code: 500, Message: "internal error"},
+			expected: false,
+		},
+		"generic non-googleapi error - non-retryable": {
+			err:      errors.New("connection reset by peer"),
+			expected: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			got := isClusterUpdateRetryableError(tc.err)
+			if got != tc.expected {
+				t.Errorf("%s: expected isClusterUpdateRetryableError=%v, got %v", tn, tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestContainerCluster_RunClusterOperation_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	attempts := 0
+	err := retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
+		attempts++
+		apiErr := &googleapi.Error{Code: 400, Message: "failedPrecondition: busy"}
+		if isClusterUpdateRetryableError(apiErr) {
+			return retry.RetryableError(apiErr)
+		}
+		return retry.NonRetryableError(apiErr)
+	})
+
+	if err == nil {
+		t.Fatal("expected error on cancelled context, got nil")
+	}
+	if attempts > 2 {
+		t.Fatalf("expected retry loop to abort quickly on canceled context, but got %d attempts", attempts)
+	}
+}
+
+func TestContainerCluster_RunClusterOperation_NonRetryableFailsFast(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	attempts := 0
+	nonRetryableErr := &googleapi.Error{Code: 400, Message: "invalidArgument: bad field value"}
+
+	err := retry.RetryContext(ctx, 1*time.Minute, func() *retry.RetryError {
+		attempts++
+		if isClusterUpdateRetryableError(nonRetryableErr) {
+			return retry.RetryableError(nonRetryableErr)
+		}
+		return retry.NonRetryableError(nonRetryableErr)
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected non-retryable error to fail immediately on attempt 1, but ran %d attempts", attempts)
+	}
+}
+

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -1020,10 +1020,6 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 	
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
-	if err != nil {
-		return err
-	}
 
 	nodePoolInfo, err := extractNodePoolInformation(d, config)
 	if err != nil {
@@ -1031,21 +1027,11 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 	name := getNodePoolName(d.Id())
 
-	_, err = containerNodePoolAwaitRestingState(config, nodePoolInfo.fullyQualifiedName(name), nodePoolInfo.project, userAgent, d.Timeout(schema.TimeoutUpdate))
-	if err != nil {
-		return err
-	}
-
 	d.Partial(true)
 	if err := nodePoolUpdate(d, meta, nodePoolInfo, "", d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return err
 	}
 	d.Partial(false)
-
-	_, err = containerNodePoolAwaitRestingState(config, nodePoolInfo.fullyQualifiedName(name), nodePoolInfo.project, userAgent, d.Timeout(schema.TimeoutUpdate))
-	if err != nil {
-		return err
-	}
 
 	npCache.remove(nodePoolInfo.fullyQualifiedName(name))
 
@@ -1165,11 +1151,6 @@ func resourceContainerNodePoolExists(d *schema.ResourceData, meta interface{}) (
 func resourceContainerNodePoolStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
-	if err != nil {
-		return nil, err
-	}
-
 	if err := tpgresource.ParseImportId([]string{"projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/clusters/(?P<cluster>[^/]+)/nodePools/(?P<name>[^/]+)", "(?P<project>[^/]+)/(?P<location>[^/]+)/(?P<cluster>[^/]+)/(?P<name>[^/]+)", "(?P<location>[^/]+)/(?P<cluster>[^/]+)/(?P<name>[^/]+)"}, d, config); err != nil {
 		return nil, err
 	}
@@ -1180,16 +1161,6 @@ func resourceContainerNodePoolStateImporter(d *schema.ResourceData, meta interfa
 	}
 
 	d.SetId(id)
-
-	project, err := tpgresource.GetProject(d, config)
-	if err != nil {
-		return nil, err
-	}
-
-
-	if _, err := containerNodePoolAwaitRestingState(config, d.Id(), project, userAgent, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return nil, err
-	}
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -788,11 +788,6 @@ func (nodePoolInformation *NodePoolInformation) parent() string {
 	)
 }
 
-func (nodePoolInformation *NodePoolInformation) clusterLockKey() string {
-	return containerClusterMutexKey(nodePoolInformation.project,
-		nodePoolInformation.location, nodePoolInformation.cluster)
-}
-
 func (nodePoolInformation *NodePoolInformation) nodePoolLockKey(nodePoolName string) string {
 	return fmt.Sprintf(
 		"projects/%s/locations/%s/clusters/%s/nodePools/%s",
@@ -850,10 +845,6 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	// Acquire read-lock on cluster.
-	clusterLockKey := nodePoolInfo.clusterLockKey()
-	transport_tpg.MutexStore.RLock(clusterLockKey)
-	defer transport_tpg.MutexStore.RUnlock(clusterLockKey)
 
 	// Acquire write-lock on nodepool.
 	npLockKey := nodePoolInfo.nodePoolLockKey(nodePool.Name)
@@ -1051,11 +1042,6 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 	d.Partial(false)
 
-	//Check cluster is in running state
-	_, err = containerClusterAwaitRestingState(config, nodePoolInfo.project, nodePoolInfo.location, nodePoolInfo.cluster, userAgent, d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return err
-	}
 	_, err = containerNodePoolAwaitRestingState(config, nodePoolInfo.fullyQualifiedName(name), nodePoolInfo.project, userAgent, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return err
@@ -1099,10 +1085,6 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	// Acquire read-lock on cluster.
-	clusterLockKey := nodePoolInfo.clusterLockKey()
-	transport_tpg.MutexStore.RLock(clusterLockKey)
-	defer transport_tpg.MutexStore.RUnlock(clusterLockKey)
 
 	// Acquire write-lock on nodepool.
 	npLockKey := nodePoolInfo.nodePoolLockKey(name)
@@ -1204,16 +1186,6 @@ func resourceContainerNodePoolStateImporter(d *schema.ResourceData, meta interfa
 		return nil, err
 	}
 
-	nodePoolInfo, err := extractNodePoolInformation(d, config)
-	if err != nil {
-		return nil, err
-	}
-
-	//Check cluster is in running state
-	_, err = containerClusterAwaitRestingState(config, nodePoolInfo.project, nodePoolInfo.location, nodePoolInfo.cluster, userAgent, d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return nil, err
-	}
 
 	if _, err := containerNodePoolAwaitRestingState(config, d.Id(), project, userAgent, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return nil, err
@@ -1808,10 +1780,6 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 		return err
 	}
 
-	// Acquire read-lock on cluster.
-	clusterLockKey := nodePoolInfo.clusterLockKey()
-	transport_tpg.MutexStore.RLock(clusterLockKey)
-	defer transport_tpg.MutexStore.RUnlock(clusterLockKey)
 
 	// Nodepool write-lock will be acquired when update function is called.
 	npLockKey := nodePoolInfo.nodePoolLockKey(name)


### PR DESCRIPTION
- Remove client-side cluster resting state pre-check and post-gate checks in cluster and node pool update/import operations
- Remove mutex lock wrapping around individual field update API calls in resourceContainerClusterUpdate
- Remove node pool read locks on cluster mutex
- Wrap cluster update API calls in retry.RetryContext accounting for remaining timeout budget
- Retry on HTTP 400 (failedPrecondition), 409, 412, 429, and 503
- Add unit tests for error classification, context cancellation, and timeout budget behavior

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
container: switched to server side request validation to allow for concurrent Cluster Upgrades. `google_container_cluster` and `google_container_node_pool` resources will proceed while not in a resting state for updates (but will continue to wait for one after creates).
```
