### PR TITLE
ces: add error_handling_settings to google_ces_app

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -691,3 +691,45 @@ properties:
           not yet apply to Python tools that may make direct HTTP calls.
         item_type:
           type: String
+  - name: errorHandlingSettings
+    type: NestedObject
+    description: |-
+      Settings to describe how errors should be handled in the app.
+    properties:
+      - name: errorHandlingStrategy
+        type: String
+        description: |-
+          The strategy to use for error handling.
+          Possible values:
+          NONE
+          FALLBACK_RESPONSE
+          END_SESSION
+      - name: fallbackResponseConfig
+        type: NestedObject
+        description: |-
+          Configuration for handling fallback responses.
+        properties:
+          - name: customFallbackMessages
+            type: KeyValuePairs
+            description: |-
+              The fallback messages in case of system errors (e.g. LLM errors),
+              mapped by supported language code
+              (https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps/reference/language).
+          - name: maxFallbackAttempts
+            type: Integer
+            description: |-
+              The maximum number of fallback attempts to make before the agent
+              emitting EndSession Signal.
+      - name: endSessionConfig
+        type: NestedObject
+        send_empty_value: true
+        allow_empty_object: true
+        description: |-
+          Configuration for ending the session in case of system errors (e.g. LLM
+          errors).
+        properties:
+          - name: escalateSession
+            type: Boolean
+            description: |-
+              Whether to escalate the session in EndSession. If session is escalated,
+              metadata in EndSession will contain session_escalated = true.

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -1075,6 +1075,54 @@ properties:
                 output: true
                 item_type:
                   type: String
+          - name: errorHandlingSettings
+            type: NestedObject
+            description: |-
+              Settings to describe how errors should be handled in the app.
+            output: true
+            properties:
+              - name: errorHandlingStrategy
+                type: String
+                description: |-
+                  The strategy to use for error handling.
+                  Possible values:
+                  NONE
+                  FALLBACK_RESPONSE
+                  END_SESSION
+                output: true
+              - name: fallbackResponseConfig
+                type: NestedObject
+                description: |-
+                  Configuration for handling fallback responses.
+                output: true
+                properties:
+                  - name: customFallbackMessages
+                    type: KeyValuePairs
+                    description: |-
+                      The fallback messages in case of system errors (e.g. LLM errors),
+                      mapped by supported language code
+                      (https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps/reference/language).
+                    output: true
+                  - name: maxFallbackAttempts
+                    type: Integer
+                    description: |-
+                      The maximum number of fallback attempts to make before the agent
+                      emitting EndSession Signal.
+                    output: true
+              - name: endSessionConfig
+                type: NestedObject
+                allow_empty_object: true
+                description: |-
+                  Configuration for ending the session in case of system errors (e.g. LLM
+                  errors).
+                output: true
+                properties:
+                  - name: escalateSession
+                    type: Boolean
+                    description: |-
+                      Whether to escalate the session in EndSession. If session is escalated,
+                      metadata in EndSession will contain session_escalated = true.
+                    output: true
       - name: examples
         type: Array
         description: List of examples in the app.

--- a/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
@@ -183,5 +183,18 @@ variable_declarations {
     allowed_origins = ["https://example.com"]
   }
 
+  error_handling_settings {
+    error_handling_strategy = "FALLBACK_RESPONSE"
+    fallback_response_config {
+      custom_fallback_messages = {
+        "en-US" = "An error occurred, please try again."
+      }
+      max_fallback_attempts = 3
+    }
+    end_session_config {
+      escalate_session = true
+    }
+  }
+
   # Root agent should not be specified when creating an app
 }

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -240,6 +240,19 @@ resource "google_ces_app" "ces_app_basic" {
     allowed_origins = ["https://example.com"]
   }
 
+  error_handling_settings {
+    error_handling_strategy = "FALLBACK_RESPONSE"
+    fallback_response_config {
+      custom_fallback_messages = {
+        "en-US" = "An error occurred, please try again."
+      }
+      max_fallback_attempts = 3
+    }
+    end_session_config {
+      escalate_session = true
+    }
+  }
+
   # Root agent should not be specified when creating an app
 }
 `, context)
@@ -438,6 +451,20 @@ resource "google_ces_app" "ces_app_basic" {
 
   vpc_sc_settings {
     allowed_origins = ["https://example.com", "https://example.org:443"]
+  }
+
+  error_handling_settings {
+    error_handling_strategy = "END_SESSION"
+    fallback_response_config {
+      custom_fallback_messages = {
+        "en-US" = "Sorry, something went wrong."
+        "es-ES" = "Lo siento, algo salió mal."
+      }
+      max_fallback_attempts = 5
+    }
+    end_session_config {
+      escalate_session = false
+    }
   }
 
   # Root agent should not be specified when creating an app


### PR DESCRIPTION
Added support for `error_handling_settings` and its nested fields (`error_handling_strategy`, `fallback_response_config`, `end_session_config`) on `google_ces_app`.

Reference: b/550544084

```release-note:enhancement
ces: added `error_handling_settings` field to `google_ces_app`
```
