### PR TITLE
integrations: add integration_version & deployment resources

### DIFF
--- a/mmv1/products/integrations/IntegrationVersion.yaml
+++ b/mmv1/products/integrations/IntegrationVersion.yaml
@@ -1,0 +1,1365 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: IntegrationVersion
+description: 'The IntegrationVersion resource is used to manage and configure an Application Integration version.
+
+  '
+references:
+  guides:
+    Official Documentation: https://cloud.google.com/application-integration/docs/overview
+  api: https://cloud.google.com/application-integration/docs/reference/rest/v1/projects.locations.integrations.versions
+docs: null
+base_url: projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions
+self_link: '{{name}}'
+id_format: '{{name}}'
+update_verb: PATCH
+update_mask: true
+import_format:
+- '{{name}}'
+- projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+custom_code:
+  custom_import: templates/terraform/custom_import/self_link_as_name.tmpl
+  decoder: templates/terraform/decoders/integrations_version.go.tmpl
+autogen_status: SW50ZWdyYXRpb25WZXJzaW9uQXV0b2dlblYyQWdlbnQ=
+samples:
+- name: integrations_integration_version_basic
+  primary_resource_id: version_basic
+  steps:
+  - name: integrations_integration_version_basic
+    resource_id_vars:
+      integration_name: test-integration
+- name: integrations_integration_version_full
+  primary_resource_id: version_full
+  steps:
+  - name: integrations_integration_version_full
+    resource_id_vars:
+      integration_name: test-integration
+    vars:
+      description: "Initial description"
+  - name: integrations_integration_version_full
+    resource_id_vars:
+      integration_name: test-integration
+    vars:
+      description: "Updated description"
+parameters:
+- name: location
+  type: String
+  required: true
+  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described
+    in https://google.aip.dev/122.
+  immutable: true
+  url_param_only: true
+- name: integration
+  type: String
+  required: true
+  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described
+    in https://google.aip.dev/122.
+  immutable: true
+  url_param_only: true
+- name: newIntegration
+  type: Boolean
+  description: 'Optional. Set this flag to true, if draft version is to be created for a brand new
+
+    integration. False, if the request is for an existing integration.
+
+    Default is true.'
+  immutable: true
+  url_param_only: true
+- name: createSampleIntegrations
+  type: Boolean
+  description: Optional. Indicates if sample workflow should be created.
+  immutable: true
+  url_param_only: true
+properties:
+- name: version
+  type: String
+  description: An ID to identify this specific version of the integration.
+  output: true
+- name: cloudKmsKey
+  type: String
+  description: Cloud KMS resource name for the CMEK encryption key.
+- name: cloudLoggingDetails
+  type: NestedObject
+  description: Cloud Logging details for execution info
+  properties:
+  - name: cloudLoggingSeverity
+    type: String
+    description: 'Severity selected by the customer for the logs to be sent to Cloud Logging,
+
+      for the integration version getting executed.
+
+      Possible values:
+
+      INFO
+
+      ERROR
+
+      WARNING'
+  - name: enableCloudLogging
+    type: Boolean
+    description: 'Status of whether Cloud Logging is enabled or not for the integration
+
+      version getting executed.'
+- name: createTime
+  type: String
+  description: Auto-generated.
+  output: true
+- name: createdFromTemplate
+  type: String
+  description: 'Optional. The resource name of the template from which the integration is
+
+    created.'
+- name: databasePersistencePolicy
+  type: String
+  description: 'Possible values:
+
+    DATABASE_PERSISTENCE_DISABLED
+
+    DATABASE_PERSISTENCE_ASYNC'
+- name: description
+  type: String
+  description: The integration description.
+- name: enableVariableMasking
+  type: Boolean
+  description: True if variable masking feature should be turned on for this version
+- name: errorCatcherConfigs
+  type: Array
+  description: Error Catch Task configuration for the integration. It's optional.
+  item_type:
+    type: NestedObject
+    properties:
+    - name: description
+      type: String
+      description: 'User-provided description intended to give more business context about the
+
+        error catcher config.'
+    - name: errorCatcherId
+      type: String
+      required: true
+      description: 'An error catcher id is string representation for the error
+
+        catcher config. Within a workflow, error_catcher_id uniquely
+
+        identifies an error catcher config among all error catcher configs for the
+
+        workflow'
+    - name: errorCatcherNumber
+      type: String
+      required: true
+      description: 'A number to uniquely identify each error catcher config within
+
+        the workflow on UI.'
+    - name: label
+      type: String
+      description: 'The user created label for a particular error catcher.
+
+        Optional.'
+    - name: position
+      type: NestedObject
+      description: Configuration detail of coordinate, it used for UI
+      properties:
+      - name: x
+        type: Integer
+        required: true
+        description: X axis of the coordinate
+      - name: y
+        type: Integer
+        required: true
+        description: Y axis of the coordinate
+    - name: startErrorTasks
+      type: Array
+      required: true
+      description: The set of start tasks that are to be executed for the error catch flow
+      item_type:
+        type: NestedObject
+        properties:
+        - name: condition
+          type: String
+          description: Standard filter expression for this task to become an eligible next task.
+        - name: description
+          type: String
+          description: 'User-provided description intended to give additional business context
+
+            about the task.'
+        - name: displayName
+          type: String
+          description: User-provided label that is attached to this edge in the UI.
+        - name: taskConfigId
+          type: String
+          description: ID of the next task.
+        - name: taskId
+          type: String
+          description: Task number of the next task.
+- name: integrationConfigParameters
+  type: Array
+  description: 'Config Parameters that are expected to be passed to the integration when an
+
+    integration is published. This consists of all the parameters that are
+
+    expected to provide configuration in the integration execution. This gives
+
+    the user the ability to provide default values, value, add information like
+
+    connection url, project based configuration value and also provide data
+
+    types of each parameter.'
+  item_type:
+    type: NestedObject
+    properties:
+    - name: parameter
+      type: NestedObject
+      description: 'Integration Parameter is defined in the integration config and are used to
+
+        provide information about data types of the expected parameters and provide
+
+        any default values if needed. They can also be used to add custom attributes.
+
+        These are static in nature and should not be used for dynamic event
+
+        definition.'
+      properties:
+      - name: containsLargeData
+        type: Boolean
+        description: 'Indicates whether this variable contains large data and need to be uploaded
+
+          to Cloud Storage.'
+      - name: dataType
+        type: String
+        description: 'Type of the parameter.
+
+          Possible values:
+
+          STRING_VALUE
+
+          INT_VALUE
+
+          DOUBLE_VALUE
+
+          BOOLEAN_VALUE
+
+          STRING_ARRAY
+
+          INT_ARRAY
+
+          DOUBLE_ARRAY
+
+          BOOLEAN_ARRAY
+
+          JSON_VALUE
+
+          PROTO_VALUE
+
+          PROTO_ARRAY
+
+          NON_SERIALIZABLE_OBJECT
+
+          PROTO_ENUM
+
+          SERIALIZED_OBJECT_VALUE
+
+          PROTO_ENUM_ARRAY
+
+          BYTES
+
+          BYTES_ARRAY'
+      - name: defaultValue
+        type: NestedObject
+        description: The type of the parameter.
+        properties:
+        - name: booleanArray
+          type: NestedObject
+          description: This message only contains a field of boolean array.
+          properties:
+          - name: booleanValues
+            type: Array
+            description: Boolean array.
+            item_type:
+              type: Boolean
+        - name: booleanValue
+          type: Boolean
+          description: Boolean.
+        - name: doubleArray
+          type: NestedObject
+          description: This message only contains a field of double number array.
+          properties:
+          - name: doubleValues
+            type: Array
+            description: Double number array.
+            item_type:
+              type: Double
+        - name: doubleValue
+          type: Double
+          description: Double Number.
+        - name: intArray
+          type: NestedObject
+          description: This message only contains a field of integer array.
+          properties:
+          - name: intValues
+            type: Array
+            description: Integer array.
+            item_type:
+              type: String
+        - name: intValue
+          type: String
+          description: Integer.
+        - name: jsonValue
+          type: String
+          description: Json.
+        - name: stringArray
+          type: NestedObject
+          description: This message only contains a field of string array.
+          properties:
+          - name: stringValues
+            type: Array
+            description: String array.
+            item_type:
+              type: String
+        - name: stringValue
+          type: String
+          description: String.
+      - name: description
+        type: String
+        description: Description of the parameter.
+      - name: displayName
+        type: String
+        description: 'The name (without prefix) to be displayed in the UI for this parameter.
+
+          E.g. if the key is "foo.bar.myName", then the name would be "myName".'
+      - name: inputOutputType
+        type: String
+        description: 'Specifies the input/output type for the parameter.
+
+          Possible values:
+
+          IN
+
+          OUT
+
+          IN_OUT'
+      - name: isTransient
+        type: Boolean
+        description: Whether this parameter is a transient parameter.
+      - name: jsonSchema
+        type: String
+        description: 'This schema will be used to validate runtime JSON-typed values of this
+
+          parameter.'
+      - name: key
+        type: String
+        description: 'Key is used to retrieve the corresponding parameter value. This should be
+
+          unique for a given fired event. These parameters must be predefined in the
+
+          integration definition.'
+      - name: masked
+        type: Boolean
+        description: True if this parameter should be masked in the logs
+      - name: producer
+        type: String
+        description: 'The identifier of the node (TaskConfig/TriggerConfig) this parameter was
+
+          produced by, if it is a transient param or a copy of an input param.'
+      - name: searchable
+        type: Boolean
+        description: Searchable in the execution log or not.
+    - name: value
+      type: NestedObject
+      description: The type of the parameter.
+      properties:
+      - name: booleanArray
+        type: NestedObject
+        description: This message only contains a field of boolean array.
+        properties:
+        - name: booleanValues
+          type: Array
+          description: Boolean array.
+          item_type:
+            type: Boolean
+      - name: booleanValue
+        type: Boolean
+        description: Boolean.
+      - name: doubleArray
+        type: NestedObject
+        description: This message only contains a field of double number array.
+        properties:
+        - name: doubleValues
+          type: Array
+          description: Double number array.
+          item_type:
+            type: Double
+      - name: doubleValue
+        type: Double
+        description: Double Number.
+      - name: intArray
+        type: NestedObject
+        description: This message only contains a field of integer array.
+        properties:
+        - name: intValues
+          type: Array
+          description: Integer array.
+          item_type:
+            type: String
+      - name: intValue
+        type: String
+        description: Integer.
+      - name: jsonValue
+        type: String
+        description: Json.
+      - name: stringArray
+        type: NestedObject
+        description: This message only contains a field of string array.
+        properties:
+        - name: stringValues
+          type: Array
+          description: String array.
+          item_type:
+            type: String
+      - name: stringValue
+        type: String
+        description: String.
+- name: integrationParameters
+  type: Array
+  description: 'Parameters that are expected to be passed to the integration when an event
+
+    is triggered. This consists of all the parameters that are expected in the
+
+    integration execution. This gives the user the ability to provide default
+
+    values, add information like PII and also provide data types of each
+
+    parameter.'
+  item_type:
+    type: NestedObject
+    properties:
+    - name: containsLargeData
+      type: Boolean
+      description: 'Indicates whether this variable contains large data and need to be uploaded
+
+        to Cloud Storage.'
+    - name: dataType
+      type: String
+      description: 'Type of the parameter.
+
+        Possible values:
+
+        STRING_VALUE
+
+        INT_VALUE
+
+        DOUBLE_VALUE
+
+        BOOLEAN_VALUE
+
+        STRING_ARRAY
+
+        INT_ARRAY
+
+        DOUBLE_ARRAY
+
+        BOOLEAN_ARRAY
+
+        JSON_VALUE
+
+        PROTO_VALUE
+
+        PROTO_ARRAY
+
+        NON_SERIALIZABLE_OBJECT
+
+        PROTO_ENUM
+
+        SERIALIZED_OBJECT_VALUE
+
+        PROTO_ENUM_ARRAY
+
+        BYTES
+
+        BYTES_ARRAY'
+    - name: defaultValue
+      type: NestedObject
+      description: The type of the parameter.
+      properties:
+      - name: booleanArray
+        type: NestedObject
+        description: This message only contains a field of boolean array.
+        properties:
+        - name: booleanValues
+          type: Array
+          description: Boolean array.
+          item_type:
+            type: Boolean
+      - name: booleanValue
+        type: Boolean
+        description: Boolean.
+      - name: doubleArray
+        type: NestedObject
+        description: This message only contains a field of double number array.
+        properties:
+        - name: doubleValues
+          type: Array
+          description: Double number array.
+          item_type:
+            type: Double
+      - name: doubleValue
+        type: Double
+        description: Double Number.
+      - name: intArray
+        type: NestedObject
+        description: This message only contains a field of integer array.
+        properties:
+        - name: intValues
+          type: Array
+          description: Integer array.
+          item_type:
+            type: String
+      - name: intValue
+        type: String
+        description: Integer.
+      - name: jsonValue
+        type: String
+        description: Json.
+      - name: stringArray
+        type: NestedObject
+        description: This message only contains a field of string array.
+        properties:
+        - name: stringValues
+          type: Array
+          description: String array.
+          item_type:
+            type: String
+      - name: stringValue
+        type: String
+        description: String.
+    - name: description
+      type: String
+      description: Description of the parameter.
+    - name: displayName
+      type: String
+      description: 'The name (without prefix) to be displayed in the UI for this parameter.
+
+        E.g. if the key is "foo.bar.myName", then the name would be "myName".'
+    - name: inputOutputType
+      type: String
+      description: 'Specifies the input/output type for the parameter.
+
+        Possible values:
+
+        IN
+
+        OUT
+
+        IN_OUT'
+    - name: isTransient
+      type: Boolean
+      description: Whether this parameter is a transient parameter.
+    - name: jsonSchema
+      type: String
+      description: 'This schema will be used to validate runtime JSON-typed values of this
+
+        parameter.'
+    - name: key
+      type: String
+      description: 'Key is used to retrieve the corresponding parameter value. This should be
+
+        unique for a given fired event. These parameters must be predefined in the
+
+        integration definition.'
+    - name: masked
+      type: Boolean
+      description: True if this parameter should be masked in the logs
+    - name: producer
+      type: String
+      description: 'The identifier of the node (TaskConfig/TriggerConfig) this parameter was
+
+        produced by, if it is a transient param or a copy of an input param.'
+    - name: searchable
+      type: Boolean
+      description: Searchable in the execution log or not.
+- name: lastModifierEmail
+  type: String
+  description: 'The last modifier''s email address. Generated based on the End User
+
+    Credentials/LOAS role of the user making the call.'
+  output: true
+- name: lockHolder
+  type: String
+  description: 'The edit lock holder''s email address. Generated based on the End User
+
+    Credentials/LOAS role of the user making the call.'
+  output: true
+- name: name
+  type: String
+  description: Auto-generated primary key.
+  output: true
+- name: origin
+  type: String
+  description: 'Possible values:
+
+    UNSPECIFIED
+
+    UI
+
+    PIPER_V2
+
+    PIPER_V3
+
+    APPLICATION_IP_PROVISIONING
+
+    TEST_CASE'
+- name: parentTemplateId
+  type: String
+  description: The id of the template which was used to create this integration_version.
+- name: runAsServiceAccount
+  type: String
+  description: 'The run-as service account email, if set and auth config is not configured,
+
+    that will be used to generate auth token to be used in Connector task,
+
+    Rest caller task and Cloud function task.'
+- name: snapshotNumber
+  type: String
+  description: 'An increasing sequence that is set when a new snapshot is created. The last
+
+    created snapshot can be identified by [workflow_name, org_id
+
+    latest(snapshot_number)]. However, last created snapshot need not be
+
+    same as the HEAD.
+
+    So users should always use "HEAD" tag to identify the head.'
+  output: true
+- name: state
+  type: String
+  description: 'Possible values:
+
+    DRAFT
+
+    ACTIVE
+
+    ARCHIVED
+
+    SNAPSHOT'
+  output: true
+- name: status
+  type: String
+  description: 'Possible values:
+
+    UNKNOWN
+
+    DRAFT
+
+    ACTIVE
+
+    ARCHIVED
+
+    SNAPSHOT'
+  output: true
+- name: taskConfigs
+  type: Array
+  description: 'Task configuration for the integration. It''s optional, but the integration
+
+    doesn''t do anything without task_configs.'
+  item_type:
+    type: NestedObject
+    properties:
+    - name: conditionalFailurePolicies
+      type: NestedObject
+      description: Conditional task failur retry strategies
+      properties:
+      - name: defaultFailurePolicy
+        type: NestedObject
+        description: 'Policy that defines the task retry logic and failure type. If no
+
+          FailurePolicy is defined for a task, all its dependent tasks will not be
+
+          executed (i.e, a `retry_strategy` of NONE will be applied).'
+        properties:
+        - name: condition
+          type: String
+          description: 'The string condition that will be evaluated to determine if the
+
+            task should be retried with this failure policy.'
+        - name: intervalTime
+          type: String
+          description: 'Required if retry_strategy is FIXED_INTERVAL or
+
+            LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+
+            initial interval in seconds for backoff.'
+        - name: maxRetries
+          type: Integer
+          description: 'Required if retry_strategy is FIXED_INTERVAL or
+
+            LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+
+            number of times the task will be retried if failed.'
+        - name: retryStrategy
+          type: String
+          description: 'Defines what happens to the task upon failure.
+
+            Possible values:
+
+            IGNORE
+
+            NONE
+
+            FATAL
+
+            FIXED_INTERVAL
+
+            LINEAR_BACKOFF
+
+            EXPONENTIAL_BACKOFF
+
+            RESTART_INTEGRATION_WITH_BACKOFF'
+      - name: failurePolicies
+        type: Array
+        description: The list of failure policies that will be applied to the task in order.
+        item_type:
+          type: NestedObject
+          properties:
+          - name: condition
+            type: String
+            description: 'The string condition that will be evaluated to determine if the
+
+              task should be retried with this failure policy.'
+          - name: intervalTime
+            type: String
+            description: 'Required if retry_strategy is FIXED_INTERVAL or
+
+              LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+
+              initial interval in seconds for backoff.'
+          - name: maxRetries
+            type: Integer
+            description: 'Required if retry_strategy is FIXED_INTERVAL or
+
+              LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+
+              number of times the task will be retried if failed.'
+          - name: retryStrategy
+            type: String
+            description: 'Defines what happens to the task upon failure.
+
+              Possible values:
+
+              IGNORE
+
+              NONE
+
+              FATAL
+
+              FIXED_INTERVAL
+
+              LINEAR_BACKOFF
+
+              EXPONENTIAL_BACKOFF
+
+              RESTART_INTEGRATION_WITH_BACKOFF'
+    - name: description
+      type: String
+      description: 'User-provided description intended to give additional business context
+
+        about the task.'
+    - name: displayName
+      type: String
+      description: User-provided label that is attached to this TaskConfig in the UI.
+    - name: errorCatcherId
+      type: String
+      description: 'Optional
+
+        Error catcher id of the error catch flow which will be executed when
+
+        execution error happens in the task'
+    - name: externalTaskType
+      type: String
+      description: 'External task type of the task
+
+        Possible values:
+
+        NORMAL_TASK
+
+        ERROR_TASK'
+    - name: failurePolicy
+      type: NestedObject
+      description: 'Policy that defines the task retry logic and failure type. If no
+
+        FailurePolicy is defined for a task, all its dependent tasks will not be
+
+        executed (i.e, a `retry_strategy` of NONE will be applied).'
+      properties:
+      - name: condition
+        type: String
+        description: 'The string condition that will be evaluated to determine if the
+
+          task should be retried with this failure policy.'
+      - name: intervalTime
+        type: String
+        description: 'Required if retry_strategy is FIXED_INTERVAL or
+
+          LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+
+          initial interval in seconds for backoff.'
+      - name: maxRetries
+        type: Integer
+        description: 'Required if retry_strategy is FIXED_INTERVAL or
+
+          LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+
+          number of times the task will be retried if failed.'
+      - name: retryStrategy
+        type: String
+        description: 'Defines what happens to the task upon failure.
+
+          Possible values:
+
+          IGNORE
+
+          NONE
+
+          FATAL
+
+          FIXED_INTERVAL
+
+          LINEAR_BACKOFF
+
+          EXPONENTIAL_BACKOFF
+
+          RESTART_INTEGRATION_WITH_BACKOFF'
+    - name: jsonValidationOption
+      type: String
+      description: 'Possible values:
+
+        SKIP
+
+        PRE_EXECUTION
+
+        POST_EXECUTION
+
+        PRE_POST_EXECUTION'
+    - name: nextTasks
+      type: Array
+      description: 'The set of tasks that are next in line to be executed as per the
+
+        execution graph defined for the parent event, specified by
+
+        `event_config_id`. Each of these next tasks are executed
+
+        only if the condition associated with them evaluates to true.'
+      item_type:
+        type: NestedObject
+        properties:
+        - name: condition
+          type: String
+          description: Standard filter expression for this task to become an eligible next task.
+        - name: description
+          type: String
+          description: 'User-provided description intended to give additional business context
+
+            about the task.'
+        - name: displayName
+          type: String
+          description: User-provided label that is attached to this edge in the UI.
+        - name: taskConfigId
+          type: String
+          description: ID of the next task.
+        - name: taskId
+          type: String
+          description: Task number of the next task.
+    - name: nextTasksExecutionPolicy
+      type: String
+      description: 'The policy dictating the execution of the next set of tasks for the current
+
+        task.
+
+        Possible values:
+
+        RUN_ALL_MATCH
+
+        RUN_FIRST_MATCH'
+    - name: parameters
+      type: Map
+      description: The customized parameters the user can pass to this task.
+      value_type:
+        type: NestedObject
+        properties:
+        - name: masked
+          type: Boolean
+          description: True if this parameter should be masked in the logs
+        - name: value
+          type: NestedObject
+          description: The type of the parameter.
+          properties:
+          - name: booleanArray
+            type: NestedObject
+            description: This message only contains a field of boolean array.
+            properties:
+            - name: booleanValues
+              type: Array
+              description: Boolean array.
+              item_type:
+                type: Boolean
+          - name: booleanValue
+            type: Boolean
+            description: Boolean.
+          - name: doubleArray
+            type: NestedObject
+            description: This message only contains a field of double number array.
+            properties:
+            - name: doubleValues
+              type: Array
+              description: Double number array.
+              item_type:
+                type: Double
+          - name: doubleValue
+            type: Double
+            description: Double Number.
+          - name: intArray
+            type: NestedObject
+            description: This message only contains a field of integer array.
+            properties:
+            - name: intValues
+              type: Array
+              description: Integer array.
+              item_type:
+                type: String
+          - name: intValue
+            type: String
+            description: Integer.
+          - name: jsonValue
+            type: String
+            description: Json.
+          - name: stringArray
+            type: NestedObject
+            description: This message only contains a field of string array.
+            properties:
+            - name: stringValues
+              type: Array
+              description: String array.
+              item_type:
+                type: String
+          - name: stringValue
+            type: String
+            description: String.
+      key_name: key
+    - name: position
+      type: NestedObject
+      description: Configuration detail of coordinate, it used for UI
+      properties:
+      - name: x
+        type: Integer
+        required: true
+        description: X axis of the coordinate
+      - name: y
+        type: Integer
+        required: true
+        description: Y axis of the coordinate
+    - name: successPolicy
+      type: NestedObject
+      description: 'Policy that dictates the behavior for the task after it completes
+
+        successfully.'
+      properties:
+      - name: finalState
+        type: String
+        description: 'State to which the execution snapshot status will be set if the task
+
+          succeeds.
+
+          Possible values:
+
+          SUCCEEDED
+
+          SUSPENDED'
+    - name: synchronousCallFailurePolicy
+      type: NestedObject
+      description: 'Policy that defines the task retry logic and failure type. If no
+
+        FailurePolicy is defined for a task, all its dependent tasks will not be
+
+        executed (i.e, a `retry_strategy` of NONE will be applied).'
+      properties:
+      - name: condition
+        type: String
+        description: 'The string condition that will be evaluated to determine if the
+
+          task should be retried with this failure policy.'
+      - name: intervalTime
+        type: String
+        description: 'Required if retry_strategy is FIXED_INTERVAL or
+
+          LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+
+          initial interval in seconds for backoff.'
+      - name: maxRetries
+        type: Integer
+        description: 'Required if retry_strategy is FIXED_INTERVAL or
+
+          LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+
+          number of times the task will be retried if failed.'
+      - name: retryStrategy
+        type: String
+        description: 'Defines what happens to the task upon failure.
+
+          Possible values:
+
+          IGNORE
+
+          NONE
+
+          FATAL
+
+          FIXED_INTERVAL
+
+          LINEAR_BACKOFF
+
+          EXPONENTIAL_BACKOFF
+
+          RESTART_INTEGRATION_WITH_BACKOFF'
+    - name: task
+      type: String
+      description: The name for the task.
+    - name: taskExecutionStrategy
+      type: String
+      description: 'The policy dictating the execution strategy of this task.
+
+        Possible values:
+
+        WHEN_ALL_SUCCEED
+
+        WHEN_ANY_SUCCEED
+
+        WHEN_ALL_TASKS_AND_CONDITIONS_SUCCEED'
+    - name: taskId
+      type: String
+      required: true
+      description: 'The identifier of this task within its parent event config,
+
+        specified by the client. This should be unique among all the tasks belong
+
+        to the same event config. We use this field as the identifier to
+
+        find next tasks (via field `next_tasks.task_id`).'
+    - name: taskTemplate
+      type: String
+      description: Used to define task-template name if task is of type task-template
+- name: triggerConfigs
+  type: Array
+  description: Trigger configurations.
+  item_type:
+    type: NestedObject
+    properties:
+    - name: alertConfig
+      type: Array
+      description: 'An alert threshold configuration for the [trigger + client + integration]
+
+        tuple. If these values are not specified in the trigger config, default
+
+        values will be populated by the system. Note that there must be exactly one
+
+        alert threshold configured per [client + trigger + integration] when
+
+        published.'
+      item_type:
+        type: NestedObject
+        properties:
+        - name: aggregationPeriod
+          type: String
+          description: 'The period over which the metric value should be aggregated and
+
+            evaluated. Format is , where integer should be a positive
+
+            integer and unit should be one of (s,m,h,d,w) meaning (second, minute,
+
+            hour, day, week).
+
+            For an EXPECTED_MIN threshold, this aggregation_period must be lesser than
+
+            24 hours.'
+        - name: alertThreshold
+          type: Integer
+          description: 'For how many contiguous aggregation periods should the expected min or
+
+            max be violated for the alert to be fired.'
+        - name: disableAlert
+          type: Boolean
+          description: 'Set to false by default. When set to true, the metrics are not aggregated
+
+            or pushed to Monarch for this integration alert.'
+        - name: displayName
+          type: String
+          description: 'Name of the alert. This will be displayed in the alert
+
+            subject. If set, this name should be unique within the scope of the
+
+            integration.'
+        - name: durationThreshold
+          type: String
+          description: 'Should be specified only for *AVERAGE_DURATION and
+
+            *PERCENTILE_DURATION metrics. This member should be used to specify what
+
+            duration value the metrics should exceed for the alert to trigger.'
+        - name: metricType
+          type: String
+          description: 'The type of metric.
+
+            Possible values:
+
+            EVENT_ERROR_RATE
+
+            EVENT_WARNING_RATE
+
+            TASK_ERROR_RATE
+
+            TASK_WARNING_RATE
+
+            TASK_RATE
+
+            EVENT_RATE
+
+            EVENT_AVERAGE_DURATION
+
+            EVENT_PERCENTILE_DURATION
+
+            TASK_AVERAGE_DURATION
+
+            TASK_PERCENTILE_DURATION'
+        - name: onlyFinalAttempt
+          type: Boolean
+          description: 'For either events or tasks, depending on the type of alert, count only
+
+            final attempts, not retries.'
+        - name: thresholdType
+          type: String
+          description: 'The threshold type, whether lower(expected_min) or upper(expected_max), for
+
+            which this alert is being configured. If value falls below expected_min or
+
+            exceeds expected_max, an alert will be fired.
+
+            Possible values:
+
+            EXPECTED_MIN
+
+            EXPECTED_MAX'
+        - name: thresholdValue
+          type: NestedObject
+          description: 'The threshold value of the metric, above or below which the alert should
+
+            be triggered. See EventAlertConfig or TaskAlertConfig for the different
+
+            alert metric types in each case.
+
+
+            For the *RATE metrics, one or both of these fields may be set. Zero is the
+
+            default value and can be left at that.
+
+
+            For *PERCENTILE_DURATION metrics, one or both of these fields may
+
+            be set, and also, the duration threshold value should be specified in the
+
+            threshold_duration_ms member below.
+
+
+            For *AVERAGE_DURATION metrics, these fields should not be set at all.
+
+            A different member, threshold_duration_ms, must be set in the
+
+            EventAlertConfig or the TaskAlertConfig.'
+          properties:
+          - name: absolute
+            type: String
+            description: Absolute value threshold.
+          - name: percentage
+            type: Integer
+            description: Percentage threshold.
+    - name: cloudSchedulerConfig
+      type: NestedObject
+      description: Cloud Scheduler Trigger configuration
+      properties:
+      - name: cronTab
+        type: String
+        required: true
+        description: The cron tab of cloud scheduler trigger.
+      - name: errorMessage
+        type: String
+        description: 'When the job was deleted from Pantheon UI, error_message will be populated
+
+          when Get/List integrations'
+      - name: location
+        type: String
+        required: true
+        description: The location where associated cloud scheduler job will be created
+      - name: serviceAccountEmail
+        type: String
+        required: true
+        description: 'Service account used by Cloud Scheduler to trigger the integration at
+
+          scheduled time'
+    - name: description
+      type: String
+      description: 'User-provided description intended to give additional business context
+
+        about the task.'
+    - name: errorCatcherId
+      type: String
+      description: 'Optional
+
+        Error catcher id of the error catch flow which will be executed when
+
+        execution error happens in the task'
+    - name: inputVariables
+      type: NestedObject
+      description: Variables names mapped to api trigger.
+      properties:
+      - name: names
+        type: Array
+        description: List of variable names.
+        item_type:
+          type: String
+    - name: label
+      type: String
+      description: The user created label for a particular trigger.
+    - name: nextTasksExecutionPolicy
+      type: String
+      description: 'Dictates how next tasks will be executed.
+
+        Possible values:
+
+        RUN_ALL_MATCH
+
+        RUN_FIRST_MATCH'
+    - name: outputVariables
+      type: NestedObject
+      description: Variables names mapped to api trigger.
+      properties:
+      - name: names
+        type: Array
+        description: List of variable names.
+        item_type:
+          type: String
+    - name: position
+      type: NestedObject
+      description: Configuration detail of coordinate, it used for UI
+      properties:
+      - name: x
+        type: Integer
+        required: true
+        description: X axis of the coordinate
+      - name: y
+        type: Integer
+        required: true
+        description: Y axis of the coordinate
+    - name: properties
+      type: KeyValuePairs
+      description: 'Configurable properties of the trigger,
+
+        not to be confused with integration parameters.
+
+        E.g. "name" is a property for API triggers
+
+        and "subscription" is a property for Pub/sub triggers.'
+    - name: startTasks
+      type: Array
+      description: 'Set of tasks numbers from where the integration execution is started by
+
+        this trigger. If this is empty, then integration is executed with default
+
+        start tasks. In the list of start tasks, none of two tasks can have direct
+
+        ancestor-descendant relationships (i.e. in a same integration execution
+
+        graph).'
+      item_type:
+        type: NestedObject
+        properties:
+        - name: condition
+          type: String
+          description: Standard filter expression for this task to become an eligible next task.
+        - name: description
+          type: String
+          description: 'User-provided description intended to give additional business context
+
+            about the task.'
+        - name: displayName
+          type: String
+          description: User-provided label that is attached to this edge in the UI.
+        - name: taskConfigId
+          type: String
+          description: ID of the next task.
+        - name: taskId
+          type: String
+          description: Task number of the next task.
+    - name: trigger
+      type: String
+      description: 'Name of the trigger. Example: "API Trigger", "Cloud Pub Sub
+
+        Trigger" When set will be sent out to monitoring dashabord for tracking
+
+        purpose.'
+    - name: triggerId
+      type: String
+      description: 'Auto-generated trigger ID. The ID is based on the properties that you
+
+        define in the trigger config. For example, for an API trigger, the trigger
+
+        ID follows the format: api_trigger/TRIGGER_NAME
+
+        Where trigger config has properties with value {"Trigger name":TRIGGER_NAME}'
+    - name: triggerNumber
+      type: String
+      required: true
+      description: 'A number to uniquely identify each trigger config within the
+
+        integration on UI.'
+    - name: triggerType
+      type: String
+      description: 'Possible values:
+
+        CRON
+
+        API
+
+        SFDC_CHANNEL
+
+        CLOUD_PUBSUB_EXTERNAL
+
+        SFDC_CDC_CHANNEL
+
+        CLOUD_SCHEDULER
+
+        INTEGRATION_CONNECTOR_TRIGGER
+
+        PRIVATE_TRIGGER
+
+        CLOUD_PUBSUB
+
+        EVENTARC_TRIGGER'
+- name: updateTime
+  type: String
+  description: Auto-generated.
+  output: true
+- name: userLabel
+  type: String
+  description: 'A user-defined label that annotates an integration version. Typically, this
+
+    is only set when the integration version is created.'

