### PR TITLE
Bump UA to dev8

### DIFF
--- a/mmv1/third_party/terraform/version/version.go
+++ b/mmv1/third_party/terraform/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// ProviderVersion is set during the release process to the release version of the binary
-	ProviderVersion = "dev7"
+	ProviderVersion = "dev8"
 )


### PR DESCRIPTION
Update default fallback provider version to `dev8` for the 8.0.0 major release cycle.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```