### PR TITLE
feat(chronicle): add google_chronicle_data_table_rows resource

### DIFF
--- a/mmv1/products/chronicle/DataTableRows.yaml
+++ b/mmv1/products/chronicle/DataTableRows.yaml
@@ -1,0 +1,98 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: DataTableRows
+description: Represents rows within a Chronicle Data Table, managed in bulk.
+base_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/dataTables/{{data_table_id}}/dataTableRows
+create_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/dataTables/{{data_table_id}}/dataTableRows:bulkReplace
+self_link: projects/{{project}}/locations/{{location}}/instances/{{instance}}/dataTables/{{data_table_id}}/dataTableRows
+update_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/dataTables/{{data_table_id}}/dataTableRows:bulkReplace
+update_verb: POST
+id_format: projects/{{project}}/locations/{{location}}/instances/{{instance}}/dataTables/{{data_table_id}}/dataTableRows
+import_format:
+  - projects/{{project}}/locations/{{location}}/instances/{{instance}}/dataTables/{{data_table_id}}/dataTableRows
+  - "{{project}}/{{location}}/{{instance}}/{{data_table_id}}"
+references:
+  guides:
+    'Google SecOps Guides': 'https://cloud.google.com/chronicle/docs/secops/secops-overview'
+  api: 'https://cloud.google.com/chronicle/docs/reference/rest/v1beta/projects.locations.instances.dataTables.dataTableRows'
+samples:
+  - name: 'chronicle_data_table_rows_basic'
+    primary_resource_id: 'example_rows'
+    steps:
+      - name: 'chronicle_data_table_rows_basic'
+        test_env_vars:
+          instance_id: 'CHRONICLE_ID'
+        resource_id_vars:
+          data_table_id: 'terraform_test_rows'
+autogen_status: RGF0YVRhYmxlUm93cw==
+custom_code:
+  constants: 'templates/terraform/constants/chronicle_data_table_rows.go.tmpl'
+  encoder: 'templates/terraform/encoders/chronicle_data_table_rows.go.tmpl'
+  decoder: 'templates/terraform/decoders/chronicle_data_table_rows.go.tmpl'
+  custom_delete: 'templates/terraform/custom_delete/chronicle_data_table_rows.go.tmpl'
+parameters:
+  - name: location
+    type: String
+    description: The GCP location of the Chronicle instance.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: instance
+    type: String
+    description: The Chronicle instance ID.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: dataTableId
+    type: String
+    description: The ID of the parent DataTable.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: rows
+    type: Array
+    is_set: true
+    set_hash_func: resourceChronicleDataTableRowHash
+    description: The rows belonging to the data table.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: values
+          type: Array
+          required: true
+          description: |-
+            All column values for a single row. The values should be in the same order
+            as the columns of the data tables.
+          item_type:
+            type: String
+        - name: rowTimeToLive
+          type: String
+          description: User-provided TTL of the data table row.
+        - name: name
+          type: String
+          description: |-
+            Identifier. The resource name of the data table row.
+            Format:
+            projects/{project}/locations/{location}/instances/{instance}/dataTables/{data_table_id}/dataTableRows/{data_table_row}
+          output: true
+        - name: createTime
+          type: String
+          description: DataTableRow create time
+          output: true
+        - name: updateTime
+          type: String
+          description: DataTableRow update time
+          output: true

--- a/mmv1/templates/terraform/constants/chronicle_data_table_rows.go.tmpl
+++ b/mmv1/templates/terraform/constants/chronicle_data_table_rows.go.tmpl
@@ -1,0 +1,16 @@
+func resourceChronicleDataTableRowHash(v interface{}) int {
+	if v == nil {
+		return 0
+	}
+	var buf bytes.Buffer
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return 0
+	}
+	if vals, ok := m["values"].([]interface{}); ok {
+		for _, val := range vals {
+			buf.WriteString(fmt.Sprintf("%v-", val))
+		}
+	}
+	return tpgresource.Hashcode(buf.String())
+}