--- a/mmv1/products/integrations/IntegrationVersion.yaml
+++ b/mmv1/products/integrations/IntegrationVersion.yaml
@@ -33,6 +33,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
+  constants: templates/terraform/constants/integrations_json_diff_suppress.go.tmpl
   decoder: templates/terraform/decoders/integrations_version.go.tmpl
   test_check_destroy: templates/terraform/custom_check_destroy/integrations_version.go.tmpl
 autogen_status: SW50ZWdyYXRpb25WZXJzaW9uQXV0b2dlblYyQWdlbnQ=
@@ -295,6 +296,7 @@ properties:
                 - name: jsonValue
                   type: String
                   description: Json.
+                  diff_suppress_func: integrationsJsonDiffSuppress
                 - name: stringArray
                   type: NestedObject
                   description: This message only contains a field of string array.
@@ -331,6 +333,7 @@ properties:
               description: |-
                 This schema will be used to validate runtime JSON-typed values of this
                 parameter.
+              diff_suppress_func: integrationsJsonDiffSuppress
             - name: key
               type: String
               description: |-
@@ -391,6 +394,7 @@ properties:
             - name: jsonValue
               type: String
               description: Json.
+              diff_suppress_func: integrationsJsonDiffSuppress
             - name: stringArray
               type: NestedObject
               description: This message only contains a field of string array.
@@ -484,6 +488,7 @@ properties:
             - name: jsonValue
               type: String
               description: Json.
+              diff_suppress_func: integrationsJsonDiffSuppress
             - name: stringArray
               type: NestedObject
               description: This message only contains a field of string array.
@@ -520,6 +525,7 @@ properties:
           description: |-
             This schema will be used to validate runtime JSON-typed values of this
             parameter.
+          diff_suppress_func: integrationsJsonDiffSuppress
         - name: key
           type: String
           description: |-
@@ -837,6 +843,7 @@ properties:
                   - name: jsonValue
                     type: String
                     description: Json.
+                    diff_suppress_func: integrationsJsonDiffSuppress
                   - name: stringArray
                     type: NestedObject
                     description: This message only contains a field of string array.

--- a/mmv1/products/integrations/IntegrationVersion.yaml
+++ b/mmv1/products/integrations/IntegrationVersion.yaml
@@ -62,19 +62,6 @@ samples:
           description: Updated description
         test_vars_overrides:
           client: BootstrapIntegrationsClient(t, "us-east4")
-  - name: integrations_integration_version_cmek
-    primary_resource_id: version_cmek
-    bootstrap_iam:
-      - member: serviceAccount:service-{project_number}@gcp-sa-integrations.iam.gserviceaccount.com
-        role: roles/cloudkms.cryptoKeyEncrypterDecrypter
-    skip_vcr: true
-    steps:
-      - name: integrations_integration_version_cmek
-        resource_id_vars:
-          integration_name: test-integration
-        test_vars_overrides:
-          client: BootstrapIntegrationsClient(t, "us-east4")
-          kms_key_name: kms.BootstrapKMSKeyInLocation(t, "us-east4").CryptoKey.Name
 
 parameters:
   - name: location

--- a/mmv1/products/integrations/IntegrationVersion.yaml
+++ b/mmv1/products/integrations/IntegrationVersion.yaml
@@ -62,6 +62,20 @@ samples:
           description: Updated description
         test_vars_overrides:
           client: BootstrapIntegrationsClient(t, "us-east4")
+  - name: integrations_integration_version_cmek
+    primary_resource_id: version_cmek
+    bootstrap_iam:
+      - member: serviceAccount:service-{project_number}@gcp-sa-integrations.iam.gserviceaccount.com
+        role: roles/cloudkms.cryptoKeyEncrypterDecrypter
+    skip_vcr: true
+    steps:
+      - name: integrations_integration_version_cmek
+        resource_id_vars:
+          integration_name: test-integration
+        test_vars_overrides:
+          client: BootstrapIntegrationsClient(t, "us-east4")
+          kms_key_name: kms.BootstrapKMSKeyInLocation(t, "us-east4").CryptoKey.Name
+
 parameters:
   - name: location
     type: String

--- a/mmv1/products/integrations/IntegrationVersion.yaml
+++ b/mmv1/products/integrations/IntegrationVersion.yaml
@@ -296,7 +296,10 @@ properties:
                 - name: jsonValue
                   type: String
                   description: Json.
+                  state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }
                   diff_suppress_func: integrationsJsonDiffSuppress
+                  validation:
+                    function: validation.StringIsJSON
                 - name: stringArray
                   type: NestedObject
                   description: This message only contains a field of string array.
