### PR TITLE
apikeys: add `check_existing_usage` and `deletion_policy = "FORCE"` to `google_apikeys_key`

### DIFF
--- a/mmv1/third_party/terraform/services/apikeys/key.go.tmpl
+++ b/mmv1/third_party/terraform/services/apikeys/key.go.tmpl
@@ -18,6 +18,7 @@ type Key struct {
 	ServiceAccountEmail *string          `json:"serviceAccountEmail"`
 	Restrictions        *KeyRestrictions `json:"restrictions"`
 	Project             *string          `json:"project"`
+	CheckExistingUsage  *string          `json:"-"`
 }
 
 func (r *Key) String() string {

--- a/mmv1/third_party/terraform/services/apikeys/key_internal.go
+++ b/mmv1/third_party/terraform/services/apikeys/key_internal.go
@@ -189,7 +189,11 @@ func (op *updateKeyUpdateKeyOperation) do(ctx context.Context, r *Key, c *Client
 		return err
 	}
 	mask := dcl.TopLevelUpdateMask(op.FieldDiffs)
-	u, err = dcl.AddQueryParams(u, map[string]string{"updateMask": mask})
+	params := map[string]string{"updateMask": mask}
+	if r.CheckExistingUsage != nil && *r.CheckExistingUsage != "" {
+		params["checkExistingUsage"] = *r.CheckExistingUsage
+	}
+	u, err = dcl.AddQueryParams(u, params)
 	if err != nil {
 		return err
 	}
@@ -299,6 +303,7 @@ func (c *Client) deleteAllKey(ctx context.Context, f func(*Key) bool, resources 
 type deleteKeyOperation struct{}
 
 func (op *deleteKeyOperation) do(ctx context.Context, r *Key, c *Client) error {
+	checkExistingUsage := r.CheckExistingUsage
 	r, err := c.GetKey(ctx, r)
 	if err != nil {
 		if dcl.IsNotFound(err) {
@@ -308,10 +313,17 @@ func (op *deleteKeyOperation) do(ctx context.Context, r *Key, c *Client) error {
 		c.Config.Logger.WarningWithContextf(ctx, "GetKey checking for existence. error: %v", err)
 		return err
 	}
+	r.CheckExistingUsage = checkExistingUsage
 
 	u, err := r.deleteURL(c.Config.BasePath)
 	if err != nil {
 		return err
+	}
+	if r.CheckExistingUsage != nil && *r.CheckExistingUsage != "" {
+		u, err = dcl.AddQueryParams(u, map[string]string{"checkExistingUsage": *r.CheckExistingUsage})
+		if err != nil {
+			return err
+		}
 	}
 
 	// Delete should never have a body
@@ -454,6 +466,7 @@ func canonicalizeKeyDesiredState(rawDesired, rawInitial *Key, opts ...dcl.ApplyO
 		return rawDesired, nil
 	}
 	canonicalDesired := &Key{}
+	canonicalDesired.CheckExistingUsage = rawDesired.CheckExistingUsage
 	if dcl.NameToSelfLink(rawDesired.Name, rawInitial.Name) {
 		canonicalDesired.Name = rawInitial.Name
 	} else {

--- a/mmv1/third_party/terraform/services/apikeys/resource_apikeys_key.go
+++ b/mmv1/third_party/terraform/services/apikeys/resource_apikeys_key.go
@@ -102,8 +102,8 @@ When set to "FORCE", deleting the resource will bypass the active traffic usage 
 			"check_existing_usage": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"CHECK_EXISTING_USAGE_UNSPECIFIED", "SKIP", "CHECK"}, false),
-				Description:  "Defines the behavior for checking existing usage when updating a key. Possible values: 'CHECK_EXISTING_USAGE_UNSPECIFIED', 'SKIP', 'CHECK'.",
+				ValidateFunc: validation.StringInSlice([]string{"SKIP", "CHECK"}, false),
+				Description:  "Defines the behavior for checking existing usage when updating a key. Possible values: 'SKIP', 'CHECK'.",
 			},
 
 			//UDP schema start

--- a/mmv1/third_party/terraform/services/apikeys/resource_apikeys_key.go
+++ b/mmv1/third_party/terraform/services/apikeys/resource_apikeys_key.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgdclresource"
 	dcl "github.com/hashicorp/terraform-provider-google/google/tpgdclresource"
@@ -16,6 +18,15 @@ import (
 )
 
 func ResourceApikeysKey() *schema.Resource {
+	deletionPolicySchema := tpgresource.DeletionPolicySchemaEntry("DELETE")
+	deletionPolicySchema.Description = `Whether Terraform will be prevented from destroying the resource. Defaults to "DELETE".
+When a 'terraform destroy' or 'terraform apply' would delete the resource,
+the command will fail if this field is set to "PREVENT" in Terraform state.
+When set to "ABANDON", the command will remove the resource from Terraform
+management without updating or deleting the resource in the API.
+When set to "DELETE", deleting the resource is allowed, and existing traffic usage will be checked. If active usage was detected in the last 7 days, the request fails.
+When set to "FORCE", deleting the resource will bypass the active traffic usage check.`
+
 	return &schema.Resource{
 		Create: resourceApikeysKeyCreate,
 		Read:   resourceApikeysKeyRead,
@@ -88,8 +99,15 @@ func ResourceApikeysKey() *schema.Resource {
 				Description: "Output only. Unique id in UUID4 format.",
 			},
 
+			"check_existing_usage": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"CHECK_EXISTING_USAGE_UNSPECIFIED", "SKIP", "CHECK"}, false),
+				Description:  "Defines the behavior for checking existing usage when updating a key. Possible values: 'CHECK_EXISTING_USAGE_UNSPECIFIED', 'SKIP', 'CHECK'.",
+			},
+
 			//UDP schema start
-			"deletion_policy": tpgresource.DeletionPolicySchemaEntry("DELETE"),
+			"deletion_policy": deletionPolicySchema,
 			//UDP schema end
 		},
 	}