--- a/mmv1/templates/terraform/custom_delete/chronicle_data_table_rows.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/chronicle_data_table_rows.go.tmpl
@@ -1,0 +1,61 @@
+parent, err := tpgresource.ReplaceVars(d, config, "projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/instances/{{"{{"}}instance{{"}}"}}/dataTables/{{"{{"}}data_table_id{{"}}"}}")
+if err != nil {
+	return err
+}
+
+getUrl, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config) + "projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/instances/{{"{{"}}instance{{"}}"}}/dataTables/{{"{{"}}data_table_id{{"}}"}}/dataTableRows")
+if err != nil {
+	return err
+}
+
+billingProject := ""
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+	billingProject = bp
+}
+
+// 1. GET existing rows to find row names
+res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    getUrl,
+	UserAgent: userAgent,
+})
+if err != nil {
+	return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ChronicleDataTableRows %q", d.Id()))
+}
+
+dataTableRows, ok := res["dataTableRows"].([]interface{})
+if !ok || len(dataTableRows) == 0 {
+	log.Printf("[DEBUG] No rows found for DataTable %q, skipping deletion", parent)
+	return nil
+}
+
+for _, rowRaw := range dataTableRows {
+	rowMap, ok := rowRaw.(map[string]interface{})
+	if !ok {
+		continue
+	}
+	name, ok := rowMap["name"].(string)
+	if !ok || name == "" {
+		continue
+	}
+	rowDeleteUrl, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config) + name)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] Deleting DataTableRow %q", name)
+	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "DELETE",
+		Project:   billingProject,
+		RawURL:    rowDeleteUrl,
+		UserAgent: userAgent,
+		Timeout:   d.Timeout(schema.TimeoutDelete),
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting DataTableRow %q: %s", name, err)
+	}
+}
+log.Printf("[DEBUG] Finished deleting all DataTableRows for %q", parent)
+return nil