@@ -333,7 +336,10 @@ properties:
               description: |-
                 This schema will be used to validate runtime JSON-typed values of this
                 parameter.
+              state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }
               diff_suppress_func: integrationsJsonDiffSuppress
+              validation:
+                function: validation.StringIsJSON
             - name: key
               type: String
               description: |-
@@ -394,7 +400,10 @@ properties:
             - name: jsonValue
               type: String
               description: Json.
+              state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }
               diff_suppress_func: integrationsJsonDiffSuppress
+              validation:
+                function: validation.StringIsJSON
             - name: stringArray
               type: NestedObject
               description: This message only contains a field of string array.
@@ -488,7 +497,10 @@ properties:
             - name: jsonValue
               type: String
               description: Json.
+              state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }
               diff_suppress_func: integrationsJsonDiffSuppress
+              validation:
+                function: validation.StringIsJSON
             - name: stringArray
               type: NestedObject
               description: This message only contains a field of string array.
@@ -525,7 +537,10 @@ properties:
           description: |-
             This schema will be used to validate runtime JSON-typed values of this
             parameter.
+          state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }
           diff_suppress_func: integrationsJsonDiffSuppress
+          validation:
+            function: validation.StringIsJSON
         - name: key
           type: String
           description: |-
@@ -843,7 +858,10 @@ properties:
                   - name: jsonValue
                     type: String
                     description: Json.
+                    state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }
                     diff_suppress_func: integrationsJsonDiffSuppress
+                    validation:
+                      function: validation.StringIsJSON
                   - name: stringArray
                     type: NestedObject
                     description: This message only contains a field of string array.

--- a/mmv1/products/integrations/IntegrationVersion.yaml
+++ b/mmv1/products/integrations/IntegrationVersion.yaml
@@ -21,20 +21,21 @@ references:
   api: https://cloud.google.com/application-integration/docs/reference/rest/v1/projects.locations.integrations.versions
 docs: null
 base_url: projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions
-self_link: '{{name}}'
-id_format: '{{name}}'
+self_link: projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}
+id_format: projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}
 update_verb: PATCH
 update_mask: true
 import_format:
-- '{{name}}'
 - projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}
+- '{{project}}/{{location}}/{{integration}}/{{version}}'
+- '{{location}}/{{integration}}/{{version}}'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
 custom_code:
-  custom_import: templates/terraform/custom_import/self_link_as_name.tmpl
   decoder: templates/terraform/decoders/integrations_version.go.tmpl
+  test_check_destroy: templates/terraform/custom_check_destroy/integrations_version.go.tmpl
 autogen_status: SW50ZWdyYXRpb25WZXJzaW9uQXV0b2dlblYyQWdlbnQ=
 samples:
 - name: integrations_integration_version_basic
@@ -608,6 +609,7 @@ properties:
   output: true
 - name: origin
   type: String
+  output: true
   description: 'Possible values:
 
     UNSPECIFIED
@@ -894,6 +896,7 @@ properties:
         RUN_FIRST_MATCH'
     - name: parameters
       type: Map
+      custom_expand: templates/terraform/custom_expand/integrations_version_parameters.go.tmpl
       description: The customized parameters the user can pass to this task.
       value_type:
         type: NestedObject

--- a/mmv1/products/integrations/IntegrationVersion.yaml
+++ b/mmv1/products/integrations/IntegrationVersion.yaml
@@ -63,6 +63,21 @@ samples:
           description: Updated description
         test_vars_overrides:
           client: BootstrapIntegrationsClient(t, "us-east4")
+  - name: integrations_integration_version_cmek
+    primary_resource_id: version_cmek
+    bootstrap_iam:
+      - member: serviceAccount:service-{project_number}@gcp-sa-integrations.iam.gserviceaccount.com
+        role: roles/cloudkms.cryptoKeyEncrypterDecrypter
+      - member: serviceAccount:service-{project_number}@gcp-sa-integrations.iam.gserviceaccount.com
+        role: roles/cloudkmskacls.serviceAgent
+    steps:
+      - name: integrations_integration_version_cmek
+        resource_id_vars:
+          integration_name: test-integration
+          kms_key_name: kms-key
+        test_vars_overrides:
+          client: BootstrapIntegrationsClient(t, "us-east4")
+          kms_key_name: kms.BootstrapKMSKeyInLocation(t, "us-east4").CryptoKey.Name
 
 parameters:
   - name: location
@@ -100,6 +115,9 @@ properties:
   - name: cloudKmsKey
     type: String
     description: Cloud KMS resource name for the CMEK encryption key.
+    immutable: true
+    # The API does not return cloudKmsKey in the GET response payload.
+    ignore_read: true
   - name: cloudLoggingDetails
     type: NestedObject
     description: Cloud Logging details for execution info

--- a/mmv1/products/integrations/IntegrationVersion.yaml
+++ b/mmv1/products/integrations/IntegrationVersion.yaml
@@ -44,6 +44,8 @@ samples:
   - name: integrations_integration_version_basic
     resource_id_vars:
       integration_name: test-integration
+    test_vars_overrides:
+      client: BootstrapIntegrationsClient(t, "us-east4")
 - name: integrations_integration_version_full
   primary_resource_id: version_full
   steps:
@@ -52,11 +54,15 @@ samples:
       integration_name: test-integration
     vars:
       description: "Initial description"
+    test_vars_overrides:
+      client: BootstrapIntegrationsClient(t, "us-east4")
   - name: integrations_integration_version_full
     resource_id_vars:
       integration_name: test-integration
     vars:
       description: "Updated description"
+    test_vars_overrides:
+      client: BootstrapIntegrationsClient(t, "us-east4")
 parameters:
 - name: location
   type: String

--- a/mmv1/products/integrations/IntegrationVersion.yaml
+++ b/mmv1/products/integrations/IntegrationVersion.yaml
@@ -11,10 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 name: IntegrationVersion
-description: 'The IntegrationVersion resource is used to manage and configure an Application Integration version.
-
-  '
+description: The IntegrationVersion resource is used to manage and configure an Application Integration version.
 references:
   guides:
     Official Documentation: https://cloud.google.com/application-integration/docs/overview
@@ -26,9 +25,9 @@ id_format: projects/{{project}}/locations/{{location}}/integrations/{{integratio
 update_verb: PATCH
 update_mask: true
 import_format:
-- projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}
-- '{{project}}/{{location}}/{{integration}}/{{version}}'
-- '{{location}}/{{integration}}/{{version}}'
+  - projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}
+  - '{{project}}/{{location}}/{{integration}}/{{version}}'
+  - '{{location}}/{{integration}}/{{version}}'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -38,1337 +37,1151 @@ custom_code:
   test_check_destroy: templates/terraform/custom_check_destroy/integrations_version.go.tmpl
 autogen_status: SW50ZWdyYXRpb25WZXJzaW9uQXV0b2dlblYyQWdlbnQ=
 samples:
-- name: integrations_integration_version_basic
-  primary_resource_id: version_basic
-  steps:
   - name: integrations_integration_version_basic
-    resource_id_vars:
-      integration_name: test-integration
-    test_vars_overrides:
-      client: BootstrapIntegrationsClient(t, "us-east4")
-- name: integrations_integration_version_full
-  primary_resource_id: version_full
-  steps:
+    primary_resource_id: version_basic
+    steps:
+      - name: integrations_integration_version_basic
+        resource_id_vars:
+          integration_name: test-integration
+        test_vars_overrides:
+          client: BootstrapIntegrationsClient(t, "us-east4")
   - name: integrations_integration_version_full
-    resource_id_vars:
-      integration_name: test-integration
-    vars:
-      description: "Initial description"
-    test_vars_overrides:
-      client: BootstrapIntegrationsClient(t, "us-east4")
-  - name: integrations_integration_version_full
-    resource_id_vars:
-      integration_name: test-integration
-    vars:
-      description: "Updated description"
-    test_vars_overrides:
-      client: BootstrapIntegrationsClient(t, "us-east4")
+    primary_resource_id: version_full
+    steps:
+      - name: integrations_integration_version_full
+        resource_id_vars:
+          integration_name: test-integration
+        vars:
+          description: Initial description
+        test_vars_overrides:
+          client: BootstrapIntegrationsClient(t, "us-east4")
+      - name: integrations_integration_version_full
+        resource_id_vars:
+          integration_name: test-integration
+        vars:
+          description: Updated description
+        test_vars_overrides:
+          client: BootstrapIntegrationsClient(t, "us-east4")
 parameters:
-- name: location
-  type: String
-  required: true
-  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described
-    in https://google.aip.dev/122.
-  immutable: true
-  url_param_only: true
-- name: integration
-  type: String
-  required: true
-  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described
-    in https://google.aip.dev/122.
-  immutable: true
-  url_param_only: true
-- name: newIntegration
-  type: Boolean
-  description: 'Optional. Set this flag to true, if draft version is to be created for a brand new
-
-    integration. False, if the request is for an existing integration.
-
-    Default is true.'
-  immutable: true
-  url_param_only: true
-- name: createSampleIntegrations
-  type: Boolean
-  description: Optional. Indicates if sample workflow should be created.
-  immutable: true
-  url_param_only: true
-properties:
-- name: version
-  type: String
-  description: An ID to identify this specific version of the integration.
-  output: true
-- name: cloudKmsKey
-  type: String
-  description: Cloud KMS resource name for the CMEK encryption key.
-- name: cloudLoggingDetails
-  type: NestedObject
-  description: Cloud Logging details for execution info
-  properties:
-  - name: cloudLoggingSeverity
+  - name: location
     type: String
-    description: 'Severity selected by the customer for the logs to be sent to Cloud Logging,
-
-      for the integration version getting executed.
-
-      Possible values:
-
-      INFO
-
-      ERROR
-
-      WARNING'
-  - name: enableCloudLogging
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as
+      described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: integration
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as
+      described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: newIntegration
     type: Boolean
-    description: 'Status of whether Cloud Logging is enabled or not for the integration
-
-      version getting executed.'
-- name: createTime
-  type: String
-  description: Auto-generated.
-  output: true
-- name: createdFromTemplate
-  type: String
-  description: 'Optional. The resource name of the template from which the integration is
-
-    created.'
-- name: databasePersistencePolicy
-  type: String
-  description: 'Possible values:
-
-    DATABASE_PERSISTENCE_DISABLED
-
-    DATABASE_PERSISTENCE_ASYNC'
-- name: description
-  type: String
-  description: The integration description.
-- name: enableVariableMasking
-  type: Boolean
-  description: True if variable masking feature should be turned on for this version
-- name: errorCatcherConfigs
-  type: Array
-  description: Error Catch Task configuration for the integration. It's optional.
-  item_type:
+    description: |-
+      Optional. Set this flag to true, if draft version is to be created for a brand new
+      integration. False, if the request is for an existing integration.
+      Default is true.
+    immutable: true
+    url_param_only: true
+  - name: createSampleIntegrations
+    type: Boolean
+    description: Optional. Indicates if sample workflow should be created.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: version
+    type: String
+    description: An ID to identify this specific version of the integration.
+    output: true
+  - name: cloudKmsKey
+    type: String
+    description: Cloud KMS resource name for the CMEK encryption key.
+  - name: cloudLoggingDetails
     type: NestedObject
+    description: Cloud Logging details for execution info
     properties:
-    - name: description
-      type: String
-      description: 'User-provided description intended to give more business context about the
-
-        error catcher config.'
-    - name: errorCatcherId
-      type: String
-      required: true
-      description: 'An error catcher id is string representation for the error
-
-        catcher config. Within a workflow, error_catcher_id uniquely
-
-        identifies an error catcher config among all error catcher configs for the
-
-        workflow'
-    - name: errorCatcherNumber
-      type: String
-      required: true
-      description: 'A number to uniquely identify each error catcher config within
-
-        the workflow on UI.'
-    - name: label
-      type: String
-      description: 'The user created label for a particular error catcher.
-
-        Optional.'
-    - name: position
+      - name: cloudLoggingSeverity
+        type: String
+        description: |-
+          Severity selected by the customer for the logs to be sent to Cloud Logging,
+          for the integration version getting executed.
+          Possible values:
+          INFO
+          ERROR
+          WARNING
+      - name: enableCloudLogging
+        type: Boolean
+        description: |-
+          Status of whether Cloud Logging is enabled or not for the integration
+          version getting executed.
+  - name: createTime
+    type: String
+    description: Auto-generated.
+    output: true
+  - name: createdFromTemplate
+    type: String
+    description: |-
+      Optional. The resource name of the template from which the integration is
+      created.
+  - name: databasePersistencePolicy
+    type: String
+    description: |-
+      Possible values:
+      DATABASE_PERSISTENCE_DISABLED
+      DATABASE_PERSISTENCE_ASYNC
+  - name: description
+    type: String
+    description: The integration description.
+  - name: enableVariableMasking
+    type: Boolean
+    description: True if variable masking feature should be turned on for this version
+  - name: errorCatcherConfigs
+    type: Array
+    description: Error Catch Task configuration for the integration. It's optional.
+    item_type:
       type: NestedObject
-      description: Configuration detail of coordinate, it used for UI
       properties:
-      - name: x
-        type: Integer
-        required: true
-        description: X axis of the coordinate
-      - name: y
-        type: Integer
-        required: true
-        description: Y axis of the coordinate
-    - name: startErrorTasks
-      type: Array
-      required: true
-      description: The set of start tasks that are to be executed for the error catch flow
-      item_type:
-        type: NestedObject
-        properties:
-        - name: condition
-          type: String
-          description: Standard filter expression for this task to become an eligible next task.
         - name: description
           type: String
-          description: 'User-provided description intended to give additional business context
-
-            about the task.'
-        - name: displayName
+          description: |-
+            User-provided description intended to give more business context about the
+            error catcher config.
+        - name: errorCatcherId
           type: String
-          description: User-provided label that is attached to this edge in the UI.
-        - name: taskConfigId
+          required: true
+          description: |-
+            An error catcher id is string representation for the error
+            catcher config. Within a workflow, error_catcher_id uniquely
+            identifies an error catcher config among all error catcher configs for the
+            workflow
+        - name: errorCatcherNumber
           type: String
-          description: ID of the next task.
-        - name: taskId
+          required: true
+          description: |-
+            A number to uniquely identify each error catcher config within
+            the workflow on UI.
+        - name: label
           type: String
-          description: Task number of the next task.
-- name: integrationConfigParameters
-  type: Array
-  description: 'Config Parameters that are expected to be passed to the integration when an
-
-    integration is published. This consists of all the parameters that are
-
-    expected to provide configuration in the integration execution. This gives
-
-    the user the ability to provide default values, value, add information like
-
-    connection url, project based configuration value and also provide data
-
-    types of each parameter.'
-  item_type:
-    type: NestedObject
-    properties:
-    - name: parameter
-      type: NestedObject
-      description: 'Integration Parameter is defined in the integration config and are used to
-
-        provide information about data types of the expected parameters and provide
-
-        any default values if needed. They can also be used to add custom attributes.
-
-        These are static in nature and should not be used for dynamic event
-
-        definition.'
-      properties:
-      - name: containsLargeData
-        type: Boolean
-        description: 'Indicates whether this variable contains large data and need to be uploaded
-
-          to Cloud Storage.'
-      - name: dataType
-        type: String
-        description: 'Type of the parameter.
-
-          Possible values:
-
-          STRING_VALUE
-
-          INT_VALUE
-
-          DOUBLE_VALUE
-
-          BOOLEAN_VALUE
-
-          STRING_ARRAY
-
-          INT_ARRAY
-
-          DOUBLE_ARRAY
-
-          BOOLEAN_ARRAY
-
-          JSON_VALUE
-
-          PROTO_VALUE
-
-          PROTO_ARRAY
-
-          NON_SERIALIZABLE_OBJECT
-
-          PROTO_ENUM
-
-          SERIALIZED_OBJECT_VALUE
-
-          PROTO_ENUM_ARRAY
-
-          BYTES
-
-          BYTES_ARRAY'
-      - name: defaultValue
-        type: NestedObject
-        description: The type of the parameter.
-        properties:
-        - name: booleanArray
+          description: |-
+            The user created label for a particular error catcher.
+            Optional.
+        - name: position
           type: NestedObject
-          description: This message only contains a field of boolean array.
+          description: Configuration detail of coordinate, it used for UI
           properties:
-          - name: booleanValues
-            type: Array
-            description: Boolean array.
-            item_type:
+            - name: x
+              type: Integer
+              required: true
+              description: X axis of the coordinate
+            - name: y
+              type: Integer
+              required: true
+              description: Y axis of the coordinate
+        - name: startErrorTasks
+          type: Array
+          required: true
+          description: The set of start tasks that are to be executed for the error catch flow
+          item_type:
+            type: NestedObject
+            properties:
+              - name: condition
+                type: String
+                description: Standard filter expression for this task to become an eligible next task.
+              - name: description
+                type: String
+                description: |-
+                  User-provided description intended to give additional business context
+                  about the task.
+              - name: displayName
+                type: String
+                description: User-provided label that is attached to this edge in the UI.
+              - name: taskConfigId
+                type: String
+                description: ID of the next task.
+              - name: taskId
+                type: String
+                description: Task number of the next task.
+  - name: integrationConfigParameters
+    type: Array
+    description: |-
+      Config Parameters that are expected to be passed to the integration when an
+      integration is published. This consists of all the parameters that are
+      expected to provide configuration in the integration execution. This gives
+      the user the ability to provide default values, value, add information like
+      connection url, project based configuration value and also provide data
+      types of each parameter.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: parameter
+          type: NestedObject
+          description: |-
+            Integration Parameter is defined in the integration config and are used to
+            provide information about data types of the expected parameters and provide
+            any default values if needed. They can also be used to add custom attributes.
+            These are static in nature and should not be used for dynamic event
+            definition.
+          properties:
+            - name: containsLargeData
               type: Boolean
-        - name: booleanValue
-          type: Boolean
-          description: Boolean.
-        - name: doubleArray
-          type: NestedObject
-          description: This message only contains a field of double number array.
-          properties:
-          - name: doubleValues
-            type: Array
-            description: Double number array.
-            item_type:
-              type: Double
-        - name: doubleValue
-          type: Double
-          description: Double Number.
-        - name: intArray
-          type: NestedObject
-          description: This message only contains a field of integer array.
-          properties:
-          - name: intValues
-            type: Array
-            description: Integer array.
-            item_type:
+              description: |-
+                Indicates whether this variable contains large data and need to be uploaded
+                to Cloud Storage.
+            - name: dataType
               type: String
