### PR TITLE
suppress copy-write header being emitted on mmv1 build when jetski uses virtual workbranches

### DIFF
--- a/mmv1/provider/provider_test.go
+++ b/mmv1/provider/provider_test.go
@@ -67,3 +67,43 @@ func TestTerraformVerboseLogging(t *testing.T) {
 		})
 	}
 }
+
+func TestExpectedOutputFolder(t *testing.T) {
+	testCases := []struct {
+		path     string
+		expected bool
+	}{
+		{"/Users/user/git/terraform-provider-google", true},
+		{"/Users/user/git/terraform-provider-google-beta", true},
+		{"/usr/local/google/home/user/.gemini/jetski/worktrees/terraform-provider-google-beta/my_branch", true},
+		{"/some/random/dir", false},
+	}
+
+	for _, tc := range testCases {
+		got := expectedOutputFolder(tc.path)
+		if got != tc.expected {
+			t.Errorf("expectedOutputFolder(%q) = %v; want %v", tc.path, got, tc.expected)
+		}
+	}
+}
+
+func TestIsHashicorpTarget(t *testing.T) {
+	testCases := []struct {
+		path     string
+		expected bool
+	}{
+		{"/Users/user/git/terraform-provider-google", true},
+		{"/Users/user/git/terraform-provider-google-beta", true},
+		{"/usr/local/google/home/user/.gemini/jetski/worktrees/terraform-provider-google-beta/my_branch", true},
+		{"/Users/user/git/terraform-google-conversion", false},
+		{"/usr/local/google/home/user/.gemini/jetski/worktrees/terraform-google-conversion/my_branch", false},
+		{"/some/random/dir", false},
+	}
+
+	for _, tc := range testCases {
+		got := isHashicorpTarget(tc.path)
+		if got != tc.expected {
+			t.Errorf("isHashicorpTarget(%q) = %v; want %v", tc.path, got, tc.expected)
+		}
+	}
+}

--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -804,7 +804,7 @@ func (t Terraform) addHashicorpCopyRightHeader(outputFolder, target string) {
 			"Watch out for unexpected changes to copied files", outputFolder)
 	}
 	// only add copyright headers when generating TPG, TPGB, and TPGN
-	if !(strings.HasSuffix(outputFolder, "terraform-provider-google") || strings.HasSuffix(outputFolder, "terraform-provider-google-beta") || strings.HasSuffix(outputFolder, "terraform-provider-google-nightly")) {
+	if !isHashicorpTarget(outputFolder) {
 		return
 	}
 
@@ -865,16 +865,32 @@ func (t Terraform) addHashicorpCopyRightHeader(outputFolder, target string) {
 
 func expectedOutputFolder(outputFolder string) bool {
 	expectedFolders := []string{"terraform-provider-google", "terraform-provider-google-beta", "terraform-provider-google-nightly", "terraform-next", "terraform-provider-google-internal", "terraform-google-conversion", "tfplan2cai"}
-	folderName := filepath.Base(outputFolder) // Possible issue with Windows OS
-	isExpected := false
-	for _, folder := range expectedFolders {
-		if folderName == folder {
-			isExpected = true
-			break
+	cleanPath := filepath.Clean(outputFolder)
+	parts := strings.Split(cleanPath, string(filepath.Separator))
+	for _, part := range parts {
+		for _, folder := range expectedFolders {
+			if part == folder {
+				return true
+			}
 		}
 	}
 
-	return isExpected
+	return false
+}
+
+func isHashicorpTarget(outputFolder string) bool {
+	targets := []string{"terraform-provider-google", "terraform-provider-google-beta", "terraform-provider-google-nightly"}
+	cleanPath := filepath.Clean(outputFolder)
+	parts := strings.Split(cleanPath, string(filepath.Separator))
+	for _, part := range parts {
+		for _, target := range targets {
+			if part == target {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (t Terraform) replaceImportPath(outputFolder, target string) {


### PR DESCRIPTION
Jetski  uses virtual worktrees which fills the logs and context window with these messages. Suppress it in these cases.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