@@ -358,12 +376,18 @@ func resourceApikeysKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	var checkExistingUsage *string
+	if v, ok := d.GetOk("check_existing_usage"); ok {
+		checkExistingUsage = dcl.String(v.(string))
+	}
+
 	obj := &Key{
 		Name:                dcl.String(d.Get("name").(string)),
 		DisplayName:         dcl.String(d.Get("display_name").(string)),
 		Project:             dcl.String(project),
 		Restrictions:        expandApikeysKeyRestrictions(d.Get("restrictions")),
 		ServiceAccountEmail: dcl.String(d.Get("service_account_email").(string)),
+		CheckExistingUsage:  checkExistingUsage,
 	}
 	directive := tpgdclresource.UpdateDirective
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
@@ -412,12 +436,19 @@ func resourceApikeysKeyDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	deletionPolicy := d.Get("deletion_policy").(string)
+	checkExistingUsage := "CHECK"
+	if strings.EqualFold(deletionPolicy, "FORCE") {
+		checkExistingUsage = "SKIP"
+	}
+
 	obj := &Key{
 		Name:                dcl.String(d.Get("name").(string)),
 		DisplayName:         dcl.String(d.Get("display_name").(string)),
 		Project:             dcl.String(project),
 		Restrictions:        expandApikeysKeyRestrictions(d.Get("restrictions")),
 		ServiceAccountEmail: dcl.String(d.Get("service_account_email").(string)),
+		CheckExistingUsage:  dcl.String(checkExistingUsage),
 	}
 
 	log.Printf("[DEBUG] Deleting Key %q", d.Id())

--- a/mmv1/third_party/terraform/services/apikeys/resource_apikeys_key_generated_test.go
+++ b/mmv1/third_party/terraform/services/apikeys/resource_apikeys_key_generated_test.go
@@ -199,6 +199,65 @@ func TestAccApikeysKey_ServiceAccountKeyHandWritten(t *testing.T) {
 	})
 }
 
+func TestAccApikeysKey_CheckExistingUsage(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]any{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckApikeysKeyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApikeysKey_CheckExistingUsage(context),
+			},
+			{
+				ResourceName:            "google_apikeys_key.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"check_existing_usage"},
+			},
+			{
+				Config: testAccApikeysKey_CheckExistingUsageUpdate(context),
+			},
+			{
+				ResourceName:            "google_apikeys_key.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"check_existing_usage"},
+			},
+		},
+	})
+}
+
+func TestAccApikeysKey_DeletionPolicyForce(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]any{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckApikeysKeyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApikeysKey_DeletionPolicyForce(context),
+			},
+			{
+				ResourceName:            "google_apikeys_key.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_policy"},
+			},
+		},
+	})
+}
+
 func testAccApikeysKey_AndroidKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_apikeys_key" "primary" {