-        - name: intValue
-          type: String
-          description: Integer.
-        - name: jsonValue
-          type: String
-          description: Json.
-        - name: stringArray
-          type: NestedObject
-          description: This message only contains a field of string array.
-          properties:
-          - name: stringValues
-            type: Array
-            description: String array.
-            item_type:
+              description: |-
+                Type of the parameter.
+                Possible values:
+                STRING_VALUE
+                INT_VALUE
+                DOUBLE_VALUE
+                BOOLEAN_VALUE
+                STRING_ARRAY
+                INT_ARRAY
+                DOUBLE_ARRAY
+                BOOLEAN_ARRAY
+                JSON_VALUE
+                PROTO_VALUE
+                PROTO_ARRAY
+                NON_SERIALIZABLE_OBJECT
+                PROTO_ENUM
+                SERIALIZED_OBJECT_VALUE
+                PROTO_ENUM_ARRAY
+                BYTES
+                BYTES_ARRAY
+            - name: defaultValue
+              type: NestedObject
+              description: The type of the parameter.
+              properties:
+                - name: booleanArray
+                  type: NestedObject
+                  description: This message only contains a field of boolean array.
+                  properties:
+                    - name: booleanValues
+                      type: Array
+                      description: Boolean array.
+                      item_type:
+                        type: Boolean
+                - name: booleanValue
+                  type: Boolean
+                  description: Boolean.
+                - name: doubleArray
+                  type: NestedObject
+                  description: This message only contains a field of double number array.
+                  properties:
+                    - name: doubleValues
+                      type: Array
+                      description: Double number array.
+                      item_type:
+                        type: Double
+                - name: doubleValue
+                  type: Double
+                  description: Double Number.
+                - name: intArray
+                  type: NestedObject
+                  description: This message only contains a field of integer array.
+                  properties:
+                    - name: intValues
+                      type: Array
+                      description: Integer array.
+                      item_type:
+                        type: String
+                - name: intValue
+                  type: String
+                  description: Integer.
+                - name: jsonValue
+                  type: String
+                  description: Json.
+                - name: stringArray
+                  type: NestedObject
+                  description: This message only contains a field of string array.
+                  properties:
+                    - name: stringValues
+                      type: Array
+                      description: String array.
+                      item_type:
+                        type: String
+                - name: stringValue
+                  type: String
+                  description: String.
+            - name: description
               type: String
-        - name: stringValue
-          type: String
-          description: String.
-      - name: description
-        type: String
-        description: Description of the parameter.
-      - name: displayName
-        type: String
-        description: 'The name (without prefix) to be displayed in the UI for this parameter.
-
-          E.g. if the key is "foo.bar.myName", then the name would be "myName".'
-      - name: inputOutputType
-        type: String
-        description: 'Specifies the input/output type for the parameter.
-
-          Possible values:
-
-          IN
-
-          OUT
-
-          IN_OUT'
-      - name: isTransient
-        type: Boolean
-        description: Whether this parameter is a transient parameter.
-      - name: jsonSchema
-        type: String
-        description: 'This schema will be used to validate runtime JSON-typed values of this
-
-          parameter.'
-      - name: key
-        type: String
-        description: 'Key is used to retrieve the corresponding parameter value. This should be
-
-          unique for a given fired event. These parameters must be predefined in the
-
-          integration definition.'
-      - name: masked
-        type: Boolean
-        description: True if this parameter should be masked in the logs
-      - name: producer
-        type: String
-        description: 'The identifier of the node (TaskConfig/TriggerConfig) this parameter was
-
-          produced by, if it is a transient param or a copy of an input param.'
-      - name: searchable
-        type: Boolean
-        description: Searchable in the execution log or not.
-    - name: value
-      type: NestedObject
-      description: The type of the parameter.
-      properties:
-      - name: booleanArray
-        type: NestedObject
-        description: This message only contains a field of boolean array.
-        properties:
-        - name: booleanValues
-          type: Array
-          description: Boolean array.
-          item_type:
-            type: Boolean
-      - name: booleanValue
-        type: Boolean
-        description: Boolean.
-      - name: doubleArray
-        type: NestedObject
-        description: This message only contains a field of double number array.
-        properties:
-        - name: doubleValues
-          type: Array
-          description: Double number array.
-          item_type:
-            type: Double
-      - name: doubleValue
-        type: Double
-        description: Double Number.
-      - name: intArray
-        type: NestedObject
-        description: This message only contains a field of integer array.
-        properties:
-        - name: intValues
-          type: Array
-          description: Integer array.
-          item_type:
-            type: String
-      - name: intValue
-        type: String
-        description: Integer.
-      - name: jsonValue
-        type: String
-        description: Json.
-      - name: stringArray
-        type: NestedObject
-        description: This message only contains a field of string array.
-        properties:
-        - name: stringValues
-          type: Array
-          description: String array.
-          item_type:
-            type: String
-      - name: stringValue
-        type: String
-        description: String.
-- name: integrationParameters
-  type: Array
-  description: 'Parameters that are expected to be passed to the integration when an event
-
-    is triggered. This consists of all the parameters that are expected in the
-
-    integration execution. This gives the user the ability to provide default
-
-    values, add information like PII and also provide data types of each
-
-    parameter.'
-  item_type:
-    type: NestedObject
-    properties:
-    - name: containsLargeData
-      type: Boolean
-      description: 'Indicates whether this variable contains large data and need to be uploaded
-
-        to Cloud Storage.'
-    - name: dataType
-      type: String
-      description: 'Type of the parameter.
-
-        Possible values:
-
-        STRING_VALUE
-
-        INT_VALUE
-
-        DOUBLE_VALUE
-
-        BOOLEAN_VALUE
-
-        STRING_ARRAY
-
-        INT_ARRAY
-
-        DOUBLE_ARRAY
-
-        BOOLEAN_ARRAY
-
-        JSON_VALUE
-
-        PROTO_VALUE
-
-        PROTO_ARRAY
-
-        NON_SERIALIZABLE_OBJECT
-
-        PROTO_ENUM
-
-        SERIALIZED_OBJECT_VALUE
-
-        PROTO_ENUM_ARRAY
-
-        BYTES
-
-        BYTES_ARRAY'
-    - name: defaultValue
-      type: NestedObject
-      description: The type of the parameter.
-      properties:
-      - name: booleanArray
-        type: NestedObject
-        description: This message only contains a field of boolean array.
-        properties:
-        - name: booleanValues
-          type: Array
-          description: Boolean array.
-          item_type:
-            type: Boolean
-      - name: booleanValue
-        type: Boolean
-        description: Boolean.
-      - name: doubleArray
-        type: NestedObject
-        description: This message only contains a field of double number array.
-        properties:
-        - name: doubleValues
-          type: Array
-          description: Double number array.
-          item_type:
-            type: Double
-      - name: doubleValue
-        type: Double
-        description: Double Number.
-      - name: intArray
-        type: NestedObject
-        description: This message only contains a field of integer array.
-        properties:
-        - name: intValues
-          type: Array
-          description: Integer array.
-          item_type:
-            type: String
-      - name: intValue
-        type: String
-        description: Integer.
-      - name: jsonValue
-        type: String
-        description: Json.
-      - name: stringArray
-        type: NestedObject
-        description: This message only contains a field of string array.
-        properties:
-        - name: stringValues
-          type: Array
-          description: String array.
-          item_type:
-            type: String
-      - name: stringValue
-        type: String
-        description: String.
-    - name: description
-      type: String
-      description: Description of the parameter.
-    - name: displayName
-      type: String
-      description: 'The name (without prefix) to be displayed in the UI for this parameter.
-
-        E.g. if the key is "foo.bar.myName", then the name would be "myName".'
-    - name: inputOutputType
-      type: String
-      description: 'Specifies the input/output type for the parameter.
-
-        Possible values:
-
-        IN
-
-        OUT
-
-        IN_OUT'
-    - name: isTransient
-      type: Boolean
-      description: Whether this parameter is a transient parameter.
-    - name: jsonSchema
-      type: String
-      description: 'This schema will be used to validate runtime JSON-typed values of this
-
-        parameter.'
-    - name: key
-      type: String
-      description: 'Key is used to retrieve the corresponding parameter value. This should be
-
-        unique for a given fired event. These parameters must be predefined in the
-
-        integration definition.'
-    - name: masked
-      type: Boolean
-      description: True if this parameter should be masked in the logs
-    - name: producer
-      type: String
-      description: 'The identifier of the node (TaskConfig/TriggerConfig) this parameter was
-
-        produced by, if it is a transient param or a copy of an input param.'
-    - name: searchable
-      type: Boolean
-      description: Searchable in the execution log or not.
-- name: lastModifierEmail
-  type: String
-  description: 'The last modifier''s email address. Generated based on the End User
-
-    Credentials/LOAS role of the user making the call.'
-  output: true
-- name: lockHolder
-  type: String
-  description: 'The edit lock holder''s email address. Generated based on the End User
-
-    Credentials/LOAS role of the user making the call.'
-  output: true
-- name: name
-  type: String
-  description: Auto-generated primary key.
-  output: true
-- name: origin
-  type: String
-  output: true
-  description: 'Possible values:
-
-    UNSPECIFIED
-
-    UI
-
-    PIPER_V2
-
-    PIPER_V3
-
-    APPLICATION_IP_PROVISIONING
-
-    TEST_CASE'
-- name: parentTemplateId
-  type: String
-  description: The id of the template which was used to create this integration_version.
-- name: runAsServiceAccount
-  type: String
-  description: 'The run-as service account email, if set and auth config is not configured,
-
-    that will be used to generate auth token to be used in Connector task,
-
-    Rest caller task and Cloud function task.'
-- name: snapshotNumber
-  type: String
-  description: 'An increasing sequence that is set when a new snapshot is created. The last
-
-    created snapshot can be identified by [workflow_name, org_id
-
-    latest(snapshot_number)]. However, last created snapshot need not be
-
-    same as the HEAD.
-
-    So users should always use "HEAD" tag to identify the head.'
-  output: true
-- name: state
-  type: String
-  description: 'Possible values:
-
-    DRAFT
-
-    ACTIVE
-
-    ARCHIVED
-
-    SNAPSHOT'
-  output: true
-- name: status
-  type: String
-  description: 'Possible values:
-
-    UNKNOWN
-
-    DRAFT
-
-    ACTIVE
-
-    ARCHIVED
-
-    SNAPSHOT'
-  output: true
-- name: taskConfigs
-  type: Array
-  description: 'Task configuration for the integration. It''s optional, but the integration
-
-    doesn''t do anything without task_configs.'
-  item_type:
-    type: NestedObject
-    properties:
-    - name: conditionalFailurePolicies
-      type: NestedObject
-      description: Conditional task failur retry strategies
-      properties:
-      - name: defaultFailurePolicy
-        type: NestedObject
-        description: 'Policy that defines the task retry logic and failure type. If no
-
-          FailurePolicy is defined for a task, all its dependent tasks will not be
-
-          executed (i.e, a `retry_strategy` of NONE will be applied).'
-        properties:
-        - name: condition
-          type: String
-          description: 'The string condition that will be evaluated to determine if the
-
-            task should be retried with this failure policy.'
-        - name: intervalTime
-          type: String
-          description: 'Required if retry_strategy is FIXED_INTERVAL or
-
-            LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
-
-            initial interval in seconds for backoff.'
-        - name: maxRetries
-          type: Integer
-          description: 'Required if retry_strategy is FIXED_INTERVAL or
-
-            LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
-
-            number of times the task will be retried if failed.'
-        - name: retryStrategy
-          type: String
-          description: 'Defines what happens to the task upon failure.
-
-            Possible values:
-
-            IGNORE
-
-            NONE
-
-            FATAL
-
-            FIXED_INTERVAL
-
-            LINEAR_BACKOFF
-
-            EXPONENTIAL_BACKOFF
-
-            RESTART_INTEGRATION_WITH_BACKOFF'
-      - name: failurePolicies
-        type: Array
-        description: The list of failure policies that will be applied to the task in order.
-        item_type:
-          type: NestedObject
-          properties:
-          - name: condition
-            type: String
-            description: 'The string condition that will be evaluated to determine if the
-
-              task should be retried with this failure policy.'
-          - name: intervalTime
-            type: String
-            description: 'Required if retry_strategy is FIXED_INTERVAL or
-
-              LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
-
-              initial interval in seconds for backoff.'
-          - name: maxRetries
-            type: Integer
-            description: 'Required if retry_strategy is FIXED_INTERVAL or
-
-              LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
-
-              number of times the task will be retried if failed.'
-          - name: retryStrategy
-            type: String
-            description: 'Defines what happens to the task upon failure.
-
-              Possible values:
-
-              IGNORE
-
-              NONE
-
-              FATAL
-
-              FIXED_INTERVAL
-
-              LINEAR_BACKOFF
-
-              EXPONENTIAL_BACKOFF
-
-              RESTART_INTEGRATION_WITH_BACKOFF'
-    - name: description
-      type: String
-      description: 'User-provided description intended to give additional business context
-
-        about the task.'
-    - name: displayName
-      type: String
-      description: User-provided label that is attached to this TaskConfig in the UI.
-    - name: errorCatcherId
-      type: String
-      description: 'Optional
-
-        Error catcher id of the error catch flow which will be executed when
-
-        execution error happens in the task'
-    - name: externalTaskType
-      type: String
-      description: 'External task type of the task
-
-        Possible values:
-
-        NORMAL_TASK
-
-        ERROR_TASK'
-    - name: failurePolicy
-      type: NestedObject
-      description: 'Policy that defines the task retry logic and failure type. If no
-
-        FailurePolicy is defined for a task, all its dependent tasks will not be
-
-        executed (i.e, a `retry_strategy` of NONE will be applied).'
-      properties:
-      - name: condition
-        type: String
-        description: 'The string condition that will be evaluated to determine if the
-
-          task should be retried with this failure policy.'
-      - name: intervalTime
-        type: String
-        description: 'Required if retry_strategy is FIXED_INTERVAL or
-
-          LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
-
-          initial interval in seconds for backoff.'
-      - name: maxRetries
-        type: Integer
-        description: 'Required if retry_strategy is FIXED_INTERVAL or
-
-          LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
-
-          number of times the task will be retried if failed.'
-      - name: retryStrategy
-        type: String
-        description: 'Defines what happens to the task upon failure.
-
-          Possible values:
-
-          IGNORE
-
-          NONE
-
-          FATAL
-
-          FIXED_INTERVAL
-
-          LINEAR_BACKOFF
-
-          EXPONENTIAL_BACKOFF
-
-          RESTART_INTEGRATION_WITH_BACKOFF'
-    - name: jsonValidationOption
-      type: String
-      description: 'Possible values:
-
-        SKIP
-
-        PRE_EXECUTION
-
-        POST_EXECUTION
-
-        PRE_POST_EXECUTION'
-    - name: nextTasks
-      type: Array
-      description: 'The set of tasks that are next in line to be executed as per the
-
-        execution graph defined for the parent event, specified by
-
-        `event_config_id`. Each of these next tasks are executed
-
-        only if the condition associated with them evaluates to true.'
-      item_type:
-        type: NestedObject
-        properties:
-        - name: condition
-          type: String
-          description: Standard filter expression for this task to become an eligible next task.
-        - name: description
-          type: String
-          description: 'User-provided description intended to give additional business context
-
-            about the task.'
-        - name: displayName
-          type: String
-          description: User-provided label that is attached to this edge in the UI.
-        - name: taskConfigId
-          type: String
-          description: ID of the next task.
-        - name: taskId
-          type: String
-          description: Task number of the next task.
-    - name: nextTasksExecutionPolicy
-      type: String
-      description: 'The policy dictating the execution of the next set of tasks for the current
-
-        task.
-
-        Possible values:
-
-        RUN_ALL_MATCH
-
-        RUN_FIRST_MATCH'
-    - name: parameters
-      type: Map
-      custom_expand: templates/terraform/custom_expand/integrations_version_parameters.go.tmpl
-      description: The customized parameters the user can pass to this task.
-      value_type:
-        type: NestedObject
-        properties:
-        - name: masked
-          type: Boolean
-          description: True if this parameter should be masked in the logs
+              description: Description of the parameter.
+            - name: displayName
+              type: String
+              description: |-
+                The name (without prefix) to be displayed in the UI for this parameter.
+                E.g. if the key is "foo.bar.myName", then the name would be "myName".
+            - name: inputOutputType
+              type: String
+              description: |-
+                Specifies the input/output type for the parameter.
+                Possible values:
+                IN
+                OUT
+                IN_OUT
+            - name: isTransient
+              type: Boolean
+              description: Whether this parameter is a transient parameter.
+            - name: jsonSchema
+              type: String
+              description: |-
+                This schema will be used to validate runtime JSON-typed values of this
+                parameter.
+            - name: key
+              type: String
+              description: |-
+                Key is used to retrieve the corresponding parameter value. This should be
+                unique for a given fired event. These parameters must be predefined in the
+                integration definition.
+            - name: masked
+              type: Boolean
+              description: True if this parameter should be masked in the logs
+            - name: producer
+              type: String
+              description: |-
+                The identifier of the node (TaskConfig/TriggerConfig) this parameter was
+                produced by, if it is a transient param or a copy of an input param.
+            - name: searchable
+              type: Boolean
+              description: Searchable in the execution log or not.
         - name: value
           type: NestedObject
           description: The type of the parameter.
           properties:
-          - name: booleanArray
-            type: NestedObject
-            description: This message only contains a field of boolean array.
-            properties:
-            - name: booleanValues
-              type: Array
-              description: Boolean array.
-              item_type:
-                type: Boolean
-          - name: booleanValue
-            type: Boolean
-            description: Boolean.
-          - name: doubleArray
-            type: NestedObject
-            description: This message only contains a field of double number array.
-            properties:
-            - name: doubleValues
-              type: Array
-              description: Double number array.
-              item_type:
-                type: Double
-          - name: doubleValue
-            type: Double
-            description: Double Number.
-          - name: intArray
-            type: NestedObject
-            description: This message only contains a field of integer array.
-            properties:
-            - name: intValues
-              type: Array
-              description: Integer array.
-              item_type:
-                type: String
-          - name: intValue
-            type: String
-            description: Integer.
-          - name: jsonValue
-            type: String
-            description: Json.
-          - name: stringArray
-            type: NestedObject
-            description: This message only contains a field of string array.
-            properties:
-            - name: stringValues
-              type: Array
-              description: String array.
-              item_type:
-                type: String
-          - name: stringValue
-            type: String
-            description: String.
-      key_name: key
-    - name: position
+            - name: booleanArray
+              type: NestedObject
+              description: This message only contains a field of boolean array.
+              properties:
+                - name: booleanValues
+                  type: Array
+                  description: Boolean array.
+                  item_type:
+                    type: Boolean
+            - name: booleanValue
+              type: Boolean
+              description: Boolean.
+            - name: doubleArray
+              type: NestedObject
+              description: This message only contains a field of double number array.
+              properties:
+                - name: doubleValues
+                  type: Array
+                  description: Double number array.
+                  item_type:
+                    type: Double
+            - name: doubleValue
+              type: Double
+              description: Double Number.
+            - name: intArray
+              type: NestedObject
+              description: This message only contains a field of integer array.
+              properties:
+                - name: intValues
+                  type: Array
+                  description: Integer array.
+                  item_type:
+                    type: String
+            - name: intValue
+              type: String
+              description: Integer.
+            - name: jsonValue
+              type: String
+              description: Json.
+            - name: stringArray
+              type: NestedObject
+              description: This message only contains a field of string array.
+              properties:
+                - name: stringValues
+                  type: Array
+                  description: String array.
+                  item_type:
+                    type: String
+            - name: stringValue
+              type: String
+              description: String.
+  - name: integrationParameters
+    type: Array
+    description: |-
+      Parameters that are expected to be passed to the integration when an event
+      is triggered. This consists of all the parameters that are expected in the
+      integration execution. This gives the user the ability to provide default
+      values, add information like PII and also provide data types of each
+      parameter.
+    item_type:
       type: NestedObject
