### PR TITLE
gkehub2: send empty fleetobservability/workloadidentity spec sub-blocks

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -187,9 +187,19 @@ properties:
         type: NestedObject
         description: Fleet Observability feature spec.
         # The API requires this sub-block to be PRESENT to enable the feature, even
-        # with nothing inside it: {"spec":{"fleetobservability":{}}} returns 200
-        # while {"spec":{}} is a 400 MissingFieldError. Without this flag the
-        # empty object is dropped by the IsEmptyValue guard and nothing is sent.
+        # with nothing inside it: {"spec":{"fleetobservability":{}}} returns 200,
+        # while both {"spec":{}} and {"spec":{"fleetobservability":null}} are a
+        # 400 MissingFieldError.
+        #
+        # BOTH flags are needed, and they fix different halves:
+        #   allow_empty_object  the expander returns an empty map instead of nil
+        #                       for a block whose optional values are all unset,
+        #                       and the flattener keeps it on read (without this
+        #                       the resource creates but never converges — every
+        #                       later plan re-adds `+ fleetobservability {}`)
+        #   send_empty_value    that empty map then survives the IsEmptyValue
+        #                       guard instead of being dropped from the request
+        allow_empty_object: true
         send_empty_value: true
         properties:
           - name: loggingConfig
@@ -287,9 +297,10 @@ properties:
       - name: workloadidentity
         type: NestedObject
         description: Workload Identity feature spec.
-        # Same as fleetobservability above: the feature is enabled by sending an
-        # EMPTY sub-block, which is also what GCP stores when it enables this
-        # itself on first cluster registration.
+        # Same as fleetobservability above, and for the same two reasons: the
+        # feature is enabled by sending an EMPTY sub-block, which is also what GCP
+        # stores when it enables this itself on first cluster registration.
+        allow_empty_object: true
         send_empty_value: true
         properties:
           - name: scopeTenancyPool

--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -186,6 +186,11 @@ properties:
       - name: fleetobservability
         type: NestedObject
         description: Fleet Observability feature spec.
+        # The API requires this sub-block to be PRESENT to enable the feature, even
+        # with nothing inside it: {"spec":{"fleetobservability":{}}} returns 200
+        # while {"spec":{}} is a 400 MissingFieldError. Without this flag the
+        # empty object is dropped by the IsEmptyValue guard and nothing is sent.
+        send_empty_value: true
         properties:
           - name: loggingConfig
             type: NestedObject
@@ -282,6 +287,10 @@ properties:
       - name: workloadidentity
         type: NestedObject
         description: Workload Identity feature spec.
