### PR TITLE
Fix TF tests: Replace oci-terraform-testing-prod with oasis-terraform-testing-prod

### DIFF
--- a/mmv1/products/oracledatabase/AutonomousDatabase.yaml
+++ b/mmv1/products/oracledatabase/AutonomousDatabase.yaml
@@ -58,7 +58,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           database_name: fmt.Sprintf("tftestdatabase%s", acctest.RandString(t, 10))
   - name: oracledatabase_autonomous_database_full
     primary_resource_id: myADB
@@ -78,12 +78,12 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: "false"
           database_name: fmt.Sprintf("tftestdatabase%s", acctest.RandString(t, 10))
           endpoint_name: fmt.Sprintf("tftestendpoint%s", acctest.RandString(t, 10))
-          odb_network: '"projects/oci-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork"'
-          odb_subnet: '"projects/oci-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+          odb_network: '"projects/oasis-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork"'
+          odb_subnet: '"projects/oasis-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
   - name: oracledatabase_autonomous_database_odbnetwork
     primary_resource_id: myADB
     steps:
@@ -99,10 +99,10 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           database_name: fmt.Sprintf("tftestdatabase%s", acctest.RandString(t, 10))
-          odb_network: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
-          odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+          odb_network: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
+          odb_subnet: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
   - name: oracledatabase_autonomous_database_publicip
     primary_resource_id: myADB
     steps:
@@ -116,7 +116,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           database_name: fmt.Sprintf("tftestdatabase%s", acctest.RandString(t, 10))
   - name: oracledatabase_autonomous_database_disaster_recovery
     primary_resource_id: myADB
@@ -133,7 +133,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           location: '"us-west3"'
           database_name: fmt.Sprintf("tftestdatabase%s", acctest.RandString(t, 10))
           enable_backup_replication: "true"

--- a/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
+++ b/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
@@ -56,7 +56,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: "false"
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
@@ -74,7 +74,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: "false"
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770

--- a/mmv1/products/oracledatabase/CloudExadataInfrastructureExascaleConfig.yaml
+++ b/mmv1/products/oracledatabase/CloudExadataInfrastructureExascaleConfig.yaml
@@ -51,7 +51,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           cloud_exadata_infrastructure_id: fmt.Sprintf("ofake-test-tf-configured-exadata-%s", acctest.RandString(t, 10))
 parameters:
   - name: location

--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -60,7 +60,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
           # As a result these resources are not sweepable
@@ -83,16 +83,16 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
           # As a result these resources are not sweepable
           # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
           cloud_vm_cluster_id: fmt.Sprintf("ofake-tf-test-vmcluster-odbnetwork-%s", acctest.RandString(t, 10))
           cloud_exadata_infrastructure_id: fmt.Sprintf("ofake-tf-test-exadata-for-vmcluster-odbnetwork-%s", acctest.RandString(t, 10))
-          odb_network: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
-          odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
-          backup_odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-backup-odbsubnet"'
+          odb_network: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
+          odb_subnet: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+          backup_odb_subnet: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-backup-odbsubnet"'
   - name: oracledatabase_cloud_vmcluster_full
     primary_resource_id: my_vmcluster
     steps:
@@ -106,7 +106,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
           # As a result these resources are not sweepable
@@ -127,7 +127,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           cloud_vm_cluster_id: fmt.Sprintf("ofake-tf-test-vmcluster-exascale-%s", acctest.RandString(t, 10))
           cloud_exadata_infrastructure_id: fmt.Sprintf("ofake-tf-test-exadata-for-vmcluster-exascale-%s", acctest.RandString(t, 10))
           exascale_db_storage_vault_id: fmt.Sprintf("ofake-tf-test-vault-for-vmcluster-exascale-%s", acctest.RandString(t, 10))

--- a/mmv1/products/oracledatabase/DbSystem.yaml
+++ b/mmv1/products/oracledatabase/DbSystem.yaml
@@ -60,7 +60,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
           # As a result these resources are not sweepable
@@ -68,8 +68,8 @@ samples:
           db_system_id: fmt.Sprintf("ofake-tf-test-dbsystem-basic-%s", acctest.RandString(t, 10))
           database_id: fmt.Sprintf("ofake-tf-test-database-basic-%s", acctest.RandString(t, 10))
           db_unique_name: fmt.Sprintf("db%s", acctest.RandString(t, 10))