-      description: Configuration detail of coordinate, it used for UI
       properties:
-      - name: x
-        type: Integer
-        required: true
-        description: X axis of the coordinate
-      - name: y
-        type: Integer
-        required: true
-        description: Y axis of the coordinate
-    - name: successPolicy
-      type: NestedObject
-      description: 'Policy that dictates the behavior for the task after it completes
-
-        successfully.'
-      properties:
-      - name: finalState
-        type: String
-        description: 'State to which the execution snapshot status will be set if the task
-
-          succeeds.
-
-          Possible values:
-
-          SUCCEEDED
-
-          SUSPENDED'
-    - name: synchronousCallFailurePolicy
-      type: NestedObject
-      description: 'Policy that defines the task retry logic and failure type. If no
-
-        FailurePolicy is defined for a task, all its dependent tasks will not be
-
-        executed (i.e, a `retry_strategy` of NONE will be applied).'
-      properties:
-      - name: condition
-        type: String
-        description: 'The string condition that will be evaluated to determine if the
-
-          task should be retried with this failure policy.'
-      - name: intervalTime
-        type: String
-        description: 'Required if retry_strategy is FIXED_INTERVAL or
-
-          LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
-
-          initial interval in seconds for backoff.'
-      - name: maxRetries
-        type: Integer
-        description: 'Required if retry_strategy is FIXED_INTERVAL or
-
-          LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
-
-          number of times the task will be retried if failed.'
-      - name: retryStrategy
-        type: String
-        description: 'Defines what happens to the task upon failure.
-
-          Possible values:
-
-          IGNORE
-
-          NONE
-
-          FATAL
-
-          FIXED_INTERVAL
-
-          LINEAR_BACKOFF
-
-          EXPONENTIAL_BACKOFF
-
-          RESTART_INTEGRATION_WITH_BACKOFF'
-    - name: task
-      type: String
-      description: The name for the task.
-    - name: taskExecutionStrategy
-      type: String
-      description: 'The policy dictating the execution strategy of this task.
-
-        Possible values:
-
-        WHEN_ALL_SUCCEED
-
-        WHEN_ANY_SUCCEED
-
-        WHEN_ALL_TASKS_AND_CONDITIONS_SUCCEED'
-    - name: taskId
-      type: String
-      required: true
-      description: 'The identifier of this task within its parent event config,
-
-        specified by the client. This should be unique among all the tasks belong
-
-        to the same event config. We use this field as the identifier to
-
-        find next tasks (via field `next_tasks.task_id`).'
-    - name: taskTemplate
-      type: String
-      description: Used to define task-template name if task is of type task-template
-- name: triggerConfigs
-  type: Array
-  description: Trigger configurations.
-  item_type:
-    type: NestedObject
-    properties:
-    - name: alertConfig
-      type: Array
-      description: 'An alert threshold configuration for the [trigger + client + integration]
-
-        tuple. If these values are not specified in the trigger config, default
-
-        values will be populated by the system. Note that there must be exactly one
-
-        alert threshold configured per [client + trigger + integration] when
-
-        published.'
-      item_type:
-        type: NestedObject
-        properties:
-        - name: aggregationPeriod
-          type: String
-          description: 'The period over which the metric value should be aggregated and
-
-            evaluated. Format is , where integer should be a positive
-
-            integer and unit should be one of (s,m,h,d,w) meaning (second, minute,
-
-            hour, day, week).
-
-            For an EXPECTED_MIN threshold, this aggregation_period must be lesser than
-
-            24 hours.'
-        - name: alertThreshold
-          type: Integer
-          description: 'For how many contiguous aggregation periods should the expected min or
-
-            max be violated for the alert to be fired.'
-        - name: disableAlert
+        - name: containsLargeData
           type: Boolean
-          description: 'Set to false by default. When set to true, the metrics are not aggregated
-
-            or pushed to Monarch for this integration alert.'
-        - name: displayName
+          description: |-
+            Indicates whether this variable contains large data and need to be uploaded
+            to Cloud Storage.
+        - name: dataType
           type: String
-          description: 'Name of the alert. This will be displayed in the alert
-
-            subject. If set, this name should be unique within the scope of the
-
-            integration.'
-        - name: durationThreshold
-          type: String
-          description: 'Should be specified only for *AVERAGE_DURATION and
-
-            *PERCENTILE_DURATION metrics. This member should be used to specify what
-
-            duration value the metrics should exceed for the alert to trigger.'
-        - name: metricType
-          type: String
-          description: 'The type of metric.
-
+          description: |-
+            Type of the parameter.
             Possible values:
-
-            EVENT_ERROR_RATE
-
-            EVENT_WARNING_RATE
-
-            TASK_ERROR_RATE
-
-            TASK_WARNING_RATE
-
-            TASK_RATE
-
-            EVENT_RATE
-
-            EVENT_AVERAGE_DURATION
-
-            EVENT_PERCENTILE_DURATION
-
-            TASK_AVERAGE_DURATION
-
-            TASK_PERCENTILE_DURATION'
-        - name: onlyFinalAttempt
-          type: Boolean
-          description: 'For either events or tasks, depending on the type of alert, count only
-
-            final attempts, not retries.'
-        - name: thresholdType
-          type: String
-          description: 'The threshold type, whether lower(expected_min) or upper(expected_max), for
-
-            which this alert is being configured. If value falls below expected_min or
-
-            exceeds expected_max, an alert will be fired.
-
-            Possible values:
-
-            EXPECTED_MIN
-
-            EXPECTED_MAX'
-        - name: thresholdValue
+            STRING_VALUE
+            INT_VALUE
+            DOUBLE_VALUE
+            BOOLEAN_VALUE
+            STRING_ARRAY
+            INT_ARRAY
+            DOUBLE_ARRAY
+            BOOLEAN_ARRAY
+            JSON_VALUE
+            PROTO_VALUE
+            PROTO_ARRAY
+            NON_SERIALIZABLE_OBJECT
+            PROTO_ENUM
+            SERIALIZED_OBJECT_VALUE
+            PROTO_ENUM_ARRAY
+            BYTES
+            BYTES_ARRAY
+        - name: defaultValue
           type: NestedObject
-          description: 'The threshold value of the metric, above or below which the alert should
-
-            be triggered. See EventAlertConfig or TaskAlertConfig for the different
-
-            alert metric types in each case.
-
-
-            For the *RATE metrics, one or both of these fields may be set. Zero is the
-
-            default value and can be left at that.
-
-
-            For *PERCENTILE_DURATION metrics, one or both of these fields may
-
-            be set, and also, the duration threshold value should be specified in the
-
-            threshold_duration_ms member below.
-
-
-            For *AVERAGE_DURATION metrics, these fields should not be set at all.
-
-            A different member, threshold_duration_ms, must be set in the
-
-            EventAlertConfig or the TaskAlertConfig.'
+          description: The type of the parameter.
           properties:
-          - name: absolute
-            type: String
-            description: Absolute value threshold.
-          - name: percentage
-            type: Integer
-            description: Percentage threshold.
-    - name: cloudSchedulerConfig
-      type: NestedObject
-      description: Cloud Scheduler Trigger configuration
-      properties:
-      - name: cronTab
-        type: String
-        required: true
-        description: The cron tab of cloud scheduler trigger.
-      - name: errorMessage
-        type: String
-        description: 'When the job was deleted from Pantheon UI, error_message will be populated
-
-          when Get/List integrations'
-      - name: location
-        type: String
-        required: true
-        description: The location where associated cloud scheduler job will be created
-      - name: serviceAccountEmail
-        type: String
-        required: true
-        description: 'Service account used by Cloud Scheduler to trigger the integration at
-
-          scheduled time'
-    - name: description
-      type: String
-      description: 'User-provided description intended to give additional business context
-
-        about the task.'
-    - name: errorCatcherId
-      type: String
-      description: 'Optional
-
-        Error catcher id of the error catch flow which will be executed when
-
-        execution error happens in the task'
-    - name: inputVariables
-      type: NestedObject
-      description: Variables names mapped to api trigger.
-      properties:
-      - name: names
-        type: Array
-        description: List of variable names.
-        item_type:
-          type: String
-    - name: label
-      type: String
-      description: The user created label for a particular trigger.
-    - name: nextTasksExecutionPolicy
-      type: String
-      description: 'Dictates how next tasks will be executed.
-
-        Possible values:
-
-        RUN_ALL_MATCH
-
-        RUN_FIRST_MATCH'
-    - name: outputVariables
-      type: NestedObject
-      description: Variables names mapped to api trigger.
-      properties:
-      - name: names
-        type: Array
-        description: List of variable names.
-        item_type:
-          type: String
-    - name: position
-      type: NestedObject
-      description: Configuration detail of coordinate, it used for UI
-      properties:
-      - name: x
-        type: Integer
-        required: true
-        description: X axis of the coordinate
-      - name: y
-        type: Integer
-        required: true
-        description: Y axis of the coordinate
-    - name: properties
-      type: KeyValuePairs
-      description: 'Configurable properties of the trigger,
-
-        not to be confused with integration parameters.
-
-        E.g. "name" is a property for API triggers
-
-        and "subscription" is a property for Pub/sub triggers.'
-    - name: startTasks
-      type: Array
-      description: 'Set of tasks numbers from where the integration execution is started by
-
-        this trigger. If this is empty, then integration is executed with default
-
-        start tasks. In the list of start tasks, none of two tasks can have direct
-
-        ancestor-descendant relationships (i.e. in a same integration execution
-
-        graph).'
-      item_type:
-        type: NestedObject
-        properties:
-        - name: condition
-          type: String
-          description: Standard filter expression for this task to become an eligible next task.
+            - name: booleanArray
+              type: NestedObject
+              description: This message only contains a field of boolean array.
+              properties:
+                - name: booleanValues
+                  type: Array
+                  description: Boolean array.
+                  item_type:
+                    type: Boolean
+            - name: booleanValue
+              type: Boolean
+              description: Boolean.
+            - name: doubleArray
+              type: NestedObject
+              description: This message only contains a field of double number array.
+              properties:
+                - name: doubleValues
+                  type: Array
+                  description: Double number array.
+                  item_type:
+                    type: Double
+            - name: doubleValue
+              type: Double
+              description: Double Number.
+            - name: intArray
+              type: NestedObject
+              description: This message only contains a field of integer array.
+              properties:
+                - name: intValues
+                  type: Array
+                  description: Integer array.
+                  item_type:
+                    type: String
+            - name: intValue
+              type: String
+              description: Integer.
+            - name: jsonValue
+              type: String
+              description: Json.
+            - name: stringArray
+              type: NestedObject
+              description: This message only contains a field of string array.
+              properties:
+                - name: stringValues
+                  type: Array
+                  description: String array.
+                  item_type:
+                    type: String
+            - name: stringValue
+              type: String
+              description: String.
         - name: description
           type: String
-          description: 'User-provided description intended to give additional business context
-
-            about the task.'
+          description: Description of the parameter.
         - name: displayName
           type: String
-          description: User-provided label that is attached to this edge in the UI.
-        - name: taskConfigId
+          description: |-
+            The name (without prefix) to be displayed in the UI for this parameter.
+            E.g. if the key is "foo.bar.myName", then the name would be "myName".
+        - name: inputOutputType
           type: String
-          description: ID of the next task.
+          description: |-
+            Specifies the input/output type for the parameter.
+            Possible values:
+            IN
+            OUT
+            IN_OUT
+        - name: isTransient
+          type: Boolean
+          description: Whether this parameter is a transient parameter.
+        - name: jsonSchema
+          type: String
+          description: |-
+            This schema will be used to validate runtime JSON-typed values of this
+            parameter.
+        - name: key
+          type: String
+          description: |-
+            Key is used to retrieve the corresponding parameter value. This should be
+            unique for a given fired event. These parameters must be predefined in the
+            integration definition.
+        - name: masked
+          type: Boolean
+          description: True if this parameter should be masked in the logs
+        - name: producer
+          type: String
+          description: |-
+            The identifier of the node (TaskConfig/TriggerConfig) this parameter was
+            produced by, if it is a transient param or a copy of an input param.
+        - name: searchable
+          type: Boolean
+          description: Searchable in the execution log or not.
+  - name: lastModifierEmail
+    type: String
+    description: |-
+      The last modifier's email address. Generated based on the End User
+      Credentials/LOAS role of the user making the call.
+    output: true
+  - name: lockHolder
+    type: String
+    description: |-
+      The edit lock holder's email address. Generated based on the End User
+      Credentials/LOAS role of the user making the call.
+    output: true
+  - name: name
+    type: String
+    description: Auto-generated primary key.
+    output: true
+  - name: origin
+    type: String
+    output: true
+    description: |-
+      Possible values:
+      UNSPECIFIED
+      UI
+      PIPER_V2
+      PIPER_V3
+      APPLICATION_IP_PROVISIONING
+      TEST_CASE
+  - name: parentTemplateId
+    type: String
+    description: The id of the template which was used to create this integration_version.
+  - name: runAsServiceAccount
+    type: String
+    description: |-
+      The run-as service account email, if set and auth config is not configured,
+      that will be used to generate auth token to be used in Connector task,
+      Rest caller task and Cloud function task.
+  - name: snapshotNumber
+    type: String
+    description: |-
+      An increasing sequence that is set when a new snapshot is created. The last
+      created snapshot can be identified by [workflow_name, org_id
+      latest(snapshot_number)]. However, last created snapshot need not be
+      same as the HEAD.
+      So users should always use "HEAD" tag to identify the head.
+    output: true
+  - name: state
+    type: String
+    description: |-
+      Possible values:
+      DRAFT
+      ACTIVE
+      ARCHIVED
+      SNAPSHOT
+    output: true
+  - name: status
+    type: String
+    description: |-
+      Possible values:
+      UNKNOWN
+      DRAFT
+      ACTIVE
+      ARCHIVED
+      SNAPSHOT
+    output: true
+  - name: taskConfigs
+    type: Array
+    description: |-
+      Task configuration for the integration. It's optional, but the integration
+      doesn't do anything without task_configs.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: conditionalFailurePolicies
+          type: NestedObject
+          description: Conditional task failur retry strategies
+          properties:
+            - name: defaultFailurePolicy
+              type: NestedObject
+              description: |-
+                Policy that defines the task retry logic and failure type. If no
+                FailurePolicy is defined for a task, all its dependent tasks will not be
+                executed (i.e, a `retry_strategy` of NONE will be applied).
+              properties:
+                - name: condition
+                  type: String
+                  description: |-
+                    The string condition that will be evaluated to determine if the
+                    task should be retried with this failure policy.
+                - name: intervalTime
+                  type: String
+                  description: |-
+                    Required if retry_strategy is FIXED_INTERVAL or
+                    LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+                    initial interval in seconds for backoff.
+                - name: maxRetries
+                  type: Integer
+                  description: |-
+                    Required if retry_strategy is FIXED_INTERVAL or
+                    LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+                    number of times the task will be retried if failed.
+                - name: retryStrategy
+                  type: String
+                  description: |-
+                    Defines what happens to the task upon failure.
+                    Possible values:
+                    IGNORE
+                    NONE
+                    FATAL
+                    FIXED_INTERVAL
+                    LINEAR_BACKOFF
+                    EXPONENTIAL_BACKOFF
+                    RESTART_INTEGRATION_WITH_BACKOFF
+            - name: failurePolicies
+              type: Array
+              description: The list of failure policies that will be applied to the task in order.
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: condition
+                    type: String
+                    description: |-
+                      The string condition that will be evaluated to determine if the
+                      task should be retried with this failure policy.
+                  - name: intervalTime
+                    type: String
+                    description: |-
+                      Required if retry_strategy is FIXED_INTERVAL or
+                      LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+                      initial interval in seconds for backoff.
+                  - name: maxRetries
+                    type: Integer
+                    description: |-
+                      Required if retry_strategy is FIXED_INTERVAL or
+                      LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+                      number of times the task will be retried if failed.
+                  - name: retryStrategy
+                    type: String
+                    description: |-
+                      Defines what happens to the task upon failure.
+                      Possible values:
+                      IGNORE
+                      NONE
+                      FATAL
+                      FIXED_INTERVAL
+                      LINEAR_BACKOFF
+                      EXPONENTIAL_BACKOFF
+                      RESTART_INTEGRATION_WITH_BACKOFF
+        - name: description
+          type: String
+          description: |-
+            User-provided description intended to give additional business context
+            about the task.
+        - name: displayName
+          type: String
+          description: User-provided label that is attached to this TaskConfig in the UI.
+        - name: errorCatcherId
+          type: String
+          description: |-
+            Optional
+            Error catcher id of the error catch flow which will be executed when
+            execution error happens in the task
+        - name: externalTaskType
+          type: String
+          description: |-
+            External task type of the task
+            Possible values:
+            NORMAL_TASK
+            ERROR_TASK
+        - name: failurePolicy
+          type: NestedObject
+          description: |-
+            Policy that defines the task retry logic and failure type. If no
+            FailurePolicy is defined for a task, all its dependent tasks will not be
+            executed (i.e, a `retry_strategy` of NONE will be applied).
+          properties:
+            - name: condition
+              type: String
+              description: |-
+                The string condition that will be evaluated to determine if the
+                task should be retried with this failure policy.
+            - name: intervalTime
+              type: String
+              description: |-
+                Required if retry_strategy is FIXED_INTERVAL or
+                LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+                initial interval in seconds for backoff.
+            - name: maxRetries
+              type: Integer
+              description: |-
+                Required if retry_strategy is FIXED_INTERVAL or
+                LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+                number of times the task will be retried if failed.
+            - name: retryStrategy
+              type: String
+              description: |-
+                Defines what happens to the task upon failure.
+                Possible values:
+                IGNORE
+                NONE
+                FATAL
+                FIXED_INTERVAL
+                LINEAR_BACKOFF
+                EXPONENTIAL_BACKOFF
+                RESTART_INTEGRATION_WITH_BACKOFF
+        - name: jsonValidationOption
+          type: String
+          description: |-
+            Possible values:
+            SKIP
+            PRE_EXECUTION
+            POST_EXECUTION
+            PRE_POST_EXECUTION
+        - name: nextTasks
+          type: Array
+          description: |-
+            The set of tasks that are next in line to be executed as per the
+            execution graph defined for the parent event, specified by
+            `event_config_id`. Each of these next tasks are executed
+            only if the condition associated with them evaluates to true.
+          item_type:
+            type: NestedObject
+            properties:
+              - name: condition
+                type: String
+                description: Standard filter expression for this task to become an eligible next task.
+              - name: description
+                type: String
+                description: |-
+                  User-provided description intended to give additional business context
+                  about the task.
+              - name: displayName
+                type: String
+                description: User-provided label that is attached to this edge in the UI.
+              - name: taskConfigId
+                type: String
+                description: ID of the next task.
+              - name: taskId
+                type: String
+                description: Task number of the next task.
+        - name: nextTasksExecutionPolicy
+          type: String
+          description: |-
+            The policy dictating the execution of the next set of tasks for the current
+            task.
+            Possible values:
+            RUN_ALL_MATCH
+            RUN_FIRST_MATCH
+        - name: parameters
+          type: Map
+          custom_expand: templates/terraform/custom_expand/integrations_version_parameters.go.tmpl
+          description: The customized parameters the user can pass to this task.
+          value_type:
+            type: NestedObject
+            properties:
+              - name: masked
+                type: Boolean
+                description: True if this parameter should be masked in the logs
+              - name: value
+                type: NestedObject
+                description: The type of the parameter.
+                properties:
+                  - name: booleanArray
+                    type: NestedObject
+                    description: This message only contains a field of boolean array.
+                    properties:
+                      - name: booleanValues
+                        type: Array
+                        description: Boolean array.
+                        item_type:
+                          type: Boolean
+                  - name: booleanValue
+                    type: Boolean
+                    description: Boolean.
+                  - name: doubleArray
+                    type: NestedObject
+                    description: This message only contains a field of double number array.
+                    properties:
+                      - name: doubleValues
+                        type: Array
+                        description: Double number array.
+                        item_type:
+                          type: Double
+                  - name: doubleValue
+                    type: Double
+                    description: Double Number.
+                  - name: intArray
+                    type: NestedObject
+                    description: This message only contains a field of integer array.
+                    properties:
+                      - name: intValues
+                        type: Array
+                        description: Integer array.
+                        item_type:
+                          type: String
+                  - name: intValue
+                    type: String
+                    description: Integer.
+                  - name: jsonValue
+                    type: String
+                    description: Json.
+                  - name: stringArray
+                    type: NestedObject
+                    description: This message only contains a field of string array.
+                    properties:
+                      - name: stringValues
+                        type: Array
+                        description: String array.
+                        item_type:
+                          type: String
+                  - name: stringValue
+                    type: String
+                    description: String.
+          key_name: key
+        - name: position
+          type: NestedObject
+          description: Configuration detail of coordinate, it used for UI
+          properties:
+            - name: x
+              type: Integer
+              required: true
+              description: X axis of the coordinate
+            - name: y
+              type: Integer
+              required: true
+              description: Y axis of the coordinate
+        - name: successPolicy
+          type: NestedObject
+          description: |-
+            Policy that dictates the behavior for the task after it completes
+            successfully.
+          properties:
+            - name: finalState
+              type: String
+              description: |-
+                State to which the execution snapshot status will be set if the task
+                succeeds.
+                Possible values:
+                SUCCEEDED
+                SUSPENDED
+        - name: synchronousCallFailurePolicy
+          type: NestedObject
+          description: |-
+            Policy that defines the task retry logic and failure type. If no
+            FailurePolicy is defined for a task, all its dependent tasks will not be
+            executed (i.e, a `retry_strategy` of NONE will be applied).
+          properties:
+            - name: condition
+              type: String
+              description: |-
+                The string condition that will be evaluated to determine if the
+                task should be retried with this failure policy.
+            - name: intervalTime
+              type: String
+              description: |-
+                Required if retry_strategy is FIXED_INTERVAL or
+                LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+                initial interval in seconds for backoff.
+            - name: maxRetries
+              type: Integer
+              description: |-
+                Required if retry_strategy is FIXED_INTERVAL or
+                LINEAR/EXPONENTIAL_BACKOFF/RESTART_INTEGRATION_WITH_BACKOFF. Defines the
+                number of times the task will be retried if failed.
+            - name: retryStrategy
+              type: String
+              description: |-
+                Defines what happens to the task upon failure.
+                Possible values:
+                IGNORE
+                NONE
+                FATAL
+                FIXED_INTERVAL
+                LINEAR_BACKOFF
+                EXPONENTIAL_BACKOFF
+                RESTART_INTEGRATION_WITH_BACKOFF
+        - name: task
+          type: String
+          description: The name for the task.
+        - name: taskExecutionStrategy
+          type: String
+          description: |-
+            The policy dictating the execution strategy of this task.
+            Possible values:
+            WHEN_ALL_SUCCEED
+            WHEN_ANY_SUCCEED
+            WHEN_ALL_TASKS_AND_CONDITIONS_SUCCEED
         - name: taskId
           type: String