--- a/mmv1/templates/terraform/decoders/chronicle_data_table_rows.go.tmpl
+++ b/mmv1/templates/terraform/decoders/chronicle_data_table_rows.go.tmpl
@@ -1,0 +1,16 @@
+{{/*
+    The license inside this block applies to this file
+    Copyright 2026 Google Inc.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/ -}}
+if rows, ok := res["dataTableRows"]; ok {
+	res["rows"] = rows
+}
+return res, nil

--- a/mmv1/templates/terraform/encoders/chronicle_data_table_rows.go.tmpl
+++ b/mmv1/templates/terraform/encoders/chronicle_data_table_rows.go.tmpl
@@ -1,0 +1,38 @@
+{{/*
+    The license inside this block applies to this file
+    Copyright 2026 Google Inc.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/ -}}
+config := meta.(*transport_tpg.Config)
+parent, err := tpgresource.ReplaceVars(d, config, "projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/instances/{{"{{"}}instance{{"}}"}}/dataTables/{{"{{"}}data_table_id{{"}}"}}")
+if err != nil {
+	return nil, err
+}
+
+var reqs []map[string]interface{}
+if rowsRaw, ok := obj["rows"]; ok && rowsRaw != nil {
+	rowsList := rowsRaw.([]interface{})
+	for _, r := range rowsList {
+		if r == nil {
+			continue
+		}
+		rowMap := r.(map[string]interface{})
+		reqs = append(reqs, map[string]interface{}{
+			"parent":        parent,
+			"dataTableRow": rowMap,
+		})
+	}
+}
+
+newObj := map[string]interface{}{
+	"parent":   parent,
+	"requests": reqs,
+}
+return newObj, nil

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_data_table_rows_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_data_table_rows_basic.tf.tmpl
@@ -1,0 +1,31 @@
+resource "google_chronicle_data_table" "example_dt" {
+  location        = "us"
+  instance        = "{{index $.TestEnvVars "instance_id"}}"
+  data_table_id   = "{{index $.ResourceIdVars "data_table_id"}}"
+  description     = "Sample DataTable for DataTableRows test"
+  deletion_policy = "FORCE"
+  column_info {
+    column_index    = 0
+    original_column = "username"
+    column_type     = "STRING"
+  }
+  column_info {
+    column_index    = 1
+    original_column = "ip_address"
+    column_type     = "CIDR"
+  }
+}
+
+resource "google_chronicle_data_table_rows" "example_rows" {
+  location      = "us"
+  instance      = "{{index $.TestEnvVars "instance_id"}}"
+  data_table_id = google_chronicle_data_table.example_dt.data_table_id
+  rows {
+    values           = ["user1", "192.168.1.1/32"]
+    row_time_to_live = "48h"
+  }
+  rows {
+    values           = ["user2", "10.0.0.1/32"]
+    row_time_to_live = "48h"
+  }
+}

--- a/mmv1/third_party/terraform/services/chronicle/resource_chronicle_data_table_rows_test.go
+++ b/mmv1/third_party/terraform/services/chronicle/resource_chronicle_data_table_rows_test.go
@@ -1,0 +1,132 @@
+package chronicle_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccChronicleDataTableRows_update(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"instance_id":   envvar.GetTestChronicleInstanceIdFromEnv(t),
+		"data_table_id": "tf_test_terraform_test_rows_" + randomSuffix,
+		"random_suffix": randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			// Step 1: Create initial 2 rows
+			{
+				Config: testAccChronicleDataTableRows_initial(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_chronicle_data_table_rows.example_rows", "rows.#", "2"),
+				),
+			},
+			// Step 2: Import Check
+			{
+				ResourceName:            "google_chronicle_data_table_rows.example_rows",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"data_table_id", "instance", "location"},
+			},
+			// Step 3: Update to 3 rows
+			{
+				Config: testAccChronicleDataTableRows_updated(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_chronicle_data_table_rows.example_rows", "rows.#", "3"),
+				),
+			},
+			// Step 4: Import Check after update
+			{
+				ResourceName:            "google_chronicle_data_table_rows.example_rows",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"data_table_id", "instance", "location"},
+			},
+		},
+	})
+}
+
+func testAccChronicleDataTableRows_initial(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_chronicle_data_table" "example_dt" {
+  location        = "us"
+  instance        = "%{instance_id}"
+  data_table_id   = "%{data_table_id}"
+  description     = "Sample DataTable for DataTableRows test"
+  deletion_policy = "FORCE"
+  column_info {
+    column_index    = 0
+    original_column = "username"
+    column_type     = "STRING"
+  }
+  column_info {
+    column_index    = 1
+    original_column = "ip_address"
+    column_type     = "CIDR"
+  }
+}
+
+resource "google_chronicle_data_table_rows" "example_rows" {
+  location      = "us"
+  instance      = "%{instance_id}"
+  data_table_id = google_chronicle_data_table.example_dt.data_table_id
+  rows {
+    values           = ["user1", "192.168.1.1/32"]
+    row_time_to_live = "48h"
+  }
+  rows {
+    values           = ["user2", "10.0.0.1/32"]
+    row_time_to_live = "48h"
+  }
+}
+`, context)
+}
+
+func testAccChronicleDataTableRows_updated(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_chronicle_data_table" "example_dt" {
+  location        = "us"
+  instance        = "%{instance_id}"
+  data_table_id   = "%{data_table_id}"
+  description     = "Sample DataTable for DataTableRows test"
+  deletion_policy = "FORCE"
+  column_info {
+    column_index    = 0
+    original_column = "username"
+    column_type     = "STRING"
+  }
+  column_info {
+    column_index    = 1
+    original_column = "ip_address"
+    column_type     = "CIDR"
+  }
+}
+
+resource "google_chronicle_data_table_rows" "example_rows" {
+  location      = "us"
+  instance      = "%{instance_id}"
+  data_table_id = google_chronicle_data_table.example_dt.data_table_id
+  rows {
+    values           = ["user1", "192.168.1.1/32"]
+    row_time_to_live = "48h"
+  }
+  rows {
+    values           = ["user2", "10.0.0.1/32"]
+    row_time_to_live = "48h"
+  }
+  rows {
+    values           = ["user3", "172.16.0.1/32"]
+    row_time_to_live = "48h"
+  }
+}
+`, context)
+}


### PR DESCRIPTION
This PR introduces the `google_chronicle_data_table_rows` resource to manage all rows in a Chronicle Data Table in bulk using the `:bulkReplace` API.

### Changes
* Added resource definition in `mmv1/products/chronicle/DataTableRows.yaml`.
* Added custom encoder to wrap rows into `BulkReplaceDataTableRowsRequest`.
* Added custom decoder to parse `GET .../dataTableRows` responses.
* Added custom delete logic to cleanly purge table rows during resource destruction.
* Used `is_set: true` with `resourceChronicleDataTableRowHash` to eliminate spurious drift caused by non-deterministic Spanner storage row order.
* Added documentation sample and acceptance tests.

### Test Results
=== RUN TestAccChronicleDataTableRows_chronicleDataTableRowsBasicExample --- PASS: TestAccChronicleDataTableRows_chronicleDataTableRowsBasicExample (31.86s) === RUN TestAccChronicleDataTableRows_update --- PASS: TestAccChronicleDataTableRows_update (41.67s) PASS

**Related Issue**
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29019

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
chronicle: added `BulkCreate`, `BulkGet`, `BulkReplace`, `BulkDelete` support to `google_chronicle_data_table_row` resource
```
