### PR TITLE
composer: update test image versions to 2.17.10

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go
@@ -1691,7 +1691,7 @@ resource "google_composer_environment" "test" {
     }
 
     software_config {
-      image_version = "composer-2.13.0-airflow-2.10.5"
+      image_version = "composer-2.17.10-airflow-2.10.5"
     }
   }
   depends_on = [google_project_iam_member.composer-worker]
@@ -1740,7 +1740,7 @@ resource "google_composer_environment" "test" {
     }
 
     software_config {
-      image_version = "composer-2.16.11-airflow-2.11.1"
+      image_version = "composer-2.17.10-airflow-2.11.1"
     }
   }
   depends_on = [google_project_iam_member.composer-worker]


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28831
Fix update composer v2 image

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