-          description: Task number of the next task.
-    - name: trigger
-      type: String
-      description: 'Name of the trigger. Example: "API Trigger", "Cloud Pub Sub
+          required: true
+          description: |-
+            The identifier of this task within its parent event config,
+            specified by the client. This should be unique among all the tasks belong
+            to the same event config. We use this field as the identifier to
+            find next tasks (via field `next_tasks.task_id`).
+        - name: taskTemplate
+          type: String
+          description: Used to define task-template name if task is of type task-template
+  - name: triggerConfigs
+    type: Array
+    description: Trigger configurations.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: alertConfig
+          type: Array
+          description: |-
+            An alert threshold configuration for the [trigger + client + integration]
+            tuple. If these values are not specified in the trigger config, default
+            values will be populated by the system. Note that there must be exactly one
+            alert threshold configured per [client + trigger + integration] when
+            published.
+          item_type:
+            type: NestedObject
+            properties:
+              - name: aggregationPeriod
+                type: String
+                description: |-
+                  The period over which the metric value should be aggregated and
+                  evaluated. Format is , where integer should be a positive
+                  integer and unit should be one of (s,m,h,d,w) meaning (second, minute,
+                  hour, day, week).
+                  For an EXPECTED_MIN threshold, this aggregation_period must be lesser than
+                  24 hours.
+              - name: alertThreshold
+                type: Integer
+                description: |-
+                  For how many contiguous aggregation periods should the expected min or
+                  max be violated for the alert to be fired.
+              - name: disableAlert
+                type: Boolean
+                description: |-
+                  Set to false by default. When set to true, the metrics are not aggregated
+                  or pushed to Monarch for this integration alert.
+              - name: displayName
+                type: String
+                description: |-
+                  Name of the alert. This will be displayed in the alert
+                  subject. If set, this name should be unique within the scope of the
+                  integration.
+              - name: durationThreshold
+                type: String
+                description: |-
+                  Should be specified only for *AVERAGE_DURATION and
+                  *PERCENTILE_DURATION metrics. This member should be used to specify what
+                  duration value the metrics should exceed for the alert to trigger.
+              - name: metricType
+                type: String
+                description: |-
+                  The type of metric.
+                  Possible values:
+                  EVENT_ERROR_RATE
+                  EVENT_WARNING_RATE
+                  TASK_ERROR_RATE
+                  TASK_WARNING_RATE
+                  TASK_RATE
+                  EVENT_RATE
+                  EVENT_AVERAGE_DURATION
+                  EVENT_PERCENTILE_DURATION
+                  TASK_AVERAGE_DURATION
+                  TASK_PERCENTILE_DURATION
+              - name: onlyFinalAttempt
+                type: Boolean
+                description: |-
+                  For either events or tasks, depending on the type of alert, count only
+                  final attempts, not retries.
+              - name: thresholdType
+                type: String
+                description: |-
+                  The threshold type, whether lower(expected_min) or upper(expected_max), for
+                  which this alert is being configured. If value falls below expected_min or
+                  exceeds expected_max, an alert will be fired.
+                  Possible values:
+                  EXPECTED_MIN
+                  EXPECTED_MAX
+              - name: thresholdValue
+                type: NestedObject
+                description: |-
+                  The threshold value of the metric, above or below which the alert should
+                  be triggered. See EventAlertConfig or TaskAlertConfig for the different
+                  alert metric types in each case.
 
-        Trigger" When set will be sent out to monitoring dashabord for tracking
+                  For the *RATE metrics, one or both of these fields may be set. Zero is the
+                  default value and can be left at that.
 
-        purpose.'
-    - name: triggerId
-      type: String
-      description: 'Auto-generated trigger ID. The ID is based on the properties that you
+                  For *PERCENTILE_DURATION metrics, one or both of these fields may
+                  be set, and also, the duration threshold value should be specified in the
+                  threshold_duration_ms member below.
 
-        define in the trigger config. For example, for an API trigger, the trigger
-
-        ID follows the format: api_trigger/TRIGGER_NAME
-
-        Where trigger config has properties with value {"Trigger name":TRIGGER_NAME}'
-    - name: triggerNumber
-      type: String
-      required: true
-      description: 'A number to uniquely identify each trigger config within the
-
-        integration on UI.'
-    - name: triggerType
-      type: String
-      description: 'Possible values:
-
-        CRON
-
-        API
-
-        SFDC_CHANNEL
-
-        CLOUD_PUBSUB_EXTERNAL
-
-        SFDC_CDC_CHANNEL
-
-        CLOUD_SCHEDULER
-
-        INTEGRATION_CONNECTOR_TRIGGER
-
-        PRIVATE_TRIGGER
-
-        CLOUD_PUBSUB
-
-        EVENTARC_TRIGGER'
-- name: updateTime
-  type: String
-  description: Auto-generated.
-  output: true
-- name: userLabel
-  type: String
-  description: 'A user-defined label that annotates an integration version. Typically, this
-
-    is only set when the integration version is created.'
+                  For *AVERAGE_DURATION metrics, these fields should not be set at all.
+                  A different member, threshold_duration_ms, must be set in the
+                  EventAlertConfig or the TaskAlertConfig.
+                properties:
+                  - name: absolute
+                    type: String
+                    description: Absolute value threshold.
+                  - name: percentage
+                    type: Integer
+                    description: Percentage threshold.
+        - name: cloudSchedulerConfig
+          type: NestedObject
+          description: Cloud Scheduler Trigger configuration
+          properties:
+            - name: cronTab
+              type: String
+              required: true
+              description: The cron tab of cloud scheduler trigger.
+            - name: errorMessage
+              type: String
+              description: |-
+                When the job was deleted from Pantheon UI, error_message will be populated
+                when Get/List integrations
+            - name: location
+              type: String
+              required: true
+              description: The location where associated cloud scheduler job will be created
+            - name: serviceAccountEmail
+              type: String
+              required: true
+              description: |-
+                Service account used by Cloud Scheduler to trigger the integration at
+                scheduled time
+        - name: description
+          type: String
+          description: |-
+            User-provided description intended to give additional business context
+            about the task.
+        - name: errorCatcherId
+          type: String
+          description: |-
+            Optional
+            Error catcher id of the error catch flow which will be executed when
+            execution error happens in the task
+        - name: inputVariables
+          type: NestedObject
+          description: Variables names mapped to api trigger.
+          properties:
+            - name: names
+              type: Array
+              description: List of variable names.
+              item_type:
+                type: String
+        - name: label
+          type: String
+          description: The user created label for a particular trigger.
+        - name: nextTasksExecutionPolicy
+          type: String
+          description: |-
+            Dictates how next tasks will be executed.
+            Possible values:
+            RUN_ALL_MATCH
+            RUN_FIRST_MATCH
+        - name: outputVariables
+          type: NestedObject
+          description: Variables names mapped to api trigger.
+          properties:
+            - name: names
+              type: Array
+              description: List of variable names.
+              item_type:
+                type: String
+        - name: position
+          type: NestedObject
+          description: Configuration detail of coordinate, it used for UI
+          properties:
+            - name: x
+              type: Integer
+              required: true
+              description: X axis of the coordinate
+            - name: y
+              type: Integer
+              required: true
+              description: Y axis of the coordinate
+        - name: properties
+          type: KeyValuePairs
+          description: |-
+            Configurable properties of the trigger,
+            not to be confused with integration parameters.
+            E.g. "name" is a property for API triggers
+            and "subscription" is a property for Pub/sub triggers.
+        - name: startTasks
+          type: Array
+          description: |-
+            Set of tasks numbers from where the integration execution is started by
+            this trigger. If this is empty, then integration is executed with default
+            start tasks. In the list of start tasks, none of two tasks can have direct
+            ancestor-descendant relationships (i.e. in a same integration execution
+            graph).
+          item_type:
+            type: NestedObject
+            properties:
+              - name: condition
+                type: String
+                description: Standard filter expression for this task to become an eligible next task.
+              - name: description
+                type: String
+                description: |-
+                  User-provided description intended to give additional business context
+                  about the task.
+              - name: displayName
+                type: String
+                description: User-provided label that is attached to this edge in the UI.
+              - name: taskConfigId
+                type: String
+                description: ID of the next task.
+              - name: taskId
+                type: String
+                description: Task number of the next task.
+        - name: trigger
+          type: String
+          description: |-
+            Name of the trigger. Example: "API Trigger", "Cloud Pub Sub
+            Trigger" When set will be sent out to monitoring dashabord for tracking
+            purpose.
+        - name: triggerId
+          type: String
+          description: |-
+            Auto-generated trigger ID. The ID is based on the properties that you
+            define in the trigger config. For example, for an API trigger, the trigger
+            ID follows the format: api_trigger/TRIGGER_NAME
+            Where trigger config has properties with value {"Trigger name":TRIGGER_NAME}
+        - name: triggerNumber
+          type: String
+          required: true
+          description: |-
+            A number to uniquely identify each trigger config within the
+            integration on UI.
+        - name: triggerType
+          type: String
+          description: |-
+            Possible values:
+            CRON
+            API
+            SFDC_CHANNEL
+            CLOUD_PUBSUB_EXTERNAL
+            SFDC_CDC_CHANNEL
+            CLOUD_SCHEDULER
+            INTEGRATION_CONNECTOR_TRIGGER
+            PRIVATE_TRIGGER
+            CLOUD_PUBSUB
+            EVENTARC_TRIGGER
+  - name: updateTime
+    type: String
+    description: Auto-generated.
+    output: true
+  - name: userLabel
+    type: String
+    description: |-
+      A user-defined label that annotates an integration version. Typically, this
+      is only set when the integration version is created.

--- a/mmv1/products/integrations/IntegrationVersionDeployment.yaml
+++ b/mmv1/products/integrations/IntegrationVersionDeployment.yaml
@@ -1,0 +1,98 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: IntegrationVersionDeployment
+description: |
+  A deployment resource for managing the published/deployed state of an Application Integration version.
+references:
+  guides:
+    Official Documentation: https://cloud.google.com/application-integration/docs/overview
+  api: https://cloud.google.com/application-integration/docs/reference/rest/v1/projects.locations.integrations.versions
+docs:
+base_url: projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}
+self_link: projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}
+create_url: projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}:publish
+delete_url: projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}:unpublish
+delete_verb: POST
+id_format: projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/integrations/{{integration}}/versions/{{version}}
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+immutable: true
+custom_code:
+  decoder: templates/terraform/decoders/integrations_version_deployment.go.tmpl
+  custom_import: templates/terraform/custom_import/self_link_as_name.tmpl
+samples:
+  - name: integrations_integration_version_deployment_basic
+    primary_resource_id: deployment_basic
+    steps:
+      - name: integrations_integration_version_deployment_basic
+        resource_id_vars:
+          integration_name: test-integration
+parameters:
+  - name: location
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      Location in which the integration version is deployed.
+  - name: integration
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The name of the integration.
+  - name: version
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The version ID of the integration to deploy/publish.
+properties:
+  - name: name
+    type: String
+    description: |
+      The full resource name of the integration version.
+    output: true
+  - name: state
+    type: String
+    description: |
+      The state of the integration version (e.g. ACTIVE).
+    output: true
+  - name: status
+    type: String
+    description: |
+      The status of the integration version.
+    output: true
+  - name: createTime
+    type: String
+    description: |
+      The time the integration version was created.
+    output: true
+  - name: updateTime
+    type: String
+    description: |
+      The time the integration version was last updated.
+    output: true
+  - name: lastModifierEmail
+    type: String
+    description: |
+      The last modifier's email address.
+    output: true

--- a/mmv1/products/integrations/IntegrationVersionDeployment.yaml
+++ b/mmv1/products/integrations/IntegrationVersionDeployment.yaml
@@ -35,7 +35,7 @@ timeouts:
 immutable: true
 custom_code:
   decoder: templates/terraform/decoders/integrations_version_deployment.go.tmpl
-  custom_import: templates/terraform/custom_import/self_link_as_name.tmpl
+  test_check_destroy: templates/terraform/custom_check_destroy/integrations_version_deployment.go.tmpl
 samples:
   - name: integrations_integration_version_deployment_basic
     primary_resource_id: deployment_basic

--- a/mmv1/products/integrations/IntegrationVersionDeployment.yaml
+++ b/mmv1/products/integrations/IntegrationVersionDeployment.yaml
@@ -43,6 +43,8 @@ samples:
       - name: integrations_integration_version_deployment_basic
         resource_id_vars:
           integration_name: test-integration
+        test_vars_overrides:
+          client: BootstrapIntegrationsClient(t, "us-east4")
 parameters:
   - name: location
     type: String

--- a/mmv1/templates/terraform/constants/integrations_json_diff_suppress.go.tmpl
+++ b/mmv1/templates/terraform/constants/integrations_json_diff_suppress.go.tmpl
@@ -1,22 +1,16 @@
 func integrationsJsonDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// Treat empty string and empty JSON object as equivalent
-	if (old == "" || old == "{}") && (new == "" || new == "{}") {
+	if old == new {
 		return true
 	}
-
 	if old == "" || new == "" {
-		return old == new
-	}
-
-	var oldJson, newJson interface{}
-
-	if err := json.Unmarshal([]byte(old), &oldJson); err != nil {
 		return false
 	}
-
-	if err := json.Unmarshal([]byte(new), &newJson); err != nil {
+	var oldObj, newObj interface{}
+	if err := json.Unmarshal([]byte(old), &oldObj); err != nil {
 		return false
 	}
-
-	return reflect.DeepEqual(oldJson, newJson)
+	if err := json.Unmarshal([]byte(new), &newObj); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(oldObj, newObj)
 }

--- a/mmv1/templates/terraform/constants/integrations_json_diff_suppress.go.tmpl
+++ b/mmv1/templates/terraform/constants/integrations_json_diff_suppress.go.tmpl
@@ -1,0 +1,22 @@
+func integrationsJsonDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// Treat empty string and empty JSON object as equivalent
+	if (old == "" || old == "{}") && (new == "" || new == "{}") {
+		return true
+	}
+
+	if old == "" || new == "" {
+		return old == new
+	}
+
+	var oldJson, newJson interface{}
+
+	if err := json.Unmarshal([]byte(old), &oldJson); err != nil {
+		return false
+	}
+
+	if err := json.Unmarshal([]byte(new), &newJson); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldJson, newJson)
+}