-          odb_network: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
-          odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+          odb_network: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
+          odb_subnet: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
   - name: oracledatabase_db_system_full
     primary_resource_id: my_db_system
     steps:
@@ -87,7 +87,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
           # As a result these resources are not sweepable
@@ -96,8 +96,8 @@ samples:
           database_id: fmt.Sprintf("ofake-tf-test-database-basic-%s", acctest.RandString(t, 10))
           pluggable_database_id: fmt.Sprintf("ofake-tf-test-mypdb-%s", acctest.RandString(t, 10))
           db_unique_name: fmt.Sprintf("db%s", acctest.RandString(t, 10))
-          odb_network: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
-          odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+          odb_network: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
+          odb_subnet: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
 virtual_fields:
   - name: deletion_protection
     type: Boolean

--- a/mmv1/products/oracledatabase/ExadbVmCluster.yaml
+++ b/mmv1/products/oracledatabase/ExadbVmCluster.yaml
@@ -62,16 +62,16 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
           # As a result these resources are not sweepable
           # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
           exadb_vm_cluster_id: fmt.Sprintf("ofake-tf-test-exadb-vm-cluster-basic-%s", acctest.RandString(t, 10))
           exascale_db_storage_vault_id: fmt.Sprintf("ofake-tf-test-storage-vault-basic-%s", acctest.RandString(t, 10))
-          odb_network: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
-          odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
-          backup_odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-backup-odbsubnet"'
+          odb_network: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
+          odb_subnet: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+          backup_odb_subnet: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-backup-odbsubnet"'
   - name: oracledatabase_exadb_vm_cluster_full
     primary_resource_id: my_exadb_vm_cluster
     steps:
@@ -88,16 +88,16 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
           # As a result these resources are not sweepable
           # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
           exadb_vm_cluster_id: fmt.Sprintf("ofake-tf-test-exadb-vm-cluster-basic-%s", acctest.RandString(t, 10))
           exascale_db_storage_vault_id: fmt.Sprintf("ofake-tf-test-storage-vault-basic-%s", acctest.RandString(t, 10))
-          odb_network: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
-          odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
-          backup_odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-backup-odbsubnet"'
+          odb_network: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
+          odb_subnet: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+          backup_odb_subnet: '"projects/oasis-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-backup-odbsubnet"'
 virtual_fields:
   - name: deletion_protection
     type: Boolean

--- a/mmv1/products/oracledatabase/ExascaleDbStorageVault.yaml
+++ b/mmv1/products/oracledatabase/ExascaleDbStorageVault.yaml
@@ -57,7 +57,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
           # As a result these resources are not sweepable
@@ -75,7 +75,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           # ofake- prefix is needed to create a dummy resource for testing purposes only
           # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
           # As a result these resources are not sweepable
@@ -94,7 +94,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-configured-exadata-%s", acctest.RandString(t, 10))'
           exascale_db_storage_vault_id: 'fmt.Sprintf("ofake-tf-test-vault-on-exadata-%s", acctest.RandString(t, 10))'
 virtual_fields:

--- a/mmv1/products/oracledatabase/GoldengateConnection.yaml
+++ b/mmv1/products/oracledatabase/GoldengateConnection.yaml
@@ -55,7 +55,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: false
           goldengate_connection_id: fmt.Sprintf("tf-conn-basic-%s", acctest.RandString(t, 10))
   - name: oracledatabase_goldengate_connection_full
@@ -73,10 +73,10 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: false
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           goldengate_connection_id: fmt.Sprintf("tf-conn-full-%s", acctest.RandString(t, 10))
-          odb_network: '"projects/oci-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork"'
-          odb_subnet: '"projects/oci-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+          odb_network: '"projects/oasis-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork"'
+          odb_subnet: '"projects/oasis-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
           autonomous_database_id: '"do-not-delete-tf-adb"'
   - name: oracledatabase_goldengate_connection_mysql
     primary_resource_id: connection
@@ -89,7 +89,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: false
           goldengate_connection_id: fmt.Sprintf("tf-conn-mysql-%s", acctest.RandString(t, 10))
   - name: oracledatabase_goldengate_connection_postgresql
