### PR TITLE
dataproc: parameterize cluster test regions and zones

### DIFF
--- a/mmv1/third_party/terraform/services/compute/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/services/compute/bootstrap_test_utils.go
@@ -167,12 +167,11 @@ func BootstrapSharedTestGlobalAddress(t *testing.T, testId string, params ...fun
 }
 
 func BootstrapSubnet(t *testing.T, subnetName string, networkName string) string {
-	return BootstrapSubnetWithOverrides(t, subnetName, networkName, make(map[string]interface{}))
+	return BootstrapSubnetWithOverrides(t, subnetName, networkName, envvar.GetTestRegionFromEnv(), make(map[string]interface{}))
 }
 
-func BootstrapSubnetWithOverrides(t *testing.T, subnetName string, networkName string, subnetOptions map[string]interface{}) string {
+func BootstrapSubnetWithOverrides(t *testing.T, subnetName, networkName, region string, subnetOptions map[string]interface{}) string {
 	projectID := envvar.GetTestProjectFromEnv()
-	region := envvar.GetTestRegionFromEnv()
 
 	config := transport_tpg.BootstrapConfig(t)
 	if config == nil {
@@ -194,7 +193,6 @@ func BootstrapSubnetWithOverrides(t *testing.T, subnetName string, networkName s
 
 		defaultSubnetObj := map[string]interface{}{
 			"name":        subnetName,
-			"region ":     region,
 			"network":     networkUrl,
 			"ipCidrRange": "10.77.0.0/20",
 		}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -17126,7 +17126,7 @@ func bootstrapAdditionalIpRangesNetworkConfig(t *testing.T, name string, additio
 
 	// We create our network to ensure no range collisions.
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, fmt.Sprintf("%s-network", name))
-	mainSubnet := tpgcompute.BootstrapSubnetWithOverrides(t, fmt.Sprintf("%s-subnet-main", name), networkName, map[string]interface{}{
+	mainSubnet := tpgcompute.BootstrapSubnetWithOverrides(t, fmt.Sprintf("%s-subnet-main", name), networkName, envvar.GetTestRegionFromEnv(), map[string]interface{}{
 		"ipCidrRange": "10.2.0.0/24",
 		"secondaryIpRanges": []map[string]interface{}{
 			{
@@ -17167,7 +17167,7 @@ func bootstrapAdditionalIpRangesNetworkConfig(t *testing.T, name string, additio
 		}
 
 		subnetName := fmt.Sprintf("%s-subnet-add-%d", name, subnetIndex)
-		tpgcompute.BootstrapSubnetWithOverrides(t, subnetName, networkName, subnetOverrides)
+		tpgcompute.BootstrapSubnetWithOverrides(t, subnetName, networkName, envvar.GetTestRegionFromEnv(), subnetOverrides)
 
 		si := subnetRangeInfo{
 			SubnetName: subnetName,

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_batch_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_batch_test.go
@@ -70,7 +70,7 @@ func BootstrapSubnetForDataprocBatches(t *testing.T, subnetName string, networkN
 	subnetOptions := map[string]interface{}{
 		"privateIpGoogleAccess": true,
 	}
-	return tpgcompute.BootstrapSubnetWithOverrides(t, subnetName, networkName, subnetOptions)
+	return tpgcompute.BootstrapSubnetWithOverrides(t, subnetName, networkName, envvar.GetTestRegionFromEnv(), subnetOptions)
 }
 
 func BootstrapSubnetWithFirewallForDataprocBatches(t *testing.T, testId string, subnetName string) string {

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
@@ -31,6 +31,12 @@ import (
 	"google.golang.org/api/dataproc/v1"
 )
 
+const (
+	testRegion        = "us-west1"
+	testZone          = "us-west1-b"
+	testStorageRegion = "US"
+)
+
 func TestAccDataprocCluster_missingZoneGlobalRegion1(t *testing.T) {
 	t.Parallel()
 
@@ -120,7 +126,7 @@ func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 	pid := envvar.GetTestProjectFromEnv()
 	version := "3.5-dataproc-17"
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "gke-cluster", networkName, testRegion, nil)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -159,9 +165,9 @@ func TestAccDataprocCluster_withAccelerators(t *testing.T) {
 
 	project := envvar.GetTestProjectFromEnv()
 	acceleratorType := "nvidia-tesla-t4"
-	zone := "us-central1-c"
+	zone := testZone
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -293,7 +299,7 @@ func TestAccDataprocCluster_withConfidentialCompute(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	imageUri := "https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images/dataproc-2-1-ubu20-20241026-165100-rc01"
 
@@ -338,7 +344,7 @@ func TestAccDataprocCluster_withConfidentialComputeType(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	imageUri := "https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images/dataproc-2-1-ubu20-20241026-165100-rc01"
 
@@ -367,7 +373,7 @@ func TestAccDataprocCluster_withMetadataAndTags(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -397,7 +403,7 @@ func TestAccDataprocCluster_withResourceManagerTags(t *testing.T) {
 	projectNumber := envvar.GetTestProjectNumberFromEnv()
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	// TODO: remove this IAM binding once tagUser permissions are present in Dataproc Service Agent role.
 	resourcemanager.BootstrapIamMembers(t, []resourcemanager.IamMember{
@@ -430,7 +436,7 @@ func TestAccDataprocCluster_withMinNumInstances(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -456,7 +462,7 @@ func TestAccDataprocCluster_withReservationAffinity(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -484,7 +490,7 @@ func TestAccDataprocCluster_withDataprocMetricConfig(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -513,7 +519,7 @@ func TestAccDataprocCluster_withNodeGroupAffinity(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -538,7 +544,7 @@ func TestAccDataprocCluster_singleNodeCluster(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -606,7 +612,7 @@ func TestAccDataprocCluster_nonPreemptibleSecondary(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -631,7 +637,7 @@ func TestAccDataprocCluster_spotSecondary(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -820,7 +826,7 @@ func TestAccDataprocCluster_spotWithAuxiliaryNodeGroups(t *testing.T) {
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_auxiliary_node_groups", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.roles.0", "DRIVER"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.num_instances", "2"),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.machine_type", "n1-standard-2"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.machine_type", "n4-standard-2"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.min_cpu_platform", "Intel Haswell"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.disk_config.0.boot_disk_size_gb", "35"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.disk_config.0.boot_disk_type", "pd-standard"),
@@ -843,7 +849,7 @@ func TestAccDataprocCluster_withStagingBucket(t *testing.T) {
 	clusterName := fmt.Sprintf("tf-test-dproc-%s", rnd)
 	bucketName := fmt.Sprintf("%s-bucket", clusterName)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -878,7 +884,7 @@ func TestAccDataprocCluster_withTempBucket(t *testing.T) {
 	clusterName := fmt.Sprintf("tf-test-dproc-%s", rnd)
 	bucketName := fmt.Sprintf("%s-temp-bucket", clusterName)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -912,7 +918,7 @@ func TestAccDataprocCluster_withInitAction(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-test-dproc-%s-init-bucket", rnd)
 	objectName := "msg.txt"
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -939,7 +945,7 @@ func TestAccDataprocCluster_withConfigOverrides(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	var cluster dataproc.Cluster
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -965,7 +971,7 @@ func TestAccDataprocCluster_withServiceAcc(t *testing.T) {
 	saEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", sa, envvar.GetTestProjectFromEnv())
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -1002,7 +1008,7 @@ func TestAccDataprocCluster_withImageVersion(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	version := "2.0.35-debian10"
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -1027,7 +1033,7 @@ func TestAccDataprocCluster_withOptionalComponents(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -1052,7 +1058,7 @@ func TestAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -1086,7 +1092,7 @@ func TestAccDataprocCluster_withLifecycleConfigAutoDeletion(t *testing.T) {
 	now := time.Now()
 	fmtString := "2006-01-02T15:04:05.072Z"
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -1116,7 +1122,7 @@ func TestAccDataprocCluster_withLifecycleConfigIdleStopTtl(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -1150,7 +1156,7 @@ func TestAccDataprocCluster_withLifecycleConfigAutoStop(t *testing.T) {
 	now := time.Now()
 	fmtString := "2006-01-02T15:04:05.072Z"
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -1179,7 +1185,7 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -1259,7 +1265,7 @@ func TestAccDataprocCluster_withEndpointConfig(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1284,7 +1290,7 @@ func TestAccDataprocCluster_KMS(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	bootstrapped := kms.BootstrapKMSKey(t)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	resourcemanager.BootstrapIamMembers(t, []resourcemanager.IamMember{
@@ -1316,7 +1322,7 @@ func TestAccDataprocCluster_withKerberos(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	bootstrapped := kms.BootstrapKMSKey(t)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -1340,7 +1346,7 @@ func TestAccDataprocCluster_withIdentityConfig(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -1365,7 +1371,7 @@ func TestAccDataprocCluster_updateIdentityConfigUserMapping(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -1398,7 +1404,7 @@ func TestAccDataprocCluster_withAutoscalingPolicy(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -1431,8 +1437,8 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 	pid := envvar.GetTestProjectFromEnv()
 	basicServiceId := "tf-test-metastore-srv-" + acctest.RandString(t, 10)
 	updateServiceId := "tf-test-metastore-srv-update-" + acctest.RandString(t, 10)
-	msName_basic := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, basicServiceId)
-	msName_update := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, updateServiceId)
+	msName_basic := fmt.Sprintf("projects/%s/locations/%s/services/%s", pid, testRegion, basicServiceId)
+	msName_update := fmt.Sprintf("projects/%s/locations/%s/services/%s", pid, testRegion, updateServiceId)
 
 	var cluster dataproc.Cluster
 	clusterName := "tf-test-" + acctest.RandString(t, 10)
@@ -1465,7 +1471,7 @@ func TestAccDataprocCluster_withClusterTier(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1504,13 +1510,13 @@ func testAccDataprocCluster_withClusterTier(rnd, subnetworkName, tier string) st
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name          = "%s"
-  location      = "US"
+  location      = "%s"
   force_destroy = "true"
 }
 
 resource "google_dataproc_cluster" "tier_cluster" {
   name   = "%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 	%s
@@ -1526,7 +1532,7 @@ resource "google_dataproc_cluster" "tier_cluster" {
     }
   }
 }
-`, bucketName, clusterName, tierConfig, subnetworkName)
+`, bucketName, testStorageRegion, clusterName, testRegion, tierConfig, subnetworkName)
 }
 
 func TestAccDataprocCluster_withEngine(t *testing.T) {
@@ -1535,7 +1541,7 @@ func TestAccDataprocCluster_withEngine(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1582,13 +1588,13 @@ func testAccDataprocCluster_withEngine(rnd, subnetworkName, engine string) strin
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name          = "%s"
-  location      = "US"
+  location      = "%s"
   force_destroy = "true"
 }
 
 resource "google_dataproc_cluster" "engine_cluster" {
   name   = "%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 	%s
@@ -1604,7 +1610,7 @@ resource "google_dataproc_cluster" "engine_cluster" {
     }
   }
 }
-`, bucketName, clusterName, engineConfig, subnetworkName)
+`, bucketName, testStorageRegion, clusterName, testRegion, engineConfig, subnetworkName)
 }
 
 func TestAccDataprocCluster_withClusterTypeSingleNode(t *testing.T) {
@@ -1613,7 +1619,7 @@ func TestAccDataprocCluster_withClusterTypeSingleNode(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1639,7 +1645,7 @@ func TestAccDataprocCluster_withClusterTypeZeroScale(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := tpgcompute.BootstrapSubnetWithOverrides(t, "dataproc-cluster", networkName, testRegion, nil)
 	BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1665,7 +1671,7 @@ func testAccDataprocCluster_withClusterTypeSingleNode(rnd, subnetworkName string
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "type_cluster" {
   name   = "%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 	cluster_type = "SINGLE_NODE"
@@ -1679,7 +1685,7 @@ resource "google_dataproc_cluster" "type_cluster" {
     }
   }
 }
-`, clusterName, subnetworkName)
+`, clusterName, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withClusterTypeZeroScale(rnd, subnetworkName string) string {
@@ -1689,14 +1695,14 @@ func testAccDataprocCluster_withClusterTypeZeroScale(rnd, subnetworkName string)
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name          = "%s"
-  location      = "US"
+  location      = "%s"
   force_destroy = "true"
 	uniform_bucket_level_access = "true"
 }
 
 resource "google_dataproc_cluster" "type_cluster" {
   name   = "%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 	cluster_type = "ZERO_SCALE"
@@ -1713,7 +1719,7 @@ resource "google_dataproc_cluster" "type_cluster" {
     }
   }
 }
-`, bucketName, clusterName, bucketName, subnetworkName)
+`, bucketName, testStorageRegion, clusterName, testRegion, bucketName, subnetworkName)
 }
 
 func testAccCheckDataprocClusterDestroy(t *testing.T) resource.TestCheckFunc {
@@ -1874,7 +1880,7 @@ func validateDataprocCluster_withConfigOverrides(n string, cluster *dataproc.Clu
 			{"cluster_config.0.master_config.0.disk_config.0.num_local_ssds", "0", strconv.Itoa(int(cluster.Config.MasterConfig.DiskConfig.NumLocalSsds))},
 			{"cluster_config.0.master_config.0.disk_config.0.boot_disk_type", "pd-ssd", cluster.Config.MasterConfig.DiskConfig.BootDiskType},
 			{"cluster_config.0.master_config.0.disk_config.0.local_ssd_interface", "nvme", cluster.Config.MasterConfig.DiskConfig.LocalSsdInterface},
-			{"cluster_config.0.master_config.0.machine_type", "n1-standard-2", tpgresource.GetResourceNameFromSelfLink(cluster.Config.MasterConfig.MachineTypeUri)},
+			{"cluster_config.0.master_config.0.machine_type", "c4-standard-4-lssd", tpgresource.GetResourceNameFromSelfLink(cluster.Config.MasterConfig.MachineTypeUri)},
 			{"cluster_config.0.master_config.0.instance_names.#", "3", strconv.Itoa(len(cluster.Config.MasterConfig.InstanceNames))},
 			{"cluster_config.0.master_config.0.min_cpu_platform", "Intel Skylake", cluster.Config.MasterConfig.MinCpuPlatform},
 
@@ -1883,7 +1889,7 @@ func validateDataprocCluster_withConfigOverrides(n string, cluster *dataproc.Clu
 			{"cluster_config.0.worker_config.0.disk_config.0.num_local_ssds", "1", strconv.Itoa(int(cluster.Config.WorkerConfig.DiskConfig.NumLocalSsds))},
 			{"cluster_config.0.worker_config.0.disk_config.0.boot_disk_type", "pd-standard", cluster.Config.WorkerConfig.DiskConfig.BootDiskType},
 			{"cluster_config.0.worker_config.0.disk_config.0.local_ssd_interface", "scsi", cluster.Config.WorkerConfig.DiskConfig.LocalSsdInterface},
-			{"cluster_config.0.worker_config.0.machine_type", "n1-standard-2", tpgresource.GetResourceNameFromSelfLink(cluster.Config.WorkerConfig.MachineTypeUri)},
+			{"cluster_config.0.worker_config.0.machine_type", "c4-standard-4-lssd", tpgresource.GetResourceNameFromSelfLink(cluster.Config.WorkerConfig.MachineTypeUri)},
 			{"cluster_config.0.worker_config.0.instance_names.#", "3", strconv.Itoa(len(cluster.Config.WorkerConfig.InstanceNames))},
 			{"cluster_config.0.worker_config.0.min_cpu_platform", "Intel Broadwell", cluster.Config.WorkerConfig.MinCpuPlatform},
 
@@ -2006,9 +2012,9 @@ func testAccDataprocCluster_basic(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 }
-`, rnd)
+`, rnd, testRegion)
 }
 
 func testAccDataprocVirtualCluster_basic(projectID, rnd, networkName, subnetworkName string) string {
@@ -2019,7 +2025,7 @@ data "google_project" "project" {
 
 resource "google_container_cluster" "primary" {
   name     = "tf-test-gke-%s"
-  location = "us-central1-a"
+  location = "%s"
   network    = "%s"
   subnetwork    = "%s"
 
@@ -2048,7 +2054,7 @@ resource "google_dataproc_cluster" "virtual_cluster" {
 	]
   
 	name   	= "tf-test-dproc-%s"
-	region  = "us-central1"
+	region  = "%s"
   
 	virtual_cluster_config {
 	  kubernetes_cluster_config {
@@ -2070,7 +2076,7 @@ resource "google_dataproc_cluster" "virtual_cluster" {
 	  }
 	}
   }
-`, projectID, rnd, networkName, subnetworkName, projectID, rnd, rnd, rnd, rnd, rnd, rnd)
+`, projectID, rnd, testZone, networkName, subnetworkName, projectID, rnd, rnd, rnd, rnd, testRegion, rnd, rnd)
 }
 
 func testAccCheckDataprocGkeClusterNodePoolsHaveRoles(cluster *dataproc.Cluster, roles ...string) func(s *terraform.State) error {
@@ -2090,7 +2096,7 @@ func testAccDataprocCluster_withAccelerators(rnd, acceleratorType, zone, subnetw
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "accelerated_cluster" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     software_config {
@@ -2118,7 +2124,7 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
     }
   }
 }
-`, rnd, subnetworkName, zone, acceleratorType, acceleratorType)
+`, rnd, testRegion, subnetworkName, zone, acceleratorType, acceleratorType)
 }
 
 func testAccDataprocCluster_withInternalIpOnlyTrueAndShieldedConfig(rnd string) string {
@@ -2140,7 +2146,7 @@ resource "google_compute_subnetwork" "dataproc_subnetwork" {
   name                     = "tf-test-dproc-subnet-%s"
   ip_cidr_range            = var.subnetwork_cidr
   network                  = google_compute_network.dataproc_network.self_link
-  region                   = "us-central1"
+  region                   = "%s"
   private_ip_google_access = true
 }
 
@@ -2175,7 +2181,7 @@ resource "google_compute_firewall" "dataproc_network_firewall" {
 
 resource "google_dataproc_cluster" "basic" {
   name       = "tf-test-dproc-%s"
-  region     = "us-central1"
+  region     = "%s"
   depends_on = [google_compute_firewall.dataproc_network_firewall]
 
   cluster_config {
@@ -2190,14 +2196,14 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd, rnd, rnd, rnd)
+`, rnd, rnd, testRegion, rnd, rnd, testRegion)
 }
 
 func testAccDataprocCluster_withShieldedConfig(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -2209,14 +2215,14 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd)
+`, rnd, testRegion)
 }
 
 func testAccDataprocCluster_withConfidentialCompute(rnd, subnetworkName string, imageUri string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "confidential" {
     name   = "tf-test-dproc-%s"
-    region = "us-central1"
+    region = "%s"
 
     cluster_config {
         gce_cluster_config {
@@ -2239,14 +2245,14 @@ resource "google_dataproc_cluster" "confidential" {
         }
     }
 }
-`, rnd, subnetworkName, imageUri, imageUri)
+`, rnd, testRegion, subnetworkName, imageUri, imageUri)
 }
 
 func testAccDataprocCluster_withConfidentialComputeType(rnd, subnetworkName, imageUri string, confType string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "confidential_type" {
     name   = "tf-test-dproc-%s"
-    region = "us-central1"
+    region = "%s"
 
 
     cluster_config {
@@ -2270,14 +2276,14 @@ resource "google_dataproc_cluster" "confidential_type" {
         }
     }
 }
-`, rnd, subnetworkName, confType, imageUri, imageUri)
+`, rnd, testRegion, subnetworkName, confType, imageUri, imageUri)
 }
 
 func testAccDataprocCluster_withMetadataAndTags(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -2290,7 +2296,7 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withResourceManagerTags(pid, rnd, subnetworkName string) string {
@@ -2317,7 +2323,7 @@ resource "google_tags_tag_value" "tag_value_2" {
 
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -2329,14 +2335,14 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, pid, rnd, rnd, pid, rnd, rnd, rnd, subnetworkName)
+`, pid, rnd, rnd, pid, rnd, rnd, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withMinNumInstances(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_min_num_instances" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
  
   cluster_config {
     gce_cluster_config {
@@ -2351,7 +2357,7 @@ resource "google_dataproc_cluster" "with_min_num_instances" {
     }
   }
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withReservationAffinity(rnd, subnetworkName string) string {
@@ -2359,12 +2365,12 @@ func testAccDataprocCluster_withReservationAffinity(rnd, subnetworkName string) 
 
 resource "google_compute_reservation" "reservation" {
   name = "tf-test-dproc-reservation-%s"
-  zone = "us-central1-f"
+  zone = "%s"
 
   specific_reservation {
     count = 10
     instance_properties {
-      machine_type = "n1-standard-2"
+      machine_type = "n4-standard-2"
     }
   }
   specific_reservation_required = true
@@ -2372,20 +2378,20 @@ resource "google_compute_reservation" "reservation" {
 
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     master_config {
-      machine_type  = "n1-standard-2"
+      machine_type  = "n4-standard-2"
     }
 
     worker_config {
-      machine_type  = "n1-standard-2"
+      machine_type  = "n4-standard-2"
     }
 
     gce_cluster_config {
       subnetwork = "%s"
-      zone = "us-central1-f"
+      zone = "%s"
       reservation_affinity {
         consume_reservation_type = "SPECIFIC_RESERVATION"
         key = "compute.googleapis.com/reservation-name"
@@ -2394,14 +2400,14 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd, rnd, subnetworkName)
+`, rnd, testZone, rnd, testRegion, subnetworkName, testZone)
 }
 
 func testAccDataprocCluster_withDataprocMetricConfig(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -2420,7 +2426,7 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withNodeGroupAffinity(rnd, subnetworkName string) string {
@@ -2428,7 +2434,7 @@ func testAccDataprocCluster_withNodeGroupAffinity(rnd, subnetworkName string) st
 
 resource "google_compute_node_template" "nodetmpl" {
   name   = "test-nodetmpl-%s"
-  region = "us-central1"
+  region = "%s"
 
   node_affinity_labels = {
     tfacc = "test"
@@ -2441,7 +2447,7 @@ resource "google_compute_node_template" "nodetmpl" {
 
 resource "google_compute_node_group" "nodes" {
   name = "test-nodegroup-%s"
-  zone = "us-central1-f"
+  zone = "%s"
 
   initial_size	= 3
   node_template = google_compute_node_template.nodetmpl.self_link
@@ -2449,35 +2455,35 @@ resource "google_compute_node_group" "nodes" {
 
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     master_config {
-      machine_type = "n1-standard-2"
+      machine_type = "n4-standard-2"
     }
     worker_config {
-      machine_type = "n1-standard-2"
+      machine_type = "n4-standard-2"
     }
     software_config {
       image_version = "2.0.35-debian10"
     }
     gce_cluster_config {
       subnetwork = "%s"
-      zone = "us-central1-f"
+      zone = "%s"
       node_group_affinity {
         node_group_uri = google_compute_node_group.nodes.name
       }
     }
   }
 }
-`, rnd, rnd, rnd, subnetworkName)
+`, rnd, testRegion, rnd, testZone, rnd, testRegion, subnetworkName, testZone)
 }
 
 func testAccDataprocCluster_singleNodeCluster(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "single_node_cluster" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -2492,14 +2498,14 @@ resource "google_dataproc_cluster" "single_node_cluster" {
     }
   }
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withConfigOverrides(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_config_overrides" {
   name     = "tf-test-dproc-%s"
-  region   = "us-central1"
+  region   = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -2507,7 +2513,7 @@ resource "google_dataproc_cluster" "with_config_overrides" {
     }
     master_config {
       num_instances = 3
-      machine_type  = "n1-standard-2"  // can't be e2 because of min_cpu_platform
+      machine_type  = "c4-standard-4-lssd"
       disk_config {
         boot_disk_type    = "pd-ssd"
         boot_disk_size_gb = 35
@@ -2518,7 +2524,7 @@ resource "google_dataproc_cluster" "with_config_overrides" {
 
     worker_config {
       num_instances = 3
-      machine_type  = "n1-standard-2"  // can't be e2 because of min_cpu_platform
+      machine_type  = "c4-standard-4-lssd"
       disk_config {
         boot_disk_type    = "pd-standard"
         boot_disk_size_gb = 35
@@ -2540,14 +2546,14 @@ resource "google_dataproc_cluster" "with_config_overrides" {
     }
   }
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withInitAction(rnd, bucket, objName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "init_bucket" {
   name          = "%s"
-  location      = "US"
+  location      = "%s"
   force_destroy = "true"
 }
 
@@ -2564,7 +2570,7 @@ EOL
 
 resource "google_dataproc_cluster" "with_init_action" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -2580,7 +2586,7 @@ resource "google_dataproc_cluster" "with_init_action" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2595,20 +2601,20 @@ resource "google_dataproc_cluster" "with_init_action" {
     }
   }
 }
-`, bucket, rnd, objName, objName, rnd, subnetworkName)
+`, bucket, testStorageRegion, rnd, objName, objName, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_updatable(rnd string, w, p int) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "updatable" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
   graceful_decommission_timeout = "0.2s"
 
   cluster_config {
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2616,7 +2622,7 @@ resource "google_dataproc_cluster" "updatable" {
 
     worker_config {
       num_instances = "%d"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2630,14 +2636,14 @@ resource "google_dataproc_cluster" "updatable" {
     }
   }
 }
-`, rnd, w, p)
+`, rnd, testRegion, w, p)
 }
 
 func testAccDataprocCluster_nonPreemptibleSecondary(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "non_preemptible_secondary" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -2646,7 +2652,7 @@ resource "google_dataproc_cluster" "non_preemptible_secondary" {
 
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2654,7 +2660,7 @@ resource "google_dataproc_cluster" "non_preemptible_secondary" {
   
     worker_config {
       num_instances = "2"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2669,14 +2675,14 @@ resource "google_dataproc_cluster" "non_preemptible_secondary" {
     }
   }
 }
-	`, rnd, subnetworkName)
+	`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_spotSecondary(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "spot_secondary" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -2685,7 +2691,7 @@ resource "google_dataproc_cluster" "spot_secondary" {
 
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2693,7 +2699,7 @@ resource "google_dataproc_cluster" "spot_secondary" {
 
     worker_config {
       num_instances = "2"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2708,13 +2714,13 @@ resource "google_dataproc_cluster" "spot_secondary" {
     }
   }
 }
-	`, rnd, subnetworkName)
+	`, rnd, testRegion, subnetworkName)
 }
 func testAccDataprocCluster_allInstanceFlexibilityPolicy(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "all_instance_flexibility_policy" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 
@@ -2770,19 +2776,19 @@ resource "google_dataproc_cluster" "all_instance_flexibility_policy" {
     }
   }
 }
-	`, rnd)
+	`, rnd, testRegion)
 }
 func testAccDataprocCluster_workerInstanceFlexibilityPolicy(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "worker_instance_flexibility_policy" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2812,14 +2818,14 @@ resource "google_dataproc_cluster" "worker_instance_flexibility_policy" {
     }
   }
 }
-	`, rnd)
+	`, rnd, testRegion)
 }
 
 func testAccDataprocCluster_masterInstanceFlexibilityPolicy(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "master_instance_flexibility_policy" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 
@@ -2842,7 +2848,7 @@ resource "google_dataproc_cluster" "master_instance_flexibility_policy" {
 
     worker_config {
       num_instances = "2"
-      machine_type  = "e2-standard-2"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2856,18 +2862,18 @@ resource "google_dataproc_cluster" "master_instance_flexibility_policy" {
     }
   }
 }
-	`, rnd)
+	`, rnd, testRegion)
 }
 func testAccDataprocCluster_spotWithInstanceFlexibilityPolicy(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "spot_with_instance_flexibility_policy" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2875,7 +2881,7 @@ resource "google_dataproc_cluster" "spot_with_instance_flexibility_policy" {
 
     worker_config {
       num_instances = "2"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2897,14 +2903,14 @@ resource "google_dataproc_cluster" "spot_with_instance_flexibility_policy" {
     }
   }
 }
-	`, rnd)
+	`, rnd, testRegion)
 }
 
 func testAccDataprocCluster_spotOnDemandMixing(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "spot_mixing" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -2912,7 +2918,7 @@ resource "google_dataproc_cluster" "spot_mixing" {
     }
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2920,7 +2926,7 @@ resource "google_dataproc_cluster" "spot_mixing" {
 
     worker_config {
       num_instances = "2"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2941,19 +2947,19 @@ resource "google_dataproc_cluster" "spot_mixing" {
     }
   }
 }
-	`, rnd)
+	`, rnd, testRegion)
 }
 
 func testAccDataprocCluster_withAuxiliaryNodeGroups(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2961,7 +2967,7 @@ resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
 
     worker_config {
       num_instances = "2"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2973,7 +2979,7 @@ resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
         roles = ["DRIVER"]
         node_group_config{
           num_instances=2
-          machine_type="n1-standard-2"
+          machine_type="n4-standard-2"
           min_cpu_platform = "Intel Haswell"
           disk_config {
             boot_disk_size_gb = 35
@@ -2990,27 +2996,27 @@ resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
     }
   }
 }
-	`, rnd)
+	`, rnd, testRegion)
 }
 
 func testAccDataprocCluster_withStagingBucketOnly(bucketName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name          = "%s"
-  location      = "US"
+  location      = "%s"
   force_destroy = "true"
 }
-`, bucketName)
+`, bucketName, testStorageRegion)
 }
 
 func testAccDataprocCluster_withTempBucketOnly(bucketName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name          = "%s"
-  location      = "US"
+  location      = "%s"
   force_destroy = "true"
 }
-`, bucketName)
+`, bucketName, testStorageRegion)
 }
 
 func testAccDataprocCluster_withStagingBucketAndCluster(clusterName, bucketName, subnetworkName string) string {
@@ -3019,7 +3025,7 @@ func testAccDataprocCluster_withStagingBucketAndCluster(clusterName, bucketName,
 
 resource "google_dataproc_cluster" "with_bucket" {
   name   = "%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     staging_bucket = google_storage_bucket.bucket.name
@@ -3037,14 +3043,14 @@ resource "google_dataproc_cluster" "with_bucket" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
     }
   }
 }
-`, testAccDataprocCluster_withStagingBucketOnly(bucketName), clusterName, subnetworkName)
+`, testAccDataprocCluster_withStagingBucketOnly(bucketName), clusterName, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withTempBucketAndCluster(clusterName, bucketName, subnetworkName string) string {
@@ -3053,7 +3059,7 @@ func testAccDataprocCluster_withTempBucketAndCluster(clusterName, bucketName, su
 
 resource "google_dataproc_cluster" "with_bucket" {
   name   = "%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     temp_bucket = google_storage_bucket.bucket.name
@@ -3071,21 +3077,21 @@ resource "google_dataproc_cluster" "with_bucket" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
     }
   }
 }
-`, testAccDataprocCluster_withTempBucketOnly(bucketName), clusterName, subnetworkName)
+`, testAccDataprocCluster_withTempBucketOnly(bucketName), clusterName, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withLabels(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_labels" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
   cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
@@ -3099,14 +3105,14 @@ resource "google_dataproc_cluster" "with_labels" {
     key1 = "value1"
   }
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withLabelsUpdate(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_labels" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
   cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
@@ -3120,14 +3126,14 @@ resource "google_dataproc_cluster" "with_labels" {
     key2 = "value2"
   }
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withoutLabels(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_labels" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
   cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
@@ -3137,14 +3143,14 @@ resource "google_dataproc_cluster" "with_labels" {
     }
   }
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withEndpointConfig(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_endpoint_config" {
 	name                  = "tf-test-%s"
-	region                = "us-central1"
+	region                = "%s"
 
 	cluster_config {
     gce_cluster_config {
@@ -3156,14 +3162,14 @@ resource "google_dataproc_cluster" "with_endpoint_config" {
 		}
 	}
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withImageVersion(rnd, version, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_image_version" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -3175,14 +3181,14 @@ resource "google_dataproc_cluster" "with_image_version" {
     }
   }
 }
-`, rnd, subnetworkName, version)
+`, rnd, testRegion, subnetworkName, version)
 }
 
 func testAccDataprocCluster_withOptionalComponents(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_opt_components" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -3194,14 +3200,14 @@ resource "google_dataproc_cluster" "with_opt_components" {
     }
   }
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(rnd, tm, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_lifecycle_config" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -3213,14 +3219,14 @@ resource "google_dataproc_cluster" "with_lifecycle_config" {
     }
   }
 }
-`, rnd, subnetworkName, tm)
+`, rnd, testRegion, subnetworkName, tm)
 }
 
 func testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, tm, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_lifecycle_config" {
  name   = "tf-test-dproc-%s"
- region = "us-central1"
+ region = "%s"
 
  cluster_config {
   gce_cluster_config {
@@ -3232,14 +3238,14 @@ resource "google_dataproc_cluster" "with_lifecycle_config" {
    }
  }
 }
-`, rnd, subnetworkName, tm)
+`, rnd, testRegion, subnetworkName, tm)
 }
 
 func testAccDataprocCluster_withLifecycleConfigIdleStopTtl(rnd, tm, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_lifecycle_config" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -3251,14 +3257,14 @@ resource "google_dataproc_cluster" "with_lifecycle_config" {
     }
   }
 }
-`, rnd, subnetworkName, tm)
+`, rnd, testRegion, subnetworkName, tm)
 }
 
 func testAccDataprocCluster_withLifecycleConfigAutoStopTime(rnd, tm, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_lifecycle_config" {
  name   = "tf-test-dproc-%s"
- region = "us-central1"
+ region = "%s"
 
  cluster_config {
   gce_cluster_config {
@@ -3270,7 +3276,7 @@ resource "google_dataproc_cluster" "with_lifecycle_config" {
    }
  }
 }
-`, rnd, subnetworkName, tm)
+`, rnd, testRegion, subnetworkName, tm)
 }
 
 func testAccDataprocCluster_withServiceAcc(sa, rnd, subnetworkName string) string {
@@ -3296,7 +3302,7 @@ resource "time_sleep" "wait_120_seconds" {
 
 resource "google_dataproc_cluster" "with_service_account" {
   name   = "dproc-cluster-test-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     # Keep the costs down with smallest config we can get away with
@@ -3308,7 +3314,7 @@ resource "google_dataproc_cluster" "with_service_account" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -3334,7 +3340,7 @@ resource "google_dataproc_cluster" "with_service_account" {
 
   depends_on = [time_sleep.wait_120_seconds]
 }
-`, sa, rnd, subnetworkName)
+`, sa, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_withNetworkRefs(rnd, netName string) string {
@@ -3374,7 +3380,7 @@ resource "google_compute_firewall" "dataproc_network_firewall" {
 
 resource "google_dataproc_cluster" "with_net_ref_by_name" {
   name       = "tf-test-dproc-net-%s"
-  region     = "us-central1"
+  region     = "%s"
   depends_on = [google_compute_firewall.dataproc_network_firewall]
 
   cluster_config {
@@ -3387,7 +3393,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
     }
 
     master_config {
-      machine_type = "e2-standard-2"
+      machine_type = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -3402,7 +3408,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
 
 resource "google_dataproc_cluster" "with_net_ref_by_url" {
   name       = "tf-test-dproc-url-%s"
-  region     = "us-central1"
+  region     = "%s"
   depends_on = [google_compute_firewall.dataproc_network_firewall]
 
   cluster_config {
@@ -3415,7 +3421,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
     }
 
     master_config {
-      machine_type = "e2-standard-2"
+      machine_type = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -3427,14 +3433,14 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
     }
   }
 }
-`, netName, rnd, rnd, rnd)
+`, netName, rnd, rnd, testRegion, rnd, testRegion)
 }
 
 func testAccDataprocCluster_KMS(rnd, kmsKey, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "kms" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -3446,14 +3452,14 @@ resource "google_dataproc_cluster" "kms" {
     }
   }
 }
-`, rnd, subnetworkName, kmsKey)
+`, rnd, testRegion, subnetworkName, kmsKey)
 }
 
 func testAccDataprocCluster_withKerberos(rnd, kmsKey, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name     = "tf-test-dproc-%s"
-  location = "US"
+  location = "%s"
 }
 resource "google_storage_bucket_object" "password" {
   name = "dataproc-password-%s"
@@ -3463,7 +3469,7 @@ resource "google_storage_bucket_object" "password" {
 
 resource "google_dataproc_cluster" "kerb" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -3478,14 +3484,14 @@ resource "google_dataproc_cluster" "kerb" {
     }
   }
 }
-`, rnd, rnd, rnd, subnetworkName, kmsKey)
+`, rnd, testStorageRegion, rnd, rnd, testRegion, subnetworkName, kmsKey)
 }
 
 func testAccDataprocCluster_withIdentityConfig(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "identity_config" {
   name   = "tf-test-dataproc-identity-%s"
-  region = "us-central1"
+  region = "%s"
   cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
@@ -3499,14 +3505,14 @@ resource "google_dataproc_cluster" "identity_config" {
     }
   }
 }
-`, rnd, subnetworkName)
+`, rnd, testRegion, subnetworkName)
 }
 
 func testAccDataprocCluster_updateIdentityConfig(rnd, subnetworkName, user, sa string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "identity_config_user_mapping" {
   name   = "tf-test-dataproc-update-identity-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 	gce_cluster_config {
@@ -3521,22 +3527,22 @@ resource "google_dataproc_cluster" "identity_config_user_mapping" {
 	}
 	master_config {
 	  num_instances = 1
-	  machine_type  = "n1-standard-2"
+	  machine_type  = "n4-standard-2"
 	}
 	worker_config {
 	  num_instances = 2
-	  machine_type  = "n1-standard-2"
+	  machine_type  = "n4-standard-2"
 	}
   }
 }
-`, rnd, subnetworkName, user, sa)
+`, rnd, testRegion, subnetworkName, user, sa)
 }
 
 func testAccDataprocCluster_withAutoscalingPolicy(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name     = "tf-test-dataproc-policy-%s"
-  region   = "us-central1"
+  region   = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -3551,7 +3557,7 @@ resource "google_dataproc_cluster" "basic" {
 
 resource "google_dataproc_autoscaling_policy" "asp" {
   policy_id = "tf-test-dataproc-policy-%s"
-  location  = "us-central1"
+  location  = "%s"
 
   worker_config {
     max_instances = 3
@@ -3565,14 +3571,14 @@ resource "google_dataproc_autoscaling_policy" "asp" {
     }
   }
 }
-`, rnd, subnetworkName, rnd)
+`, rnd, testRegion, subnetworkName, rnd, testRegion)
 }
 
 func testAccDataprocCluster_removeAutoscalingPolicy(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name     = "tf-test-dataproc-policy-%s"
-  region   = "us-central1"
+  region   = "%s"
 
   cluster_config {
     gce_cluster_config {
@@ -3587,7 +3593,7 @@ resource "google_dataproc_cluster" "basic" {
 
 resource "google_dataproc_autoscaling_policy" "asp" {
   policy_id = "tf-test-dataproc-policy-%s"
-  location  = "us-central1"
+  location  = "%s"
 
   worker_config {
     max_instances = 3
@@ -3601,14 +3607,14 @@ resource "google_dataproc_autoscaling_policy" "asp" {
     }
   }
 }
-`, rnd, subnetworkName, rnd)
+`, rnd, testRegion, subnetworkName, rnd, testRegion)
 }
 
 func testAccDataprocCluster_withMetastoreConfig(clusterName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
   name                  = "%s"
-  region                = "us-central1"
+  region                = "%s"
 
   cluster_config {
     metastore_config {
@@ -3619,7 +3625,7 @@ resource "google_dataproc_cluster" "with_metastore_config" {
 
 resource "google_dataproc_metastore_service" "ms" {
   service_id = "%s"
-  location   = "us-central1"
+  location   = "%s"
   port       = 9080
   tier       = "DEVELOPER"
 
@@ -3632,14 +3638,14 @@ resource "google_dataproc_metastore_service" "ms" {
     version = "3.1.2"
   }
 }
-`, clusterName, serviceId)
+`, clusterName, testRegion, serviceId, testRegion)
 }
 
 func testAccDataprocCluster_withMetastoreConfig_update(clusterName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
   name                  = "%s"
-  region                = "us-central1"
+  region                = "%s"
 
   cluster_config {
     metastore_config {
@@ -3650,7 +3656,7 @@ resource "google_dataproc_cluster" "with_metastore_config" {
 
 resource "google_dataproc_metastore_service" "ms" {
   service_id = "%s"
-  location   = "us-central1"
+  location   = "%s"
   port       = 9080
   tier       = "DEVELOPER"
 
@@ -3663,7 +3669,7 @@ resource "google_dataproc_metastore_service" "ms" {
     version = "3.1.2"
   }
 }
-`, clusterName, serviceId)
+`, clusterName, testRegion, serviceId, testRegion)
 }
 
 func TestAccDataprocCluster_withProvisionedIopsAndThroughput(t *testing.T) {
@@ -3718,7 +3724,7 @@ func testAccDataprocCluster_withProvisionedIopsAndThroughput(clusterName string)
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "tf_test_cluster" {
   name   = "%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 
@@ -3745,14 +3751,14 @@ resource "google_dataproc_cluster" "tf_test_cluster" {
     }
   }
 }
-`, clusterName)
+`, clusterName, testRegion)
 }
 
 func testAccDataprocCluster_withProvisionedIopsAndThroughputNodePools(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "tf_test_cluster" {
   name   = "%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 
@@ -3786,7 +3792,7 @@ resource "google_dataproc_cluster" "tf_test_cluster" {
     }
   }
 }
-`, clusterName)
+`, clusterName, testRegion)
 }
 
 func TestAccDataprocCluster_instanceFlexibilityDiskConfig(t *testing.T) {
@@ -3824,12 +3830,12 @@ func testAccDataprocCluster_instanceFlexibilityDiskConfig(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "instance_flexibility_disk_config" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n4-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -3864,7 +3870,7 @@ resource "google_dataproc_cluster" "instance_flexibility_disk_config" {
 		}
 	}
 }
-`, rnd)
+`, rnd, testRegion)
 }
 
 func TestAccDataprocCluster_AttachedDiskConfigMaster(t *testing.T) {
@@ -3937,7 +3943,7 @@ func testAccDataprocCluster_attachedDiskConfigMaster(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "attached_disk_config_master" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 
@@ -3955,24 +3961,24 @@ resource "google_dataproc_cluster" "attached_disk_config_master" {
     }
 		worker_config {
 			num_instances = 2
-			machine_type  = "n1-standard-2"
+			machine_type  = "n4-standard-2"
 		}
 	}
 }
-`, rnd)
+`, rnd, testRegion)
 }
 
 func testAccDataprocCluster_attachedDiskConfigWorker(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "attached_disk_config_worker" {
   name   = "tf-test-dproc-%s"
-  region = "asia-east1"
+  region = "%s"
 
   cluster_config {
 
 		master_config {
 			num_instances = 1
-			machine_type  = "n1-standard-2"
+			machine_type  = "n4-standard-2"
 		}
 
     worker_config {
@@ -3989,25 +3995,25 @@ resource "google_dataproc_cluster" "attached_disk_config_worker" {
 		}
 	}
 }
-`, rnd)
+`, rnd, testRegion)
 }
 
 func testAccDataprocCluster_attachedDiskConfigSecondary(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "attached_disk_config_secondary" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+  region = "%s"
 
   cluster_config {
 
 		master_config {
 			num_instances = 1
-			machine_type  = "n1-standard-2"
+			machine_type  = "n4-standard-2"
 		}
 
 		worker_config {
 			num_instances = 2
-			machine_type  = "n1-standard-2"
+			machine_type  = "n4-standard-2"
 		}
 		
 		preemptible_worker_config {
@@ -4037,5 +4043,5 @@ resource "google_dataproc_cluster" "attached_disk_config_secondary" {
 		}
 	}
 }
-`, rnd)
+`, rnd, testRegion)
 }


### PR DESCRIPTION
Configure Dataproc cluster acceptance tests to use package-level variables for regions, zones, and storage bucket locations rather than hardcoded string literals.

This simplifies relocating test resources when encountering regional stockouts or quota constraints.

```release-note:none

```