--- a/mmv1/templates/terraform/custom_check_destroy/integrations_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/integrations_version.go.tmpl
@@ -1,0 +1,25 @@
+config := acctest.GoogleProviderConfig(t)
+
+url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}IntegrationsBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/integrations/{{"{{"}}integration{{"}}"}}/versions/{{"{{"}}version{{"}}"}}")
+if err != nil {
+    return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+    billingProject = config.BillingProject
+}
+
+resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+    Config:    config,
+    Method:    "GET",
+    Project:   billingProject,
+    RawURL:    url,
+    UserAgent: config.UserAgent,
+})
+if err == nil && resp != nil {
+	if state, ok := resp["state"].(string); !ok || state != "ARCHIVED" {
+		return fmt.Errorf("IntegrationsIntegrationVersion still exists at %s with state %v", url, resp["state"])
+	}
+}

--- a/mmv1/templates/terraform/custom_check_destroy/integrations_version_deployment.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/integrations_version_deployment.go.tmpl
@@ -1,0 +1,25 @@
+config := acctest.GoogleProviderConfig(t)
+
+url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}IntegrationsBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/integrations/{{"{{"}}integration{{"}}"}}/versions/{{"{{"}}version{{"}}"}}")
+if err != nil {
+    return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+    billingProject = config.BillingProject
+}
+
+resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+    Config:    config,
+    Method:    "GET",
+    Project:   billingProject,
+    RawURL:    url,
+    UserAgent: config.UserAgent,
+})
+if err == nil && resp != nil {
+	if state, ok := resp["state"].(string); ok && state == "ACTIVE" {
+		return fmt.Errorf("IntegrationsIntegrationVersionDeployment still active at %s with state %s", url, state)
+	}
+}

--- a/mmv1/templates/terraform/custom_expand/integrations_version_parameters.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/integrations_version_parameters.go.tmpl
@@ -1,0 +1,42 @@
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (map[string]interface{}, error) {
+  if v == nil {
+    return map[string]interface{}{}, nil
+  }
+  m := make(map[string]interface{})
+  for _, raw := range v.(*schema.Set).List() {
+    original := raw.(map[string]interface{})
+    transformed := make(map[string]interface{})
+      {{- range $prop := $.NestedProperties }}
+        {{- if not (or (eq $prop.Name $prop.KeyName) $prop.ClientSide) }}
+
+    transformed{{$prop.TitlelizeProperty}}, err := expand{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}({{if $prop.WriteOnly }}tpgresource.GetRawConfigAttributeAsString(d.(*schema.ResourceData), "{{ join $prop.Lineage ".0." }}"){{ else }}original["{{ underscore $prop.Name }}"]{{ end }}, d, config)
+    if err != nil {
+      return nil, err
+          {{- if or ($prop.SendEmptyValue) (and $prop.TGCSendEmptyValue $.ResourceMetadata.ProductMetadata.IsTgcCompiler) }}
+    } else {
+      transformed["{{$prop.ApiName}}"] = transformed{{$prop.TitlelizeProperty}}
+          {{- else }}
+    } else if val := reflect.ValueOf(transformed{{$prop.TitlelizeProperty}}); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+      transformed["{{$prop.ApiName}}"] = transformed{{$prop.TitlelizeProperty}}
+          {{- end }}
+    }
+        {{- end }}
+      {{ end }}
+
+    transformed{{ camelize $.KeyName "upper" }}, err := {{ $.KeyExpander }}(original["{{ underscore $.KeyName }}"], d, config)
+    if err != nil {
+      return nil, err
+    }
+    transformed["{{ $.KeyName }}"] = transformed{{ camelize $.KeyName "upper" }}
+    m[transformed{{ camelize $.KeyName "upper" }}] = transformed
+  }
+  return m, nil
+}
+
+{{ if $.NestedProperties }}
+  {{- range $prop := $.NestedProperties }}
+    {{- if not (and (hasPrefix $prop.Type "KeyValue") $prop.IgnoreWrite) }}
+      {{- template "expandPropertyMethod" $prop -}}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/mmv1/templates/terraform/decoders/integrations_version.go.tmpl
+++ b/mmv1/templates/terraform/decoders/integrations_version.go.tmpl
@@ -1,8 +1,26 @@
+if state, ok := res["state"].(string); ok && state == "ARCHIVED" {
+	return nil, nil
+}
+
 if name, ok := res["name"].(string); ok {
 	parts := strings.Split(name, "/versions/")
 	if len(parts) == 2 {
 		res["version"] = parts[1]
 	}
+}
+
+// Filter out server-injected transient parameters so they don't cause non-empty diffs
+if rawParams, ok := res["integrationParameters"].([]interface{}); ok {
+	var userParams []interface{}
+	for _, p := range rawParams {
+		if pMap, ok := p.(map[string]interface{}); ok {
+			if isTransient, ok := pMap["isTransient"].(bool); ok && isTransient {
+				continue
+			}
+			userParams = append(userParams, pMap)
+		}
+	}
+	res["integrationParameters"] = userParams
 }
 
 return res, nil

--- a/mmv1/templates/terraform/decoders/integrations_version.go.tmpl
+++ b/mmv1/templates/terraform/decoders/integrations_version.go.tmpl
@@ -1,0 +1,8 @@
+if name, ok := res["name"].(string); ok {
+	parts := strings.Split(name, "/versions/")
+	if len(parts) == 2 {
+		res["version"] = parts[1]
+	}
+}
+
+return res, nil

--- a/mmv1/templates/terraform/decoders/integrations_version_deployment.go.tmpl
+++ b/mmv1/templates/terraform/decoders/integrations_version_deployment.go.tmpl
@@ -1,0 +1,5 @@
+if v := res["state"]; v != "ACTIVE" {
+	return nil, nil
+}
+
+return res, nil

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_basic.tf.tmpl
@@ -1,5 +1,10 @@
+resource "google_integrations_client" "client" {
+  location = "us-west1"
+}
+
 resource "google_integrations_integration_version" "{{$.PrimaryResourceId}}" {
   location = "us-west1"
   integration = "{{index $.ResourceIdVars "integration_name"}}"
   description = "Integration version created via terraform"
+  depends_on = [google_integrations_client.client]
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_basic.tf.tmpl
@@ -1,10 +1,5 @@
-resource "google_integrations_client" "client" {
-  location = "us-west1"
-}
-
 resource "google_integrations_integration_version" "{{$.PrimaryResourceId}}" {
-  location = "us-west1"
+  location = "us-east4"
   integration = "{{index $.ResourceIdVars "integration_name"}}"
   description = "Integration version created via terraform"
-  depends_on = [google_integrations_client.client]
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_basic.tf.tmpl
@@ -2,4 +2,6 @@ resource "google_integrations_integration_version" "{{$.PrimaryResourceId}}" {
   location = "us-east4"
   integration = "{{index $.ResourceIdVars "integration_name"}}"
   description = "Integration version created via terraform"
+  new_integration = true
+  create_sample_integrations = false
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_basic.tf.tmpl
@@ -1,11 +1,5 @@
-resource "google_integrations_client" "client" {
-  location = "us-west1"
-}
-
 resource "google_integrations_integration_version" "{{$.PrimaryResourceId}}" {
   location = "us-west1"
   integration = "{{index $.ResourceIdVars "integration_name"}}"
   description = "Integration version created via terraform"
-  origin = "UI"
-  depends_on = [google_integrations_client.client]
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_basic.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_integrations_client" "client" {
+  location = "us-west1"
+}
+
+resource "google_integrations_integration_version" "{{$.PrimaryResourceId}}" {
+  location = "us-west1"
+  integration = "{{index $.ResourceIdVars "integration_name"}}"
+  description = "Integration version created via terraform"
+  origin = "UI"
+  depends_on = [google_integrations_client.client]
+}

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_cmek.tf.tmpl
@@ -1,0 +1,6 @@
+resource "google_integrations_integration_version" "{{$.PrimaryResourceId}}" {
+  location = "us-east4"
+  integration = "{{index $.ResourceIdVars "integration_name"}}"
+  description = "Integration version with CMEK"
+  cloud_kms_key = "{{index $.ResourceIdVars "kms_key_name"}}"
+}

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_cmek.tf.tmpl
@@ -1,0 +1,6 @@
+resource "google_integrations_integration_version" "version_cmek" {
+  location = "us-east4"
+  integration = "%{integration_name}"
+  description = "CMEK integration version"
+  cloud_kms_key = "%{kms_key_name}"
+}

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_cmek.tf.tmpl
@@ -1,6 +1,0 @@
-resource "google_integrations_integration_version" "version_cmek" {
-  location = "us-east4"
-  integration = "%{integration_name}"
-  description = "CMEK integration version"
-  cloud_kms_key = "%{kms_key_name}"
-}

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_deployment_basic.tf.tmpl
@@ -1,9 +1,5 @@
-resource "google_integrations_client" "client" {
-  location = "us-west1"
-}
-
 resource "google_integrations_integration_version" "version" {
-  location = "us-west1"
+  location = "us-east4"
   integration = "%{integration_name}"
   description = "Integration version created via terraform"
 
@@ -44,12 +40,10 @@ resource "google_integrations_integration_version" "version" {
       }
     }
   }
-
-  depends_on = [google_integrations_client.client]
 }
 
 resource "google_integrations_integration_version_deployment" "deployment_basic" {
-  location = "us-west1"
+  location = "us-east4"
   integration = "%{integration_name}"
   version = google_integrations_integration_version.version.version
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_deployment_basic.tf.tmpl
@@ -1,3 +1,7 @@
+resource "google_integrations_client" "client" {
+  location = "us-west1"
+}
+
 resource "google_integrations_integration_version" "version" {
   location = "us-west1"
   integration = "%{integration_name}"
@@ -40,6 +44,8 @@ resource "google_integrations_integration_version" "version" {
       }
     }
   }
+
+  depends_on = [google_integrations_client.client]
 }
 
 resource "google_integrations_integration_version_deployment" "deployment_basic" {

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_deployment_basic.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_integrations_client" "client" {
+  location = "us-west1"
+}
+
+resource "google_integrations_integration_version" "version" {
+  location = "us-west1"
+  integration = "%{integration_name}"
+  description = "Integration version created via terraform"
+  depends_on = [google_integrations_client.client]
+}
+
+resource "google_integrations_integration_version_deployment" "deployment_basic" {
+  location = "us-west1"
+  integration = "%{integration_name}"
+  version = google_integrations_integration_version.version.version
+}

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_deployment_basic.tf.tmpl
@@ -1,12 +1,45 @@
-resource "google_integrations_client" "client" {
-  location = "us-west1"
-}
-
 resource "google_integrations_integration_version" "version" {
   location = "us-west1"
   integration = "%{integration_name}"
   description = "Integration version created via terraform"
-  depends_on = [google_integrations_client.client]
+
+  trigger_configs {
+    label = "test_trigger"
+    trigger_type = "API"
+    trigger_number = "1"
+    trigger_id = "api_trigger/test_trigger"
+    properties = {
+      "Trigger name" = "test_trigger"
+    }
+    start_tasks {
+      task_id = "1"
+    }
+  }
+
+  task_configs {
+    task = "GenericRestV2Task"
+    task_id = "1"
+    external_task_type = "NORMAL_TASK"
+    task_execution_strategy = "WHEN_ALL_SUCCEED"
+    parameters {
+      key = "url"
+      masked = false
+      value {
+        boolean_value = false
+        double_value = 0
+        string_value = "https://example.com"
+      }
+    }
+    parameters {
+      key = "httpMethod"
+      masked = false
+      value {
+        boolean_value = false
+        double_value = 0
+        string_value = "GET"
+      }
+    }
+  }
 }
 
 resource "google_integrations_integration_version_deployment" "deployment_basic" {

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
@@ -177,6 +177,7 @@ resource "google_integrations_integration_version" "version_full" {
     input_output_type = "IN"
     searchable = true
     masked = false
+    contains_large_data = false
     description = "string parameter"
   }
 
@@ -306,6 +307,7 @@ resource "google_integrations_integration_version" "version_full" {
       input_output_type = "IN"
       searchable = true
       masked = false
+      contains_large_data = false
       description = "config param description"
     }
   }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
@@ -2,25 +2,46 @@ resource "google_integrations_integration_version" "version_full" {
   location = "us-west1"
   integration = "%{integration_name}"
   description = "%{description}"
+  user_label = "v1.0.0"
+  database_persistence_policy = "DATABASE_PERSISTENCE_DISABLED"
+  enable_variable_masking = true
+
+  cloud_logging_details {
+    cloud_logging_severity = "INFO"
+    enable_cloud_logging = true
+  }
 
   trigger_configs {
     label = "test_trigger"
     trigger_type = "API"
     trigger_number = "1"
     trigger_id = "api_trigger/test_trigger"
+    description = "API trigger description"
     properties = {
       "Trigger name" = "test_trigger"
     }
+    position {
+      x = "50"
+      y = "50"
+    }
     start_tasks {
       task_id = "1"
+      display_name = "start"
     }
   }
 
   task_configs {
     task = "GenericRestV2Task"
     task_id = "1"
+    description = "Task 1 description"
+    display_name = "REST Caller Task"
     external_task_type = "NORMAL_TASK"
     task_execution_strategy = "WHEN_ALL_SUCCEED"
+    json_validation_option = "SKIP"
+    position {
+      x = "100"
+      y = "100"
+    }
     parameters {
       key = "url"
       masked = false
@@ -39,6 +60,65 @@ resource "google_integrations_integration_version" "version_full" {
         string_value = "GET"
       }
     }
+    conditional_failure_policies {
+      failure_policies {
+        condition = "true"
+        interval_time = "1970-01-01T00:00:10Z"
+        max_retries = 3
+        retry_strategy = "FIXED_INTERVAL"
+      }
+    }
+    next_tasks {
+      task_id = "2"
+      condition = "true"
+      display_name = "Next Task"
+    }
+    next_tasks_execution_policy = "RUN_ALL_MATCH"
+  }
+
+  task_configs {
+    task = "GenericRestV2Task"
+    task_id = "2"
+    description = "Task 2 description"
+    display_name = "REST Caller Task 2"
+    external_task_type = "NORMAL_TASK"
+    task_execution_strategy = "WHEN_ALL_SUCCEED"
+    position {
+      x = "200"
+      y = "200"
+    }
+    parameters {
+      key = "url"
+      masked = false
+      value {
+        boolean_value = false
+        double_value = 0
+        string_value = "https://example.com/api"
+      }
+    }
+    parameters {
+      key = "httpMethod"
+      masked = false
+      value {
+        boolean_value = false
+        double_value = 0
+        string_value = "POST"
+      }
+    }
+  }
+
+  error_catcher_configs {
+    error_catcher_id = "ERROR_CATCHER_1"
+    error_catcher_number = "1"
+    label = "Catch Flow"
+    description = "Error catcher description"
+    position {
+      x = 100
+      y = 100
+    }
+    start_error_tasks {
+      task_id = "2"
+    }
   }
 
   integration_parameters {
@@ -49,5 +129,47 @@ resource "google_integrations_integration_version" "version_full" {
     }
     display_name = "param1"
     input_output_type = "IN"
+    searchable = true
+    masked = false
+    description = "string parameter"
+  }
+
+  integration_parameters {
+    key = "param2"
+    data_type = "INT_VALUE"
+    default_value {
+      int_value = "10"
+    }
+    display_name = "param2"
+    input_output_type = "IN"
+    searchable = true
+    masked = false
+    description = "int parameter"
+  }
+
+  integration_parameters {
+    key = "param3"
+    data_type = "BOOLEAN_VALUE"
+    default_value {
+      boolean_value = true
+    }
+    display_name = "param3"
+    input_output_type = "IN"
+    searchable = true
+    masked = false
+    description = "bool parameter"
+  }
+
+  integration_parameters {
+    key = "param4"
+    data_type = "DOUBLE_VALUE"
+    default_value {
+      double_value = 3.14
+    }
+    display_name = "param4"
+    input_output_type = "IN"
+    searchable = true
+    masked = false
+    description = "double parameter"
   }
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
@@ -57,7 +57,37 @@ resource "google_integrations_integration_version" "version_full" {
       threshold_type = "EXPECTED_MAX"
       threshold_value {
         absolute = "1"
+        percentage = 50
       }
+    }
+  }
+
+  trigger_configs {
+    label = "schedule_trigger"
+    trigger_type = "CRON"
+    trigger_number = "2"
+    trigger_id = "cron_trigger/schedule_trigger/0+0+*+*+*"
+    description = "Cloud scheduler trigger description"
+    trigger = "Cloud Scheduler Trigger"
+    properties = {
+      "Timer Name" = "schedule_trigger"
+      "Scheduled Time spec" = "0 0 * * *"
+    }
+    position {
+      x = "150"
+      y = "150"
+    }
+    start_tasks {
+      task_id = "1"
+      condition = "true"
+      description = "Start task from scheduler"
+      display_name = "start"
+      task_config_id = "1"
+    }
+    cloud_scheduler_config {
+      cron_tab = "0 0 * * *"
+      location = "us-east4"
+      service_account_email = google_service_account.test_sa.email
     }
   }
 
