### PR TITLE
remove product level build -- confuses llm

### DIFF
--- a/.agents/skills/SKILL_TEMPLATE.md
+++ b/.agents/skills/SKILL_TEMPLATE.md
@@ -27,7 +27,7 @@ Provide the precise, bulletproof bash commands, python script, or instruction se
 #### Example: Compile Downstream Provider
 ```bash
 # Make terraform provider for Beta
-make terraform VERSION=beta OUTPUT_PATH=$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta PRODUCT=compute
+make terraform VERSION=beta OUTPUT_PATH=$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
 ```
 
 ### 3. Verification & Handoff

--- a/.agents/skills/workflows/add_list_resource/SKILL.md
+++ b/.agents/skills/workflows/add_list_resource/SKILL.md
@@ -115,7 +115,7 @@ PROVIDER_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google"
 # Stop if downstream has uncommitted work
 ( cd "$PROVIDER_PATH" && git status --porcelain ) && echo "Confirm clean before continuing"
 
-make provider VERSION=ga OUTPUT_PATH="$PROVIDER_PATH" PRODUCT=<PRODUCT>
+make provider VERSION=ga OUTPUT_PATH="$PROVIDER_PATH"
 ```
 
 Expected new files in the downstream per opted-in resource:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,10 +6,6 @@ default: build
 
 
 # mm setup
-ifneq ($(PRODUCT),)
-  mmv1_args=--product $(PRODUCT)
-endif
-
 ifneq ($(RESOURCE),)
   mmv1_args += --resource $(RESOURCE)
 endif
@@ -82,12 +78,7 @@ mmv1: mm_binary
 		fi
 
 clean-provider: check_safe_build
-	@if [ -n "$(PRODUCT)" ]; then \
-		printf "\n\e[1;33mWARNING:\e[0m Skipping clean-provider step because PRODUCT ('$(PRODUCT)') is set.\n"; \
-		printf " Ensure your downstream repository is synchronized with the Magic Modules branch\n"; \
-		printf " to avoid potential build inconsistencies.\n"; \
-		printf " Downstream repository (OUTPUT_PATH): %s\n\n" "$(OUTPUT_PATH)"; \
-	elif [ "$(SHOULD_SKIP_CLEAN)" = "true" ]; then \
+	@if [ "$(SHOULD_SKIP_CLEAN)" = "true" ]; then \
 		printf "\e[1;33mINFO:\e[0m Skipping clean-provider step because SKIP_CLEAN is set to a non-false value ('$(SKIP_CLEAN)').\n"; \
 	else \
 		echo "Executing clean-provider in $(OUTPUT_PATH)..."; \

--- a/docs/content/reference/make-commands.md
+++ b/docs/content/reference/make-commands.md
@@ -19,15 +19,6 @@ Examples:
 ```bash
 make provider VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google"
 make provider VERSION=beta OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta"
-
-# Only generate a specific product (plus all common files)
-make provider VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google" PRODUCT=pubsub
-
-# Only generate only a specific resources for a product
-make provider VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google" PRODUCT=pubsub RESOURCE=Topic
-
-# Only generate common files, including all third_party code
-make provider VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google" PRODUCT=doesnotexist
 ```
 
 #### Arguments


### PR DESCRIPTION
I've had several turns where the llm will do a product level build and since the tpgb files aren't cleaned up downstream it produces a garbled downstream. Removing product level build from make file and documentation since full build is sufficiently fast

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
