### PR TITLE
Fix SQL Server Entra ID user matching in google_sql_user

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -483,7 +483,7 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 	var user *sqladmin.User
 	for _, currentUser := range users.Items {
 		var username string
-		if !(strings.Contains(databaseInstance.DatabaseVersion, "POSTGRES") || currentUser.Type == "CLOUD_IAM_GROUP") {
+		if !(strings.Contains(databaseInstance.DatabaseVersion, "POSTGRES") || currentUser.Type == "CLOUD_IAM_GROUP" || currentUser.Type == "ENTRAID_USER") {
 			username = strings.Split(name, "@")[0]
 		} else if strings.Contains(databaseInstance.DatabaseVersion, "MYSQL") && currentUser.Type == "CLOUD_IAM_GROUP" {
 			splitName := strings.SplitN(name, "@", 2)

--- a/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -159,7 +159,8 @@ The following arguments are supported:
     include "BUILT_IN", "CLOUD_IAM_USER", "CLOUD_IAM_SERVICE_ACCOUNT", "CLOUD_IAM_GROUP",
     "CLOUD_IAM_GROUP_USER" and "CLOUD_IAM_GROUP_SERVICE_ACCOUNT" for
     [Postgres](https://cloud.google.com/sql/docs/postgres/admin-api/rest/v1beta4/users#sqlusertype)
-    and [MySQL](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/users#sqlusertype).
+    and [MySQL](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/users#sqlusertype),
+    and "BUILT_IN" and "ENTRAID_USER" for [SQL Server](https://cloud.google.com/sql/docs/sqlserver/admin-api/rest/v1beta4/users#sqlusertype).
 
 * `deletion_policy` - (Optional) Whether Terraform will be prevented from destroying the resource. Defaults to "DELETE".
     When a 'terraform destroy' or 'terraform apply' would delete the resource,


### PR DESCRIPTION
Fixes an issue where creating a Cloud SQL SQL Server Entra ID user (`type = "ENTRAID_USER"`) fails on refresh with `Root object was present, but now absent`.
`resourceSqlUserRead` was stripping `@domain` using `strings.Split(name, "@")[0]` for all non-Postgres engines. 

For email-based Entra ID users (e.g. `user@tenant.onmicrosoft.com`), this causs name matching to fail against the API response.
This change exempts `ENTRAID_USER` from domain stripping so the full email names is preserved.

### Tests
* Verified manually end-to-end against a Cloud SQL SQL Server 2022 instance (creating, and deleting `ENTRAID_USER`).
* *Note: Acceptance tests for `ENTRAID_USER` require pre-provisioned Azure Active Directory certificates and tenant configuration on the instance, so end-to-end testing was performed manually.*


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
sql: fixed issue where creating SQL Server Entra ID users (`google_sql_user` with `type = "ENTRAID_USER"`) failed state refresh due to username domain truncation
```
