### PR TITLE
feat(iap): add forwarding rule resource type support to IAP Settings

### DIFF
--- a/mmv1/products/iap/Settings.yaml
+++ b/mmv1/products/iap/Settings.yaml
@@ -67,6 +67,10 @@ properties:
       * projects/{project_id}/iap_web/compute-{region}
       * projects/{project_id}/iap_web/compute/services/{service_id}
       * projects/{project_id}/iap_web/compute-{region}/services/{service_id}
+      * projects/{project_id}/iap_web/forwarding_rule
+      * projects/{project_id}/iap_web/forwarding_rule-{region}
+      * projects/{project_id}/iap_web/forwarding_rule/services/{service_id}
+      * projects/{project_id}/iap_web/forwarding_rule-{region}/services/{service_id}
       * projects/{project_id}/iap_web/appengine-{app_id}
       * projects/{project_id}/iap_web/appengine-{app_id}/services/{service_id}
       * projects/{project_id}/iap_web/appengine-{app_id}/services/{service_id}/version/{version_id}


### PR DESCRIPTION
### Description
Adds missing documentation and support for `forwarding_rule` resource types in Identity-Aware Proxy (IAP) Settings.

### Release Note
```release-note:enhancement
iap: added support for `forwarding_rule` resource types in `google_iap_settings`
```