@@ -412,6 +471,35 @@ resource "google_service_account" "key_service_account" {
   account_id   = "tf-test-app%{random_suffix}"
   project      = google_project.project.project_id
   display_name = "Test Service Account"
+}
+`, context)
+}
+
+func testAccApikeysKey_CheckExistingUsage(context map[string]any) string {
+	return acctest.Nprintf(`
+resource "google_apikeys_key" "primary" {
+  name         = "tf-test-key%{random_suffix}"
+  display_name = "sample-key"
+}
+`, context)
+}
+
+func testAccApikeysKey_CheckExistingUsageUpdate(context map[string]any) string {
+	return acctest.Nprintf(`
+resource "google_apikeys_key" "primary" {
+  name                 = "tf-test-key%{random_suffix}"
+  display_name         = "sample-key-updated"
+  check_existing_usage = "CHECK"
+}
+`, context)
+}
+
+func testAccApikeysKey_DeletionPolicyForce(context map[string]any) string {
+	return acctest.Nprintf(`
+resource "google_apikeys_key" "primary" {
+  name            = "tf-test-key%{random_suffix}"
+  display_name    = "sample-key"
+  deletion_policy = "FORCE"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/apikeys/resource_apikeys_key_meta.yaml
+++ b/mmv1/third_party/terraform/services/apikeys/resource_apikeys_key_meta.yaml
@@ -19,3 +19,5 @@ fields:
   - api_field: 'serviceAccountEmail'
   - field: 'deletion_policy'
     provider_only: true
+  - field: 'check_existing_usage'
+    provider_only: true

--- a/mmv1/third_party/terraform/website/docs/r/apikeys_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/apikeys_key.html.markdown
@@ -156,12 +156,17 @@ The following arguments are supported:
   (Optional)
   The email of the service account the key is bound to. If this field is specified, the key is a service account bound key and auth enabled. See [Documentation](https://cloud.google.com/docs/authentication/api-keys?#api-keys-bound-sa) for more details.
 
+* `check_existing_usage` -
+  (Optional)
+  Defines the behavior for checking existing usage when updating a key. Possible values: `CHECK_EXISTING_USAGE_UNSPECIFIED`, `SKIP`, `CHECK`.
+
 * `deletion_policy` - (Optional) Whether Terraform will be prevented from destroying the resource. Defaults to "DELETE".
     When a 'terraform destroy' or 'terraform apply' would delete the resource,
     the command will fail if this field is set to "PREVENT" in Terraform state.
     When set to "ABANDON", the command will remove the resource from Terraform
     management without updating or deleting the resource in the API.
-    When set to "DELETE", deleting the resource is allowed.
+    When set to "DELETE", deleting the resource is allowed, and existing traffic usage will be checked. If active usage was detected in the last 7 days, the request fails.
+    When set to "FORCE", deleting the resource will bypass the active traffic usage check.
   
 
 

--- a/mmv1/third_party/terraform/website/docs/r/apikeys_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/apikeys_key.html.markdown
@@ -158,7 +158,7 @@ The following arguments are supported:
 
 * `check_existing_usage` -
   (Optional)
-  Defines the behavior for checking existing usage when updating a key. Possible values: `CHECK_EXISTING_USAGE_UNSPECIFIED`, `SKIP`, `CHECK`.
+  Defines the behavior for checking existing usage when updating a key. Possible values: `SKIP`, `CHECK`.
 
 * `deletion_policy` - (Optional) Whether Terraform will be prevented from destroying the resource. Defaults to "DELETE".
     When a 'terraform destroy' or 'terraform apply' would delete the resource,


### PR DESCRIPTION
```release-note:enhancement
apikeys: added `check_existing_usage` field and `FORCE` `deletion_policy` support to `google_apikeys_key`
```

### Description
Add support for API Keys traffic guardrails to prevent accidental outages:
- **Key Updates (`check_existing_usage`)**: Adds `check_existing_usage` enum attribute on key updates (`CHECK`, `SKIP`, `CHECK_EXISTING_USAGE_UNSPECIFIED`).
- **Key Deletions (`deletion_policy`)**: Enhances `deletion_policy` to support `deletion_policy = "FORCE"` to bypass active traffic checks on delete (defaults to `"DELETE"` which enforces `check_existing_usage = "CHECK"`).
- **Metadata & DCL Models**: Updates DCL models, schema mappings, and metadata definitions (`resource_apikeys_key_meta.yaml`).
- **Tests**: Adds acceptance tests `TestAccApikeysKey_CheckExistingUsage` and `TestAccApikeysKey_DeletionPolicyForce`.

Bug: https://b.corp.google.com/issues/536043868  
Reference: OMG/99738  
CL Reference: cl/971381113