@@ -309,6 +339,137 @@ resource "google_integrations_integration_version" "version_full" {
       masked = false
       contains_large_data = false
       description = "config param description"
+      is_transient = false
+      producer = "1_1"
+    }
+  }
+
+  integration_config_parameters {
+    parameter {
+      key = "` + "`CONFIG_param2`" + `"
+      data_type = "INT_VALUE"
+      default_value {
+        int_value = "10"
+      }
+      display_name = "` + "`CONFIG_param2`" + `"
+      input_output_type = "IN"
+      searchable = true
+      masked = false
+      description = "int config param"
+    }
+  }
+
+  integration_config_parameters {
+    parameter {
+      key = "` + "`CONFIG_param3`" + `"
+      data_type = "BOOLEAN_VALUE"
+      default_value {
+        boolean_value = true
+      }
+      display_name = "` + "`CONFIG_param3`" + `"
+      input_output_type = "IN"
+      searchable = true
+      masked = false
+      description = "bool config param"
+    }
+  }
+
+  integration_config_parameters {
+    parameter {
+      key = "` + "`CONFIG_param4`" + `"
+      data_type = "DOUBLE_VALUE"
+      default_value {
+        double_value = 3.14
+      }
+      display_name = "` + "`CONFIG_param4`" + `"
+      input_output_type = "IN"
+      searchable = true
+      masked = false
+      description = "double config param"
+    }
+  }
+
+  integration_config_parameters {
+    parameter {
+      key = "` + "`CONFIG_param5`" + `"
+      data_type = "STRING_ARRAY"
+      default_value {
+        string_array {
+          string_values = ["val1", "val2"]
+        }
+      }
+      display_name = "` + "`CONFIG_param5`" + `"
+      input_output_type = "IN"
+      searchable = true
+      masked = false
+      description = "string array config param"
+    }
+  }
+
+  integration_config_parameters {
+    parameter {
+      key = "` + "`CONFIG_param6`" + `"
+      data_type = "INT_ARRAY"
+      default_value {
+        int_array {
+          int_values = ["1", "2"]
+        }
+      }
+      display_name = "` + "`CONFIG_param6`" + `"
+      input_output_type = "IN"
+      searchable = true
+      masked = false
+      description = "int array config param"
+    }
+  }
+
+  integration_config_parameters {
+    parameter {
+      key = "` + "`CONFIG_param7`" + `"
+      data_type = "BOOLEAN_ARRAY"
+      default_value {
+        boolean_array {
+          boolean_values = [true, false]
+        }
+      }
+      display_name = "` + "`CONFIG_param7`" + `"
+      input_output_type = "IN"
+      searchable = true
+      masked = false
+      description = "bool array config param"
+    }
+  }
+
+  integration_config_parameters {
+    parameter {
+      key = "` + "`CONFIG_param8`" + `"
+      data_type = "DOUBLE_ARRAY"
+      default_value {
+        double_array {
+          double_values = [1.1, 2.2]
+        }
+      }
+      display_name = "` + "`CONFIG_param8`" + `"
+      input_output_type = "IN"
+      searchable = true
+      masked = false
+      description = "double array config param"
+    }
+  }
+
+  integration_config_parameters {
+    parameter {
+      key = "` + "`CONFIG_param9`" + `"
+      data_type = "JSON_VALUE"
+      default_value {
+        json_value = jsonencode({ "key" = "val" })
+      }
+      display_name = "` + "`CONFIG_param9`" + `"
+      input_output_type = "IN"
+      searchable = true
+      masked = false
+      description = "json config param"
+      json_schema = jsonencode({ "$schema" = "http://json-schema.org/draft-04/schema#" })
     }
   }
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
@@ -1,3 +1,7 @@
+resource "google_integrations_client" "client" {
+  location = "us-west1"
+}
+
 resource "google_integrations_integration_version" "version_full" {
   location = "us-west1"
   integration = "%{integration_name}"
@@ -172,4 +176,6 @@ resource "google_integrations_integration_version" "version_full" {
     masked = false
     description = "double parameter"
   }
+
+  depends_on = [google_integrations_client.client]
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
@@ -30,7 +30,7 @@ resource "google_integrations_integration_version" "version_full" {
       names = ["param1"]
     }
     output_variables {
-      names = ["param1"]
+      names = ["param2"]
     }
     properties = {
       "Trigger name" = "test_trigger"
@@ -52,9 +52,9 @@ resource "google_integrations_integration_version" "version_full" {
       disable_alert = false
       display_name = "test-alert"
       duration_threshold = "3600s"
-      metric_type = "ERROR_RATE"
+      metric_type = "EVENT_ERROR_RATE"
       only_final_attempt = false
-      threshold_type = "ABSOLUTE"
+      threshold_type = "EXPECTED_MAX"
       threshold_value {
         absolute = "1"
       }
@@ -91,62 +91,6 @@ resource "google_integrations_integration_version" "version_full" {
         string_value = "GET"
       }
     }
-    parameters {
-      key = "stringArrayParam"
-      masked = false
-      value {
-        string_array {
-          string_values = ["val1", "val2"]
-        }
-      }
-    }
-    parameters {
-      key = "intArrayParam"
-      masked = false
-      value {
-        int_array {
-          int_values = ["1", "2"]
-        }
-      }
-    }
-    parameters {
-      key = "boolArrayParam"
-      masked = false
-      value {
-        boolean_array {
-          boolean_values = [true, false]
-        }
-      }
-    }
-    parameters {
-      key = "doubleArrayParam"
-      masked = false
-      value {
-        double_array {
-          double_values = [1.1, 2.2]
-        }
-      }
-    }
-    parameters {
-      key = "jsonParam"
-      masked = false
-      value {
-        json_value = "{\"key\": \"val\"}"
-      }
-    }
-    parameters {
-      key = "intParam"
-      masked = false
-      value {
-        int_value = "42"
-      }
-    }
-    failure_policy {
-      condition = "true"
-      interval_time = "1970-01-01T00:00:10Z"
-      max_retries = 3
-      retry_strategy = "FIXED_INTERVAL"
-    }
     conditional_failure_policies {
       default_failure_policy {
         condition = "true"
@@ -160,15 +104,6 @@ resource "google_integrations_integration_version" "version_full" {
         max_retries = 3
         retry_strategy = "FIXED_INTERVAL"
       }
-    }
-    success_policy {
-      final_state = "SUCCEEDED"
-    }
-    synchronous_call_failure_policy {
-      condition = "true"
-      interval_time = "1970-01-01T00:00:10Z"
-      max_retries = 3
-      retry_strategy = "FIXED_INTERVAL"
     }
     next_tasks {
       task_id = "2"
@@ -249,7 +184,7 @@ resource "google_integrations_integration_version" "version_full" {
       int_value = "10"
     }
     display_name = "param2"
-    input_output_type = "IN"
+    input_output_type = "OUT"
     searchable = true
     masked = false
     description = "int parameter"
@@ -341,37 +276,5 @@ resource "google_integrations_integration_version" "version_full" {
     searchable = true
     masked = false
     description = "double array parameter"
-  }
-
-  integration_parameters {
-    key = "param9"
-    data_type = "JSON_VALUE"
-    default_value {
-      json_value = "{\"key\": \"val\"}"
-    }
-    display_name = "param9"
-    input_output_type = "IN"
-    searchable = true
-    masked = false
-    description = "json parameter"
-    json_schema = "{\"$schema\": \"http://json-schema.org/draft-04/schema#\"}"
-  }
-
-  integration_config_parameters {
-    parameter {
-      key = "config_param1"
-      data_type = "STRING_VALUE"
-      default_value {
-        string_value = "default_config_val"
-      }
-      display_name = "config_param1"
-      input_output_type = "IN"
-      searchable = true
-      masked = false
-      description = "config param description"
-    }
-    value {
-      string_value = "val1"
-    }
   }
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
@@ -1,9 +1,5 @@
-resource "google_integrations_client" "client" {
-  location = "us-west1"
-}
-
 resource "google_integrations_integration_version" "version_full" {
-  location = "us-west1"
+  location = "us-east4"
   integration = "%{integration_name}"
   description = "%{description}"
   user_label = "v1.0.0"
@@ -176,6 +172,4 @@ resource "google_integrations_integration_version" "version_full" {
     masked = false
     description = "double parameter"
   }
-
-  depends_on = [google_integrations_client.client]
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
@@ -1,3 +1,8 @@
+resource "google_service_account" "test_sa" {
+  account_id   = "tf-test-sa%{random_suffix}"
+  display_name = "Test Service Account"
+}
+
 resource "google_integrations_integration_version" "version_full" {
   location = "us-east4"
   integration = "%{integration_name}"
@@ -5,6 +10,7 @@ resource "google_integrations_integration_version" "version_full" {
   user_label = "v1.0.0"
   database_persistence_policy = "DATABASE_PERSISTENCE_DISABLED"
   enable_variable_masking = true
+  run_as_service_account = google_service_account.test_sa.email
 
   cloud_logging_details {
     cloud_logging_severity = "INFO"
@@ -17,6 +23,15 @@ resource "google_integrations_integration_version" "version_full" {
     trigger_number = "1"
     trigger_id = "api_trigger/test_trigger"
     description = "API trigger description"
+    trigger = "API Trigger"
+    error_catcher_id = "ERROR_CATCHER_1"
+    next_tasks_execution_policy = "RUN_ALL_MATCH"
+    input_variables {
+      names = ["param1"]
+    }
+    output_variables {
+      names = ["param1"]
+    }
     properties = {
       "Trigger name" = "test_trigger"
     }
@@ -26,7 +41,23 @@ resource "google_integrations_integration_version" "version_full" {
     }
     start_tasks {
       task_id = "1"
+      condition = "true"
+      description = "Start task description"
       display_name = "start"
+      task_config_id = "1"
+    }
+    alert_config {
+      aggregation_period = "3600s"
+      alert_threshold = 1
+      disable_alert = false
+      display_name = "test-alert"
+      duration_threshold = "3600s"
+      metric_type = "ERROR_RATE"
+      only_final_attempt = false
+      threshold_type = "ABSOLUTE"
+      threshold_value {
+        absolute = "1"
+      }
     }
   }
 
@@ -60,7 +91,69 @@ resource "google_integrations_integration_version" "version_full" {
         string_value = "GET"
       }
     }
+    parameters {
+      key = "stringArrayParam"
+      masked = false
+      value {
+        string_array {
+          string_values = ["val1", "val2"]
+        }
+      }
+    }
+    parameters {
+      key = "intArrayParam"
+      masked = false
+      value {
+        int_array {
+          int_values = ["1", "2"]
+        }
+      }
+    }
+    parameters {
+      key = "boolArrayParam"
+      masked = false
+      value {
+        boolean_array {
+          boolean_values = [true, false]
+        }
+      }
+    }
+    parameters {
+      key = "doubleArrayParam"
+      masked = false
+      value {
+        double_array {
+          double_values = [1.1, 2.2]
+        }
+      }
+    }
+    parameters {
+      key = "jsonParam"
+      masked = false
+      value {
+        json_value = "{\"key\": \"val\"}"
+      }
+    }
+    parameters {
+      key = "intParam"
+      masked = false
+      value {
+        int_value = "42"
+      }
+    }
+    failure_policy {
+      condition = "true"
+      interval_time = "1970-01-01T00:00:10Z"
+      max_retries = 3
+      retry_strategy = "FIXED_INTERVAL"
+    }
     conditional_failure_policies {
+      default_failure_policy {
+        condition = "true"
+        interval_time = "1970-01-01T00:00:10Z"
+        max_retries = 3
+        retry_strategy = "FIXED_INTERVAL"
+      }
       failure_policies {
         condition = "true"
         interval_time = "1970-01-01T00:00:10Z"
@@ -68,10 +161,21 @@ resource "google_integrations_integration_version" "version_full" {
         retry_strategy = "FIXED_INTERVAL"
       }
     }
+    success_policy {
+      final_state = "SUCCEEDED"
+    }
+    synchronous_call_failure_policy {
+      condition = "true"
+      interval_time = "1970-01-01T00:00:10Z"
+      max_retries = 3
+      retry_strategy = "FIXED_INTERVAL"
+    }
     next_tasks {
       task_id = "2"
       condition = "true"
       display_name = "Next Task"
+      description = "Next task description"
+      task_config_id = "2"
     }
     next_tasks_execution_policy = "RUN_ALL_MATCH"
   }
@@ -118,6 +222,10 @@ resource "google_integrations_integration_version" "version_full" {
     }
     start_error_tasks {
       task_id = "2"
+      condition = "true"
+      description = "Start error task description"
+      display_name = "Start Error Task"
+      task_config_id = "2"
     }
   }
 
@@ -171,5 +279,99 @@ resource "google_integrations_integration_version" "version_full" {
     searchable = true
     masked = false
     description = "double parameter"
+  }
+
+  integration_parameters {
+    key = "param5"
+    data_type = "STRING_ARRAY"
+    default_value {
+      string_array {
+        string_values = ["val1", "val2"]
+      }
+    }
+    display_name = "param5"
+    input_output_type = "IN"
+    searchable = true
+    masked = false
+    description = "string array parameter"
+    is_transient = false
+    producer = "1_1"
+  }
+
+  integration_parameters {
+    key = "param6"
+    data_type = "INT_ARRAY"
+    default_value {
+      int_array {
+        int_values = ["1", "2"]
+      }
+    }
+    display_name = "param6"
+    input_output_type = "IN"
+    searchable = true
+    masked = false
+    description = "int array parameter"
+  }
+
+  integration_parameters {
+    key = "param7"
+    data_type = "BOOLEAN_ARRAY"
+    default_value {
+      boolean_array {
+        boolean_values = [true, false]
+      }
+    }
+    display_name = "param7"
+    input_output_type = "IN"
+    searchable = true
+    masked = false
+    description = "bool array parameter"
+  }
+
+  integration_parameters {
+    key = "param8"
+    data_type = "DOUBLE_ARRAY"
+    default_value {
+      double_array {
+        double_values = [1.1, 2.2]
+      }
+    }
+    display_name = "param8"
+    input_output_type = "IN"
+    searchable = true
+    masked = false
+    description = "double array parameter"
+  }
+
+  integration_parameters {
+    key = "param9"
+    data_type = "JSON_VALUE"
+    default_value {
+      json_value = "{\"key\": \"val\"}"
+    }
+    display_name = "param9"
+    input_output_type = "IN"
+    searchable = true
+    masked = false
+    description = "json parameter"
+    json_schema = "{\"$schema\": \"http://json-schema.org/draft-04/schema#\"}"
+  }
+
+  integration_config_parameters {
+    parameter {
+      key = "config_param1"
+      data_type = "STRING_VALUE"
+      default_value {
+        string_value = "default_config_val"
+      }
+      display_name = "config_param1"
+      input_output_type = "IN"
+      searchable = true
+      masked = false
+      description = "config param description"
+    }
+    value {
+      string_value = "val1"
+    }
   }
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
@@ -1,0 +1,40 @@
+resource "google_integrations_client" "client" {
+  location = "us-west1"
+}
+
+resource "google_integrations_integration_version" "version_full" {
+  location = "us-west1"
+  integration = "%{integration_name}"
+  description = "%{description}"
+  database_persistence_policy = "DATABASE_PERSISTENCE_POLICY_UNSPECIFIED"
+
+  trigger_configs {
+    label = "api_trigger"
+    trigger_type = "API"
+    trigger_number = "1"
+    trigger_id = "api_trigger/test_trigger"
+  }
+
+  task_configs {
+    task = "GenericRestEndpointTask"
+    task_id = "1"
+    parameters {
+      key = "endpointUrl"
+      value {
+        string_value = "https://example.com"
+      }
+    }
+  }
+
+  integration_parameters {
+    key = "param1"
+    data_type = "STRING_VALUE"
+    default_value {
+      string_value = "default_val"
+    }
+    display_name = "param1"
+    input_output_type = "IN"
+  }
+
+  depends_on = [google_integrations_client.client]
+}

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
@@ -1,27 +1,42 @@
-resource "google_integrations_client" "client" {
-  location = "us-west1"
-}
-
 resource "google_integrations_integration_version" "version_full" {
   location = "us-west1"
   integration = "%{integration_name}"
   description = "%{description}"
-  database_persistence_policy = "DATABASE_PERSISTENCE_POLICY_UNSPECIFIED"
 
   trigger_configs {
-    label = "api_trigger"
+    label = "test_trigger"
     trigger_type = "API"
     trigger_number = "1"
     trigger_id = "api_trigger/test_trigger"
+    properties = {
+      "Trigger name" = "test_trigger"
+    }
+    start_tasks {
+      task_id = "1"
+    }
   }
 
   task_configs {
-    task = "GenericRestEndpointTask"
+    task = "GenericRestV2Task"
     task_id = "1"
+    external_task_type = "NORMAL_TASK"
+    task_execution_strategy = "WHEN_ALL_SUCCEED"
     parameters {
-      key = "endpointUrl"
+      key = "url"
+      masked = false
       value {
+        boolean_value = false
+        double_value = 0
         string_value = "https://example.com"
+      }
+    }
+    parameters {
+      key = "httpMethod"
+      masked = false
+      value {
+        boolean_value = false
+        double_value = 0
+        string_value = "GET"
       }
     }
   }
@@ -35,6 +50,4 @@ resource "google_integrations_integration_version" "version_full" {
     display_name = "param1"
     input_output_type = "IN"
   }
-
-  depends_on = [google_integrations_client.client]
 }

--- a/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/integrations/integrations_integration_version_full.tf.tmpl
@@ -91,6 +91,9 @@ resource "google_integrations_integration_version" "version_full" {
         string_value = "GET"
       }
     }
+    success_policy {
+      final_state = "SUCCEEDED"
+    }
     conditional_failure_policies {
       default_failure_policy {
         condition = "true"
@@ -276,5 +279,34 @@ resource "google_integrations_integration_version" "version_full" {
     searchable = true
     masked = false
     description = "double array parameter"
+  }
+
+  integration_parameters {
+    key = "param9"
+    data_type = "JSON_VALUE"
+    default_value {
+      json_value = jsonencode({ "key" = "val" })
+    }
+    display_name = "param9"
+    input_output_type = "IN"
+    searchable = true
+    masked = false
+    description = "json parameter"
+    json_schema = jsonencode({ "$schema" = "http://json-schema.org/draft-04/schema#" })
+  }
+
+  integration_config_parameters {
+    parameter {
+      key = "` + "`CONFIG_param1`" + `"
+      data_type = "STRING_VALUE"
+      default_value {
+        string_value = "default_config_val"
+      }
+      display_name = "` + "`CONFIG_param1`" + `"
+      input_output_type = "IN"
+      searchable = true
+      masked = false
+      description = "config param description"
+    }
   }
 }

--- a/mmv1/third_party/terraform/services/integrations/resource_integrations_auth_config_test.go
+++ b/mmv1/third_party/terraform/services/integrations/resource_integrations_auth_config_test.go
@@ -48,10 +48,11 @@ func BootstrapIntegrationsClient(t *testing.T, locationID string) BootstrapClien
 			t.Fatalf("Error reading client from response")
 		}
 
-		// A client is GMEK if it does not have a CMEK cloudKmsConfig configured.
-		shouldDeprovision := false
-		if kmsVal, ok := client["cloudKmsConfig"]; ok && kmsVal != nil {
-			shouldDeprovision = true
+		shouldDeprovision := true
+		if isGmekVal, ok := client["isGmek"]; ok {
+			if isGmek, ok := isGmekVal.(bool); ok && isGmek {
+				shouldDeprovision = false
+			}
 		}
 
 		if shouldDeprovision {

--- a/mmv1/third_party/terraform/services/integrations/resource_integrations_auth_config_test.go
+++ b/mmv1/third_party/terraform/services/integrations/resource_integrations_auth_config_test.go
@@ -48,11 +48,10 @@ func BootstrapIntegrationsClient(t *testing.T, locationID string) BootstrapClien
 			t.Fatalf("Error reading client from response")
 		}
 
-		shouldDeprovision := true
-		if isGmekVal, ok := client["isGmek"]; ok {
-			if isGmek, ok := isGmekVal.(bool); ok {
-				shouldDeprovision = !isGmek
-			}
+		// A client is GMEK if it does not have a CMEK cloudKmsConfig configured.
+		shouldDeprovision := false
+		if kmsVal, ok := client["cloudKmsConfig"]; ok && kmsVal != nil {
+			shouldDeprovision = true
 		}
 
 		if shouldDeprovision {
@@ -66,6 +65,12 @@ func BootstrapIntegrationsClient(t *testing.T, locationID string) BootstrapClien
 			})
 			if err != nil {
 				t.Fatalf("Unable to deprovision client: %s", err)
+			}
+		} else {
+			return BootstrapClient{
+				ProjectID: projectID,
+				Region:    locationID,
+				IsGMEK:    true,
 			}
 		}
 	}


### PR DESCRIPTION
Adds `google_integrations_integration_version` and `google_integrations_integration_version_deployment` resources to manage Application Integration versions and their deployments.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28972
b/551967897

```release-note:new-resource
integrations: `google_integrations_integration_version_deployment`
```

```release-note:new-resource
integrations: `google_integrations_integration_version`
```