@@ -103,7 +103,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: false
           goldengate_connection_id: fmt.Sprintf("tf-conn-pg-%s", acctest.RandString(t, 10))
   - name: oracledatabase_goldengate_connection_redis
@@ -117,7 +117,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: false
           goldengate_connection_id: fmt.Sprintf("tf-conn-redis-%s", acctest.RandString(t, 10))
   - name: oracledatabase_goldengate_connection_kafka
@@ -131,7 +131,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: false
           goldengate_connection_id: fmt.Sprintf("tf-conn-kafka-%s", acctest.RandString(t, 10))
   - name: oracledatabase_goldengate_connection_iceberg
@@ -145,7 +145,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: false
           goldengate_connection_id: fmt.Sprintf("tf-conn-iceberg-%s", acctest.RandString(t, 10))
   - name: oracledatabase_goldengate_connection_snowflake
@@ -159,7 +159,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: false
           goldengate_connection_id: fmt.Sprintf("tf-conn-snowflake-%s", acctest.RandString(t, 10))
   - name: oracledatabase_goldengate_connection_jms
@@ -173,7 +173,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: false
           goldengate_connection_id: fmt.Sprintf("tf-conn-jms-%s", acctest.RandString(t, 10))
 virtual_fields:

--- a/mmv1/products/oracledatabase/GoldengateConnectionAssignment.yaml
+++ b/mmv1/products/oracledatabase/GoldengateConnectionAssignment.yaml
@@ -55,7 +55,7 @@ samples:
         ignore_read_extra:
           - deletion_protection
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_protection: false
           goldengate_connection_assignment_id: fmt.Sprintf("tf-gcca-%s", acctest.RandString(t, 10))
           goldengate_deployment_id: '"tf-test-permanent-deployment"'

--- a/mmv1/products/oracledatabase/GoldengateDeployment.yaml
+++ b/mmv1/products/oracledatabase/GoldengateDeployment.yaml
@@ -54,10 +54,10 @@ samples:
         ignore_read_extra:
           - deletion_policy
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_policy: '"DELETE"'
           goldengate_deployment_id: fmt.Sprintf("tf-ggdep-basic-%s", acctest.RandString(t, 10))
-          odb_subnet: '"projects/oci-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+          odb_subnet: '"projects/oasis-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
   - name: oracledatabase_goldengate_deployment_full
     primary_resource_id: deployment
     steps:
@@ -71,11 +71,11 @@ samples:
         ignore_read_extra:
           - deletion_policy
         test_vars_overrides:
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           deletion_policy: '"DELETE"'
           goldengate_deployment_id: fmt.Sprintf("tf-ggdep-full-%s", acctest.RandString(t, 10))
-          odb_network: '"projects/oci-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork"'
-          odb_subnet: '"projects/oci-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+          odb_network: '"projects/oasis-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork"'
+          odb_subnet: '"projects/oasis-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
 parameters:
   - name: location
     type: String

--- a/mmv1/products/oracledatabase/OdbNetwork.yaml
+++ b/mmv1/products/oracledatabase/OdbNetwork.yaml
@@ -60,7 +60,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           odb_network_id: fmt.Sprintf("tf-test-odbnetwork-%s", acctest.RandString(t, 10))
   - name: oracledatabase_odbnetwork_full
     primary_resource_id: my-odbnetwork
@@ -74,7 +74,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           odb_network_id: fmt.Sprintf("tf-test-odbnetwork-full-%s", acctest.RandString(t, 10))
 virtual_fields:
   - name: deletion_protection

--- a/mmv1/products/oracledatabase/OdbSubnet.yaml
+++ b/mmv1/products/oracledatabase/OdbSubnet.yaml
@@ -65,7 +65,7 @@ samples:
           - deletion_protection
         test_vars_overrides:
           deletion_protection: "false"
