### PR TITLE
biglakehive: promote BigLake Hive Metastore resources to GA

### DIFF
--- a/mmv1/products/biglakehive/HiveCatalog.yaml
+++ b/mmv1/products/biglakehive/HiveCatalog.yaml
@@ -18,14 +18,11 @@ description: |
 references:
   guides:
     QUICKSTART_TITLE: https://docs.cloud.google.com/lakehouse/docs/about-spark-hive-metastore
-# hive/v1beta is added here instead of into the base url of the product.yaml.
+# hive/v1 is added here instead of into the base url of the product.yaml.
 # This is because the IAM policy does not contain this prefix, so it must be separated.
-base_url: hive/v1beta/projects/{{project}}/catalogs
-# Marks the resource as beta-only. Ensure a beta version block is present in
-# provider.yaml.
-min_version: beta
-self_link: hive/v1beta/projects/{{project}}/catalogs/{{name}}
-create_url: hive/v1beta/projects/{{project}}/catalogs?hiveCatalogId={{name}}&primary_location={{primary_location}}
+base_url: hive/v1/projects/{{project}}/catalogs
+self_link: hive/v1/projects/{{project}}/catalogs/{{name}}
+create_url: hive/v1/projects/{{project}}/catalogs?hiveCatalogId={{name}}&primary_location={{primary_location}}
 update_mask: true
 update_verb: PATCH
 # The IAM policy is shared with Iceberg Catalog (biglakeiceberg).

--- a/mmv1/products/biglakehive/HiveDatabase.yaml
+++ b/mmv1/products/biglakehive/HiveDatabase.yaml
@@ -18,12 +18,11 @@ description: |
 references:
   guides:
     'QUICKSTART_TITLE': 'https://docs.cloud.google.com/lakehouse/docs/about-spark-hive-metastore'
-min_version: beta
-# hive/v1beta is added here instead of into the base url of the product.yaml.
+# hive/v1 is added here instead of into the base url of the product.yaml.
 # This is because the IAM policy does not contain this prefix, so it must be separated.
-base_url: 'hive/v1beta/projects/{{project}}/catalogs/{{catalog}}/databases'
-self_link: 'hive/v1beta/projects/{{project}}/catalogs/{{catalog}}/databases/{{name}}'
-create_url: 'hive/v1beta/projects/{{project}}/catalogs/{{catalog}}/databases?hiveDatabaseId={{name}}'
+base_url: 'hive/v1/projects/{{project}}/catalogs/{{catalog}}/databases'
+self_link: 'hive/v1/projects/{{project}}/catalogs/{{catalog}}/databases/{{name}}'
+create_url: 'hive/v1/projects/{{project}}/catalogs/{{catalog}}/databases?hiveDatabaseId={{name}}'
 update_verb: 'PATCH'
 update_mask: true
 # The IAM policy is shared with Iceberg Catalog (biglakeiceberg).
@@ -40,7 +39,6 @@ iam_policy:
 samples:
   - name: 'biglake_hive_database'
     primary_resource_id: 'my_hive_database'
-    min_version: beta
     steps:
       - name: 'biglake_hive_database'
         resource_id_vars:

--- a/mmv1/products/biglakehive/HiveTable.yaml
+++ b/mmv1/products/biglakehive/HiveTable.yaml
@@ -14,12 +14,11 @@
 ---
 name: 'HiveTable'
 description: 'Hive Tables in BigLake Metastore that exist within a Hive Catalog and Database.'
-min_version: 'beta'
-# hive/v1beta is added here instead of into the base url of the product.yaml.
+# hive/v1 is added here instead of into the base url of the product.yaml.
 # This is because the IAM policy does not contain this prefix, so it must be separated.
-base_url: 'hive/v1beta/projects/{{project}}/catalogs/{{catalog}}/databases/{{database}}/tables'
-self_link: 'hive/v1beta/projects/{{project}}/catalogs/{{catalog}}/databases/{{database}}/tables/{{name}}'
-create_url: 'hive/v1beta/projects/{{project}}/catalogs/{{catalog}}/databases/{{database}}/tables?hiveTableId={{name}}'
+base_url: 'hive/v1/projects/{{project}}/catalogs/{{catalog}}/databases/{{database}}/tables'
+self_link: 'hive/v1/projects/{{project}}/catalogs/{{catalog}}/databases/{{database}}/tables/{{name}}'
+create_url: 'hive/v1/projects/{{project}}/catalogs/{{catalog}}/databases/{{database}}/tables?hiveTableId={{name}}'
 update_verb: 'PATCH'
 update_mask: true
 
