### PR TITLE
contactcenterinsights: add list resources

### DIFF
--- a/mmv1/products/contactcenterinsights/AnalysisRule.yaml
+++ b/mmv1/products/contactcenterinsights/AnalysisRule.yaml
@@ -24,6 +24,7 @@ references:
     Configure analysis rules using the API: https://cloud.google.com/contact-center/insights/docs/analysis-rule
   api: https://cloud.google.com/contact-center/insights/docs/reference/rest/v1/projects.locations.analysisRules
 base_url: projects/{{project}}/locations/{{location}}/analysisRules
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/analysisRules/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/analysisRules
 delete_url: projects/{{project}}/locations/{{location}}/analysisRules/{{name}}

--- a/mmv1/products/contactcenterinsights/AssessmentRule.yaml
+++ b/mmv1/products/contactcenterinsights/AssessmentRule.yaml
@@ -23,6 +23,7 @@ references:
     Configure assessment rules using the API: https://cloud.google.com/contact-center/insights/docs/assessment-rule
   api: https://cloud.google.com/contact-center/insights/docs/reference/rest/v1/projects.locations.assessmentRules
 base_url: projects/{{project}}/locations/{{location}}/assessmentRules
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/assessmentRules/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/assessmentRules?assessmentRuleId={{assessment_rule_id}}
 update_mask: true

--- a/mmv1/products/contactcenterinsights/AssessmentRule.yaml
+++ b/mmv1/products/contactcenterinsights/AssessmentRule.yaml
@@ -23,7 +23,6 @@ references:
     Configure assessment rules using the API: https://cloud.google.com/contact-center/insights/docs/assessment-rule
   api: https://cloud.google.com/contact-center/insights/docs/reference/rest/v1/projects.locations.assessmentRules
 base_url: projects/{{project}}/locations/{{location}}/assessmentRules
-generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/assessmentRules/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/assessmentRules?assessmentRuleId={{assessment_rule_id}}
 update_mask: true

--- a/mmv1/products/contactcenterinsights/AutoLabelingRule.yaml
+++ b/mmv1/products/contactcenterinsights/AutoLabelingRule.yaml
@@ -21,7 +21,6 @@ references:
     Configure auto labeling rules using the API: https://cloud.google.com/contact-center/insights/docs/auto-labeling-rule
   api: https://cloud.google.com/contact-center/insights/docs/reference/rest/v1/projects.locations.autoLabelingRules
 base_url: projects/{{project}}/locations/{{location}}/autoLabelingRules
-generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/autoLabelingRules/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/autoLabelingRules?autoLabelingRuleId={{auto_labeling_rule_id}}
 update_mask: true

--- a/mmv1/products/contactcenterinsights/AutoLabelingRule.yaml
+++ b/mmv1/products/contactcenterinsights/AutoLabelingRule.yaml
@@ -21,6 +21,7 @@ references:
     Configure auto labeling rules using the API: https://cloud.google.com/contact-center/insights/docs/auto-labeling-rule
   api: https://cloud.google.com/contact-center/insights/docs/reference/rest/v1/projects.locations.autoLabelingRules
 base_url: projects/{{project}}/locations/{{location}}/autoLabelingRules
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/autoLabelingRules/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/autoLabelingRules?autoLabelingRuleId={{auto_labeling_rule_id}}
 update_mask: true

--- a/mmv1/products/contactcenterinsights/QaScorecard.yaml
+++ b/mmv1/products/contactcenterinsights/QaScorecard.yaml
@@ -15,6 +15,7 @@
 name: QaScorecard
 description: A QaScorecard represents a collection of questions to be scored during analysis.
 base_url: projects/{{project}}/locations/{{location}}/qaScorecards
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/qaScorecards/{{qa_scorecard_id}}
 create_url: projects/{{project}}/locations/{{location}}/qaScorecards?qaScorecardId={{qa_scorecard_id}}
 update_mask: true

--- a/mmv1/products/contactcenterinsights/View.yaml
+++ b/mmv1/products/contactcenterinsights/View.yaml
@@ -18,6 +18,7 @@ description: |
 references:
   api: https://cloud.google.com/contact-center/insights/docs/reference/rest/v1/projects.locations.views
 base_url: projects/{{project}}/locations/{{location}}/views
+generate_list_resource: true
 self_link: projects/{{project}}/locations/{{location}}/views/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/views
 delete_url: projects/{{project}}/locations/{{location}}/views/{{name}}

--- a/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
@@ -20,6 +20,7 @@
 package {{ lower $.ProductMetadata.Name }}_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -32,6 +33,7 @@ import (
 )
 
 var (
+	_ = strings.Trim
 	_ = envvar.TestEnvVar
 )
 


### PR DESCRIPTION
Adds list-resource generation for the following contactcenterinsights resources:

- `google_contact_center_insights_analysis_rule`
- `google_contact_center_insights_assessment_rule`
- `google_contact_center_insights_auto_labeling_rule`
- `google_contact_center_insights_qa_scorecard`
- `google_contact_center_insights_view`

`query_test_file.go.tmpl` now imports `strings` (with `_ = strings.Trim`, same pattern as the regular sample test file) so list-query tests compile when the first sample uses `strings.*` in `test_vars_overrides`.

Left out:

- `EncryptionSpec` — location singleton, no list collection
- `QaScorecardRevision` / `QaQuestion` — list URLs have unsupported parent scope params

```release-note:new-list-resource
`google_contact_center_insights_analysis_rule`
```

```release-note:new-list-resource
`google_contact_center_insights_assessment_rule`
```

```release-note:new-list-resource
`google_contact_center_insights_auto_labeling_rule`
```

```release-note:new-list-resource
`google_contact_center_insights_qa_scorecard`
```

```release-note:new-list-resource
`google_contact_center_insights_view`
```