-          project: '"oci-terraform-testing-prod"'
+          project: '"oasis-terraform-testing-prod"'
           odb_network_id: '"tf-test-permanent-odbnetwork"'
           odb_subnet_id: fmt.Sprintf("tf-test-odbsubnet-%s", acctest.RandString(t, 10))
           cidr_range: fmt.Sprintf("10.1.%d.0/24", acctest.RandInt(t) % 200 + 10)

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_autonomous_database_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_autonomous_database_test.go
@@ -20,8 +20,6 @@ func TestAccOracleDatabaseAutonomousDatabase_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_database.my-adb", "display_name"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_database.my-adb", "database"),
-					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_database.my-adb", "cidr"),
-					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_database.my-adb", "network"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_database.my-adb", "properties.#"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_database.my-adb", "properties.0.character_set"),
 				),

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_autonomous_database_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_autonomous_database_test.go
@@ -35,7 +35,7 @@ func testAccOracleDatabaseAutonomousDatabase_basic() string {
 data "google_oracle_database_autonomous_database" "my-adb"{
 	autonomous_database_id = "do-not-delete-tf-adb"
 	location = "us-east4"
-	project = "oci-terraform-testing-prod"
+	project = "oasis-terraform-testing-prod"
 }
 `)
 }

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_autonomous_databases_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_autonomous_databases_test.go
@@ -36,7 +36,7 @@ func testAccOracleDatabaseAutonomousDatabases_basic() string {
 	return fmt.Sprintf(`
 data "google_oracle_database_autonomous_databases" "my-adbs"{
   location = "us-east4"
-  project = "oci-terraform-testing-prod"
+  project = "oasis-terraform-testing-prod"
 }
 `)
 }

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_autonomous_databases_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_autonomous_databases_test.go
@@ -20,8 +20,6 @@ func TestAccOracleDatabaseAutonomousDatabases_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.#"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.display_name"),
-					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.cidr"),
-					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.network"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.entitlement_id"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.database"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.properties.#"),

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_cloud_exadata_infrastructure_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_cloud_exadata_infrastructure_test.go
@@ -36,7 +36,7 @@ func testAccOracleDatabaseCloudExadataInfrastructure_basic() string {
 	return fmt.Sprintf(`
 data "google_oracle_database_cloud_exadata_infrastructure" "my-exadata"{
   cloud_exadata_infrastructure_id = "ofake-do-not-delete-tf-exadata"
-  project = "oci-terraform-testing-prod"
+  project = "oasis-terraform-testing-prod"
   location = "us-east4"
 }
 `)

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_cloud_exadata_infrastructures_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_cloud_exadata_infrastructures_test.go
@@ -37,7 +37,7 @@ func testAccOracleDatabaseCloudExadataInfrastructures_basic() string {
 	return fmt.Sprintf(`
 data "google_oracle_database_cloud_exadata_infrastructures" "my_cloud_exadatas"{
   location = "us-east4"
-  project = "oci-terraform-testing-prod"
+  project = "oasis-terraform-testing-prod"
 }
 `)
 }

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_cloud_vm_cluster_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_cloud_vm_cluster_test.go
@@ -39,7 +39,7 @@ func testAccOracleDatabaseCloudVmCluster_basic() string {
 	return fmt.Sprintf(`
 data "google_oracle_database_cloud_vm_cluster" "my-vmcluster"{
   cloud_vm_cluster_id = "ofake-do-not-delete-tf-vmcluster"
-  project = "oci-terraform-testing-prod"
+  project = "oasis-terraform-testing-prod"
   location = "us-east4"
 }
 `)

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_cloud_vm_clusters_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_cloud_vm_clusters_test.go
@@ -31,7 +31,7 @@ func testAccOracleDatabaseCloudVmClusters_basic() string {
 	return fmt.Sprintf(`
 data "google_oracle_database_cloud_vm_clusters" "my_vmclusters"{
   location = "us-east4"
-  project = "oci-terraform-testing-prod"
+  project = "oasis-terraform-testing-prod"
 }
 `)
 }

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_db_nodes_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_db_nodes_test.go
@@ -35,7 +35,7 @@ func testAccOracleDatabaseDbNodesConfig() string {
 	return fmt.Sprintf(`
 data "google_oracle_database_db_nodes" "my_db_nodes"{
 	location = "us-east4"
-	project = "oci-terraform-testing-prod"
+	project = "oasis-terraform-testing-prod"
 	cloud_vm_cluster = "ofake-do-not-delete-tf-vmcluster"
 }
 `)

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_db_servers_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_db_servers_test.go
@@ -34,7 +34,7 @@ func TestAccOracleDatabaseDbServers_basic(t *testing.T) {
 const testAccOracleDatabaseDbServers_basic = `
 data "google_oracle_database_db_servers" "my_db_servers"{
 	location = "us-east4"
-	project = "oci-terraform-testing-prod"
+	project = "oasis-terraform-testing-prod"
 	cloud_exadata_infrastructure = "ofake-do-not-delete-tf-exadata"
 }
 `

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vault_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vault_test.go
@@ -16,7 +16,7 @@ func TestAccOracleDatabaseExascaleDbStorageVaultDataSource_basic(t *testing.T) {
 
 	context := map[string]interface{}{
 		"vault_id": vaultId,
-		"project":  "oci-terraform-testing-prod",
+		"project":  "oasis-terraform-testing-prod",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vaults_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vaults_test.go
@@ -16,7 +16,7 @@ func TestAccOracleDatabaseExascaleDbStorageVaultsDataSource_basic(t *testing.T) 
 
 	context := map[string]interface{}{
 		"vault_id": vaultId,
-		"project":  "oci-terraform-testing-prod",
+		"project":  "oasis-terraform-testing-prod",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_connection_types_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_connection_types_test.go
@@ -10,7 +10,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-google/google/services/oracledatabase"
 )
 
-var oracleProject = flag.String("oracle_project", "oci-terraform-testing-prod", "The project to use for Oracle Database tests")
+var oracleProject = flag.String("oracle_project", "oasis-terraform-testing-prod", "The project to use for Oracle Database tests")
 
 func TestAccOracleDatabaseGoldengateConnectionTypes_basic(t *testing.T) {
 	t.Parallel()

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_deployment_environments_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_deployment_environments_test.go
@@ -30,7 +30,7 @@ func testAccOracleDatabaseGoldengateDeploymentEnvironmentsConfig() string {
 	return fmt.Sprintf(`
 data "google_oracle_database_goldengate_deployment_environments" "my_deployment_environments" {
 	location = "us-east4"
-	project  = "oci-terraform-testing-prod"
+	project  = "oasis-terraform-testing-prod"
 }
 `)
 }

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_deployment_types_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_deployment_types_test.go
@@ -29,7 +29,7 @@ func testAccOracleDatabaseGoldengateDeploymentTypesConfig() string {
 	return fmt.Sprintf(`
 data "google_oracle_database_goldengate_deployment_types" "my_deployment_types" {
 	location = "us-east4"
-	project  = "oci-terraform-testing-prod"
+	project  = "oasis-terraform-testing-prod"
 }
 `)
 }

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_deployment_versions_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_deployment_versions_test.go
@@ -29,7 +29,7 @@ func testAccOracleDatabaseGoldengateDeploymentVersionsConfig() string {
 	return fmt.Sprintf(`
 data "google_oracle_database_goldengate_deployment_versions" "my_deployment_versions" {
 	location = "us-east4"
-	project  = "oci-terraform-testing-prod"
+	project  = "oasis-terraform-testing-prod"
 }
 `)
 }

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_odb_network_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_odb_network_test.go
@@ -34,7 +34,7 @@ func testAccOracleDatabaseOdbNetwork_basic() string {
 data "google_oracle_database_odb_network" "my-net" {
   odb_network_id = "tf-test-permanent-odbnetwork"
   location = "europe-west2"
-  project = "oci-terraform-testing-prod"
+  project = "oasis-terraform-testing-prod"
 }
 `)
 }

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_odb_subnet_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_odb_subnet_test.go
@@ -35,7 +35,7 @@ data "google_oracle_database_odb_subnet" "my-subnet" {
   odb_subnet_id = "tf-test-permanent-client-odbsubnet"
   odbnetwork = "tf-test-permanent-odbnetwork"
   location = "europe-west2"
-  project = "oci-terraform-testing-prod"
+  project = "oasis-terraform-testing-prod"
 }
 `)
 }


### PR DESCRIPTION
This PR updates the project ID used in Oracle Database acceptance tests and configurations from `oci-terraform-testing-prod` to `oasis-terraform-testing-prod`. 

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/29022

This is required due to an urgent migration of tenancy for Oracle. Failing to update these references puts all Terraform tests for these services at risk of failure.

**Release Note Template for Downstream PRs**

```release-note:none
```

