### PR TITLE
cloudidentity: fix post-test destruction errors for Group and GroupMembership

### DIFF
--- a/mmv1/products/cloudidentity/Group.yaml
+++ b/mmv1/products/cloudidentity/Group.yaml
@@ -38,6 +38,8 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 exclude_sweeper: true
+error_retry_predicates:
+  - transport_tpg.IsCloudIdentityGroup409
 async:
   type: PollAsync
   actions: [create, update, delete]

--- a/mmv1/products/cloudidentity/GroupMembership.yaml
+++ b/mmv1/products/cloudidentity/GroupMembership.yaml
@@ -43,6 +43,7 @@ custom_code:
   post_create: templates/terraform/post_create/set_computed_name.tmpl
   custom_update: templates/terraform/custom_update/cloud_identity_group_membership.go.tmpl
   post_import: templates/terraform/post_import/cloud_identity_group_membership.go.tmpl
+  custom_delete: templates/terraform/custom_delete/cloud_identity_group_membership.go.tmpl
 samples:
   - name: cloud_identity_group_membership
     primary_resource_id: cloud_identity_group_membership_basic

--- a/mmv1/templates/terraform/custom_delete/cloud_identity_group_membership.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/cloud_identity_group_membership.go.tmpl
@@ -1,0 +1,33 @@
+	billingProject := ""
+
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"{{ "{{" }}name{{ "}}" }}")
+	if err != nil {
+		return err
+	}
+
+	var obj map[string]interface{}
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	headers := make(http.Header)
+
+	log.Printf("[DEBUG] Deleting GroupMembership %q", d.Id())
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "DELETE",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutDelete),
+		Headers:   headers,
+	})
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(transformCloudIdentityGroupMembershipReadError(err), d, "GroupMembership")
+	}
+
+	log.Printf("[DEBUG] Finished deleting GroupMembership %q: %#v", d.Id(), res)
+	return nil

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -741,3 +741,12 @@ func IsNetworkAttachmentConnectedEndpointsError(err error) (bool, string) {
 	}
 	return false, ""
 }
+
+func IsCloudIdentityGroup409(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 409 {
+			return true, "saw a 409 - The operation was aborted"
+		}
+	}
+	return false, ""
+}

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -744,7 +744,9 @@ func IsNetworkAttachmentConnectedEndpointsError(err error) (bool, string) {
 
 func IsCloudIdentityGroup409(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
-		if gerr.Code == 409 {
+		if gerr.Code == 409 && strings.Contains(strings.ToLower(gerr.Body), "operation was aborted") {
+			return true, "saw a 409 - The operation was aborted"
+		}
 			return true, "saw a 409 - The operation was aborted"
 		}
 	}

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -745,9 +745,7 @@ func IsNetworkAttachmentConnectedEndpointsError(err error) (bool, string) {
 func IsCloudIdentityGroup409(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
 		if gerr.Code == 409 && strings.Contains(strings.ToLower(gerr.Body), "operation was aborted") {
-			return true, "saw a 409 - The operation was aborted"
-		}
-			return true, "saw a 409 - The operation was aborted"
+			return true, "Retrying aborted operation"
 		}
 	}
 	return false, ""


### PR DESCRIPTION
Fixes nightly acceptance test failures for Cloud Identity Group test cases:

* `TestAccCloudIdentityGroup/update`
* `TestAccCloudIdentityGroup/membership_dne`

### Root Cause & Fix

1. **Cloud Identity Group Membership 403 on Deletion/Teardown**:
   When deleting a `google_cloud_identity_group_membership` that no longer exists (e.g. during post-test destroy or cleanup), Cloud Identity returns `googleapi: Error 403: Error(2028): Permission denied for resource ... (or it may not exist)`.
   Because Terraform standard deletion expects a 404 for nonexistent resources, the 403 error caused destroy operations to fail.
   This change adds a `custom_delete` template in `mmv1/templates/terraform/custom_delete/cloud_identity_group_membership.go.tmpl` that applies the existing `transformCloudIdentityGroupMembershipReadError` helper during deletion, properly converting the ambiguous 403 to a 404 so `HandleNotFoundError` treats the resource as removed.

2. **Cloud Identity Group 409 Aborted on Deletion**:
   When deleting a `google_cloud_identity_group`, concurrent updates or backend state transitions can cause the API to return `googleapi: Error 409: The operation was aborted.` before async polling begins.
   This change introduces `IsCloudIdentityGroup409` in `mmv1/third_party/terraform/transport/error_retry_predicates.go` and attaches it to `error_retry_predicates` in `mmv1/products/cloudidentity/Group.yaml` to retry transient 409 abort errors during deletion.

```release-note:none
```