@@ -36,7 +35,6 @@ iam_policy:
 samples:
   - name: 'biglake_hive_table'
     primary_resource_id: 'my_hive_table'
-    min_version: beta
     steps:
       - name: 'biglake_hive_table'
         resource_id_vars:

--- a/mmv1/products/biglakehive/product.yaml
+++ b/mmv1/products/biglakehive/product.yaml
@@ -21,5 +21,3 @@ scopes:
 versions:
   - name: ga
     base_url: https://biglake.googleapis.com/
-  - name: beta
-    base_url: https://biglake.googleapis.com/

--- a/mmv1/templates/terraform/samples/services/biglakehive/biglake_hive_catalog.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/biglakehive/biglake_hive_catalog.tf.tmpl
@@ -3,7 +3,6 @@ resource "google_storage_bucket" "bucket_for_{{$.PrimaryResourceId}}" {
   location      = "us-central1"
   force_destroy = true
   uniform_bucket_level_access = true
-  provider = google-beta
 }
 
 resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
@@ -13,5 +12,4 @@ resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
   depends_on = [
     google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
   ]
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/samples/services/biglakehive/biglake_hive_catalog_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/biglakehive/biglake_hive_catalog_full.tf.tmpl
@@ -3,7 +3,6 @@ resource "google_storage_bucket" "bucket_for_{{$.PrimaryResourceId}}" {
   location      = "us-central1"
   force_destroy = true
   uniform_bucket_level_access = true
-  provider = google-beta
 }
 
 resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
@@ -14,5 +13,4 @@ resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
   depends_on = [
     google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
   ]
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/samples/services/biglakehive/biglake_hive_database.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/biglakehive/biglake_hive_database.tf.tmpl
@@ -1,11 +1,3 @@
-terraform {
-  required_providers {
-    google = {
-      source = "hashicorp/google-beta"
-    }
-  }
-}
-
 resource "google_storage_bucket" "bucket" {
   name          = "{{index $.ResourceIdVars "bucket_name"}}"
   location      = "us-central1"

--- a/mmv1/templates/terraform/samples/services/biglakehive/biglake_hive_table.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/biglakehive/biglake_hive_table.tf.tmpl
@@ -1,11 +1,3 @@
-terraform {
-  required_providers {
-    google = {
-      source = "hashicorp/google-beta"
-    }
-  }
-}
-
 resource "google_storage_bucket" "bucket" {
   name          = "{{index $.ResourceIdVars "bucket_name"}}"
   location      = "us-central1"

--- a/mmv1/third_party/terraform/services/biglakehive/resource_biglake_hive_catalog_test.go
+++ b/mmv1/third_party/terraform/services/biglakehive/resource_biglake_hive_catalog_test.go
@@ -1,6 +1,5 @@
 package biglakehive_test
 
-{{- if ne $.TargetVersionName "ga" }}
 import (
 	"fmt"
 	"log"
@@ -47,7 +46,7 @@ func TestAccBiglakeHiveHiveCatalog_biglakeHiveCatalog_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckBiglakeHiveHiveCatalogDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -79,14 +78,11 @@ func TestAccBiglakeHiveHiveCatalog_biglakeHiveCatalog_update(t *testing.T) {
 
 func testAccBiglakeHiveHiveCatalog_biglakeHiveCatalog_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-provider "google-beta" {
-}
 resource "google_storage_bucket" "bucket_for_my_hive_catalog" {
   name          = "%{name}"
   location      = "us-central1"
   force_destroy = true
   uniform_bucket_level_access = true
-  provider      = google-beta
 }
 
 resource "google_biglake_hive_catalog" "my_hive_catalog" {
@@ -97,8 +93,6 @@ resource "google_biglake_hive_catalog" "my_hive_catalog" {
   depends_on = [
 	google_storage_bucket.bucket_for_my_hive_catalog
   ]
-  provider = google-beta
 }
 `, context)
 }
-{{- end }}


### PR DESCRIPTION
Promote BigLake Hive Metastore resources (`google_biglake_hive_catalog`, `google_biglake_hive_database`, and `google_biglake_hive_table`) to GA.

```release-note:new-resource
`google_biglake_hive_catalog` (ga)
```
```release-note:new-resource
`google_biglake_hive_database` (ga)
```
```release-note:new-resource
`google_biglake_hive_table` (ga)
```