### PR TITLE
gkehub2: send empty fleetobservability/workloadidentity spec sub-blocks

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -186,6 +186,11 @@ properties:
       - name: fleetobservability
         type: NestedObject
         description: Fleet Observability feature spec.
+        # The API requires this sub-block to be PRESENT to enable the feature, even
+        # with nothing inside it: {"spec":{"fleetobservability":{}}} returns 200
+        # while {"spec":{}} is a 400 MissingFieldError. Without this flag the
+        # empty object is dropped by the IsEmptyValue guard and nothing is sent.
+        send_empty_value: true
         properties:
           - name: loggingConfig
             type: NestedObject
@@ -282,6 +287,10 @@ properties:
       - name: workloadidentity
         type: NestedObject
         description: Workload Identity feature spec.
+        # Same as fleetobservability above: the feature is enabled by sending an
+        # EMPTY sub-block, which is also what GCP stores when it enables this
+        # itself on first cluster registration.
+        send_empty_value: true
         properties:
           - name: scopeTenancyPool
             type: String


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#29012

### What

`send_empty_value: true` on the `fleetobservability` and `workloadidentity` sub-blocks of `google_gke_hub_feature.spec`.

### Why

The GKE Hub API enables these two features by receiving their spec sub-block **present but empty**. Verified against the live API:

```
{}                                  -> 400 MissingFieldError for field spec
{"spec":{}}                         -> 400 MissingFieldError for field spec
{"spec":{"workloadidentity":{}}}    -> 200
{"spec":{"fleetobservability":{}}}  -> 200
```

An empty object is also what GCP itself stores. It enables both features automatically when the first cluster is registered into a fleet, and reading one back gives `{"spec": {"workloadidentity": {}}}`.

The generated expander drops it. `expandGKEHub2FeatureSpec` guards each sub-block with `!tpgresource.IsEmptyValue(val)`; `expandGKEHub2FeatureSpecWorkloadidentity` correctly returns an empty `map[string]interface{}{}`, `IsEmptyValue` reports an empty map as empty, so the key is removed. `spec` is then itself an empty map and is dropped by the same rule one level up, so the request carries no `spec` at all.

Net effect: neither feature can be created by Terraform. `terraform import` works and lands at zero diff, so they are adopt-only today — which is awkward, because reproducing a fleet in a fresh project requires registering a cluster first and then adopting what the registration made.

### Precedent

`send_empty_value` already does exactly this for a NestedObject one property away in this same resource:

```yaml
  - name: fleetDefaultMemberConfig
    type: NestedObject
    send_empty_value: true
```

and the two generated branches differ by precisely the guard (google-beta v7.44.0, `resourceGKEHub2FeatureCreate`):

```go
// spec — no send_empty_value
} else if v, ok := d.GetOkExists("spec"); !tpgresource.IsEmptyValue(reflect.ValueOf(specProp)) && (ok || !reflect.DeepEqual(v, specProp)) {

// fleetDefaultMemberConfig — send_empty_value: true
} else if v, ok := d.GetOkExists("fleet_default_member_config"); ok || !reflect.DeepEqual(v, fleetDefaultMemberConfigProp) {
```

Once the sub-block survives, `spec` is a non-empty map and passes its own guard unchanged, so `spec` itself should not need the flag.

### Scope

Only these two sub-blocks are affected. Every other feature either needs no spec at all — `authorizer`, `metering`, `rbacrolebindingactuation`, `multiclusterservicediscovery` all return 200 on a bare create — or carries a required value that survives the guard (`multiclusteringress.configMembership`). It only bites where the API requires the named sub-block *and* there is nothing non-empty to put in it.

### Not the same as #28472

That change made `scopeTenancyPool` optional and shipped in 7.43.0. Tested on 7.44.0: with the field optional and unset, the block is still dropped. The blocker is the empty-object guard, not the required flag.

### Also ruled out

* `scope_tenancy_pool = ""` — an empty string is also `IsEmptyValue`, block still dropped.
* `scope_tenancy_pool = "<project>.svc.id.goog"` — `400 InvalidValueError`; the API wants an IAM Workload Identity Pool *resource*, which the baseline feature does not have.
* Forcing serialisation with a throwaway nested value creates the resource but never converges: `fleetobservability` with `logging_config.default_config.mode = "MODE_UNSPECIFIED"` applies, GCP drops the mode, and every later plan re-adds it. A real mode (`COPY`) does converge, but that configures log routing — a different resource.

### Testing

Behaviour above was measured directly against the GKE Hub API and against `google-beta` 6.10.0 / 7.37.0 / 7.44.0 under both Terraform 1.5.7 and OpenTofu 1.12.

I have **not** been able to confirm that `send_empty_value` on a *nested* NestedObject removes the corresponding guard inside `expandGKEHub2FeatureSpec` — every usage I can find in this resource is top-level, and the only nested one is `send_empty_value: false` on a scalar. If the nested codegen path ignores the flag, a `custom_expand` on `spec` would be the fallback. Happy to take direction here, and to add an acceptance test covering an empty sub-block once the approach is settled.
