### PR TITLE
colab: add custom_container_image to workbench_runtime in google_colab_notebook_execution

### DIFF
--- a/mmv1/products/colab/NotebookExecution.yaml
+++ b/mmv1/products/colab/NotebookExecution.yaml
@@ -73,6 +73,15 @@ samples:
         test_env_vars:
           project_id: 'PROJECT_NAME'
           service_account: 'SERVICE_ACCT'
+  - name: 'colab_notebook_execution_workbench_runtime_container'
+    primary_resource_id: 'notebook-execution'
+    steps:
+      - name: 'colab_notebook_execution_workbench_runtime_container'
+        resource_id_vars:
+          bucket: 'my_bucket'
+        test_env_vars:
+          project_id: 'PROJECT_NAME'
+          service_account: 'SERVICE_ACCT'
   - name: 'colab_notebook_execution_full'
     min_version: beta
     primary_resource_id: 'notebook-execution'
@@ -247,9 +256,25 @@ properties:
     ignore_read: true
     description: 'Configuration for a Workbench Instances-based environment.'
     properties:
+      - name: customContainerImage
+        type: NestedObject
+        exactly_one_of:
+          - workbench_runtime.0.custom_container_image
+          - workbench_runtime.0.vm_image
+        description: 'Use a user-provided container image to run the notebook execution in. The notebook execution will run in a container based on this image.'
+        properties:
+          - name: repository
+            type: String
+            required: true
+            description: 'The path to the Container Registry or Artifact Registry image. For example: gcr.io/{project_id}/{image_name}'
+          - name: tag
+            type: String
+            description: 'The tag of the container image. If not specified, this defaults to the latest tag.'
       - name: vmImage
         type: NestedObject
-        required: true
+        exactly_one_of:
+          - workbench_runtime.0.custom_container_image
+          - workbench_runtime.0.vm_image
         description: 'Custom Compute Engine VM image for the Workbench instance.'
         properties:
           - name: family

--- a/mmv1/templates/terraform/samples/services/colab/colab_notebook_execution_workbench_runtime_container.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/colab/colab_notebook_execution_workbench_runtime_container.tf.tmpl
@@ -1,0 +1,77 @@
+resource "google_storage_bucket" "output_bucket" {
+  name          = "{{index $.ResourceIdVars "bucket"}}"
+  location      = "US"
+  force_destroy = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_colab_notebook_execution" "{{$.PrimaryResourceId}}" {
+  display_name = "Notebook execution workbench runtime container"
+  location = "us-central1"
+
+  direct_notebook_source {
+    content = base64encode(<<EOT
+    {
+      "cells": [
+        {
+          "cell_type": "code",
+          "execution_count": null,
+          "metadata": {},
+          "outputs": [],
+          "source": [
+            "print(\"Hello, World!\")"
+          ]
+        }
+      ],
+      "metadata": {
+        "kernelspec": {
+          "display_name": "Python 3",
+          "language": "python",
+          "name": "python3"
+        },
+        "language_info": {
+          "codemirror_mode": {
+            "name": "ipython",
+            "version": 3
+          },
+          "file_extension": ".py",
+          "mimetype": "text/x-python",
+          "name": "python",
+          "nbconvert_exporter": "python",
+          "pygments_lexer": "ipython3",
+          "version": "3.8.5"
+        }
+      },
+      "nbformat": 4,
+      "nbformat_minor": 4
+    }
+    EOT
+    )
+  }
+
+  custom_environment_spec {
+    machine_spec {
+      machine_type = "n1-standard-2"
+    }
+
+    persistent_disk_spec {
+      disk_type    = "pd-standard"
+      disk_size_gb = 200
+    }
+  }
+
+  workbench_runtime {
+    custom_container_image {
+      repository = "gcr.io/deeplearning-platform-release/workbench-container"
+      tag        = "latest"
+    }
+  }
+
+  gcs_output_uri = "gs://${google_storage_bucket.output_bucket.name}"
+
+  service_account = "{{index $.TestEnvVars "service_account"}}"
+
+  depends_on = [
+    google_storage_bucket.output_bucket,
+  ]
+}


### PR DESCRIPTION
Add `custom_container_image` field under `workbench_runtime` for `google_colab_notebook_execution`.

This field allows specifying a user-provided container image (`repository` and optional `tag`) to execute the notebook in Workbench runtime mode. Configured mutual exclusivity between `workbench_runtime.custom_container_image` and `workbench_runtime.vm_image` via `exactly_one_of`.

```release-note:enhancement
colab: added `workbench_runtime.custom_container_image` to `google_colab_notebook_execution`
```