+        # Same as fleetobservability above: the feature is enabled by sending an
+        # EMPTY sub-block, which is also what GCP stores when it enables this
+        # itself on first cluster registration.
+        send_empty_value: true
         properties:
           - name: scopeTenancyPool
             type: String

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go
@@ -1081,6 +1081,90 @@ resource "google_gke_hub_feature" "feature" {
 `, context)
 }
 
+// TestAccGKEHubFeature_EmptySpecSubBlock covers the one shape send_empty_value
+// exists for on this resource: a spec sub-block that is PRESENT but EMPTY.
+//
+// The GKE Hub API enables workloadidentity and fleetobservability by receiving
+// exactly that — {"spec":{"workloadidentity":{}}} returns 200, while {"spec":{}}
+// is a 400 MissingFieldError. Without the flag the generated expander drops the
+// empty object (tpgresource.IsEmptyValue), spec collapses to an empty map and is
+// dropped in turn, and the request carries no spec at all — so neither feature
+// could be created by Terraform.
+//
+// Every other test in this file supplies a value inside the block
+// (workloadidentity.scope_tenancy_pool, fleetobservability.logging_config), which
+// survives the guard on its own. That is why the empty path was never exercised.
+// Both features are asserted in one config so a single acceptance run covers both
+// patched properties.
+func TestAccGKEHubFeature_EmptySpecSubBlock(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckGKEHubFeatureDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEHubFeature_EmptySpecSubBlock(context),
+				Check: resource.ComposeTestCheckFunc(
+					// The block must round-trip as present-and-empty. Asserting the
+					// count rather than a value is the point: there is no value to
+					// assert, and its absence is precisely the bug.
+					resource.TestCheckResourceAttr(
+						"google_gke_hub_feature.workloadidentity", "spec.0.workloadidentity.#", "1"),
+					resource.TestCheckResourceAttr(
+						"google_gke_hub_feature.fleetobservability", "spec.0.fleetobservability.#", "1"),
+				),
+			},
+			{
+				ResourceName:            "google_gke_hub_feature.workloadidentity",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project", "labels", "terraform_labels"},
+			},
+			{
+				ResourceName:            "google_gke_hub_feature.fleetobservability",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccGKEHubFeature_EmptySpecSubBlock(context map[string]interface{}) string {
+	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
+resource "google_gke_hub_feature" "workloadidentity" {
+  name     = "workloadidentity"
+  location = "global"
+  project  = google_project.project.project_id
+  spec {
+    workloadidentity {}
+  }
+  depends_on = [time_sleep.wait_for_gkehub_enablement]
+}
+
+resource "google_gke_hub_feature" "fleetobservability" {
+  name     = "fleetobservability"
+  location = "global"
+  project  = google_project.project.project_id
+  spec {
+    fleetobservability {}
+  }
+  depends_on = [time_sleep.wait_for_gkehub_enablement]
+}
+`, context)
+}
+
 func gkeHubFeatureProjectSetupForGA(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go
@@ -1081,21 +1081,31 @@ resource "google_gke_hub_feature" "feature" {
 `, context)
 }
 
-// TestAccGKEHubFeature_EmptySpecSubBlock covers the one shape send_empty_value
-// exists for on this resource: a spec sub-block that is PRESENT but EMPTY.
+// TestAccGKEHubFeature_EmptySpecSubBlock covers a spec sub-block that is PRESENT
+// but EMPTY — the shape the GKE Hub API requires to enable these two features.
 //
-// The GKE Hub API enables workloadidentity and fleetobservability by receiving
-// exactly that — {"spec":{"workloadidentity":{}}} returns 200, while {"spec":{}}
-// is a 400 MissingFieldError. Without the flag the generated expander drops the
-// empty object (tpgresource.IsEmptyValue), spec collapses to an empty map and is
-// dropped in turn, and the request carries no spec at all — so neither feature
-// could be created by Terraform.
+// {"spec":{"workloadidentity":{}}} returns 200, while BOTH {"spec":{}} and
+// {"spec":{"workloadidentity":null}} are a 400 MissingFieldError. Getting the
+// empty object onto the wire needs two flags doing different jobs:
+//
+//	allow_empty_object  the expander returns an empty map rather than nil for a
+//	                    block whose optional values are all unset, and the
+//	                    flattener keeps it on read
+//	send_empty_value    that empty map then survives the IsEmptyValue guard
+//	                    instead of being dropped from the request
+//
+// Both halves are load-bearing, which is what this test pins. With only the guard
+// removed the request carries "workloadidentity": null and the create fails; with
+// only the expander fixed the object never reaches the wire. And without the
+// flatten half the resource creates but never converges — the second plan re-adds
+// `+ workloadidentity {}` forever, which is why the import steps below matter as
+// much as the create.
 //
 // Every other test in this file supplies a value inside the block
 // (workloadidentity.scope_tenancy_pool, fleetobservability.logging_config), which
-// survives the guard on its own. That is why the empty path was never exercised.
-// Both features are asserted in one config so a single acceptance run covers both
-// patched properties.
+// is non-empty and survives on its own. That is why the empty path was never
+// exercised. Both features are asserted in one config so a single acceptance run
+// covers both patched properties.
 func TestAccGKEHubFeature_EmptySpecSubBlock(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#29014

## What

`allow_empty_object: true` **and** `send_empty_value: true` on the `fleetobservability` and `workloadidentity` sub-blocks of `google_gke_hub_feature.spec`.

> **Corrected after testing.** This PR originally proposed `send_empty_value` alone, on the stated basis that `expandGKEHub2FeatureSpecWorkloadidentity` "returns an empty `map[string]interface{}{}`". **That was wrong** — it returns `nil` for an empty block. I built the provider from this branch and applied it against a real project; the create still failed. Both flags are required, and the measurements are below.

## Why

The GKE Hub API enables these two features by receiving their spec sub-block **present but empty**. Verified against the live API:

```
{}                                       -> 400 MissingFieldError for field spec
{"spec":{}}                              -> 400 MissingFieldError for field spec
{"spec":{"workloadidentity":null}}       -> 400 MissingFieldError for field spec
{"spec":{"workloadidentity":{}}}         -> 200
{"spec":{"fleetobservability":{}}}       -> 200
```

An empty object is also what GCP itself stores: it enables both features automatically when the first cluster is registered into a fleet, and reading one back gives `{"spec": {"workloadidentity": {}}}`.

## The two flags fix different halves

**`send_empty_value`** removes the outer guard. `expandGKEHub2FeatureSpec` wraps each sub-block in `!tpgresource.IsEmptyValue(val)`, so an empty value is dropped from `spec`; `spec` then becomes an empty map and is dropped by the same rule one level up, and the request carries no `spec` at all.

**`allow_empty_object`** is what makes there be a value to keep. The inner expander returns `nil` before the guard is ever reached:

```go
l := v.([]interface{})
if len(l) == 0 || l[0] == nil {
    return nil, nil        // an empty block arrives as l[0] == nil
}
```

Removing only the guard therefore turns "key absent" into `"workloadidentity": null` — which the API rejects identically. `allow_empty_object` makes the expander return an empty map instead, and — the half I missed first time — **stops the flattener discarding it on read**. Without the flatten half the resource creates and then never converges: every subsequent plan re-adds `+ workloadidentity {}`.

The flag's own doc comment describes this exactly:

> *the difference between this and `send_empty_value` is that `send_empty_value` applies when the key of an object is empty; this applies when the values are all nil / default. eg: `expiration: null` vs `expiration: {}` … Terraform returns a nil instead of an empty `map[string]interface{}` like we'd expect.*

## Tested end to end

Provider generated from this branch (`go run . --product=gkehub2 --version=beta`), built, and applied with `dev_overrides` against a real project. One variable changed at a time:

| provider | body sent | result |
|---|---|---|
| stock v7.44.0 | `spec` absent | `400 MissingFieldError` |
| `send_empty_value` only | `{"spec":{"workloadidentity":null}}` | `400 MissingFieldError` |
| + `allow_empty_object` | `{"spec":{"workloadidentity":{}}}` | **200**, created in 7s |

Then, with both flags, on a clean slate:

```
terraform destroy   -> Destroy complete! Resources: 2 destroyed.
terraform apply     -> Apply complete! Resources: 2 added        (both from an empty block)
terraform plan      -> No changes. Your infrastructure matches the configuration.
```

Both features create from empty and converge. The generated expander and flattener match the hand-patched build I used to isolate each layer.

## Scope

Only these two sub-blocks are affected. Every other feature either needs no `spec` at all — `authorizer`, `metering`, `rbacrolebindingactuation`, `multiclusterservicediscovery` all return 200 on a bare create — or carries a required value that survives the guard (`multiclusteringress.configMembership`). It only bites where the API requires the named sub-block and there is nothing non-empty to put in it.

## Not the same as #28472

That change made `scopeTenancyPool` optional and shipped in 7.43.0. Tested on 7.44.0: with the field optional and unset, the block is still dropped. The blocker is the empty-object handling, not the required flag.

## Also ruled out

- `scope_tenancy_pool = ""` — an empty string is also `IsEmptyValue`, block still dropped.
- `scope_tenancy_pool = "<project>.svc.id.goog"` — `400 InvalidValueError`; the API wants an IAM Workload Identity Pool resource, which the baseline feature does not have.
- Forcing serialisation with a throwaway nested value creates the resource but never converges: `fleetobservability` with `logging_config.default_config.mode = "MODE_UNSPECIFIED"` applies, GCP drops the mode, and every later plan re-adds it. A real mode (`COPY`) does converge, but that configures log routing — a different resource.

## Test

`TestAccGKEHubFeature_EmptySpecSubBlock` creates both features with the block present and empty, and import-verifies each. Every existing Feature test supplies a value *inside* the block (`workloadidentity.scope_tenancy_pool`, `fleetobservability.logging_config`), which survives the guard on its own — which is why the empty path was never exercised. The assertion is on block presence rather than a value, because there is no value: the block being sent at all is the behaviour under test.

I have not run the acceptance test itself — it creates a project per run and needs org + billing. The end-to-end evidence above is from a real apply against an existing project.

```release-note:bug
gkehub2: fixed `google_gke_hub_feature` so an empty `fleetobservability` or `workloadidentity` spec sub-block is sent to the API instead of dropped, making those features creatable
```
