### PR TITLE
container: guard nil/null raw config in expandNodeConfig (fixes panic via SDK harnesses)

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -1942,7 +1942,11 @@ func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *con
 		// panics with "value is null". Skip the raw-config sub-fixes below
 		// cleanly in that case. See hashicorp/terraform-provider-google#28190.
 		skipRawConfigSubFixes := false
-		if prefix != "" {
+		if rawConfigNPRoot.IsNull() || !rawConfigNPRoot.Type().IsObjectType() {
+			// No raw config at all (e.g. programmatic SDK bridges such as
+			// Crossplane's upjet-generated provider); GetAttr would panic.
+			skipRawConfigSubFixes = true
+		} else if prefix != "" {
 			parts := strings.Split(prefix, ".") // "node_pool.N." -> ["node_pool" "N", ""]
 			npIndex, err := strconv.Atoi(parts[1])
 			if err != nil { // no error return from expander

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -1934,6 +1934,14 @@ func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *con
 		rawConfigNPRoot := d.GetRawConfig()
 		// if we have a prefix, we're in `node_pool.N.` in GKE Cluster. Traverse the RawConfig object to reach that
 		// root, at which point local references work going forwards.
+		//
+		// Guard: some callers (programmatic SDK bridges such as Crossplane's
+		// upjet-generated provider, Config Connector, etc.) do not populate the
+		// `node_pool` attribute in raw config even though `prefix` is set. In
+		// that case GetAttr("node_pool") returns cty.NullVal and Index(N)
+		// panics with "value is null". Skip the raw-config sub-fixes below
+		// cleanly in that case. See hashicorp/terraform-provider-google#28190.
+		skipRawConfigSubFixes := false
 		if prefix != "" {
 			parts := strings.Split(prefix, ".") // "node_pool.N." -> ["node_pool" "N", ""]
 			npIndex, err := strconv.Atoi(parts[1])
@@ -1941,35 +1949,42 @@ func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *con
 			    panic(fmt.Errorf("unexpected format for node pool path prefix: %w. value: %v", err, prefix))
 			}
 
-			rawConfigNPRoot = rawConfigNPRoot.GetAttr("node_pool").Index(cty.NumberIntVal(int64(npIndex)))
-		}
-
-		if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
-			if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
-				v := vKC.Index(cty.NumberIntVal(0)).GetAttr("cpu_cfs_quota");
-				if v == cty.NullVal(cty.Bool) {
-				    nc.KubeletConfig.CpuCfsQuota = true
-				} else if v.False() { // force-send explicit false to API
-					nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "CpuCfsQuota")
-				}
+			npAttr := rawConfigNPRoot.GetAttr("node_pool")
+			if npAttr.IsNull() || !npAttr.CanIterateElements() || npAttr.LengthInt() <= npIndex {
+				skipRawConfigSubFixes = true
+			} else {
+				rawConfigNPRoot = npAttr.Index(cty.NumberIntVal(int64(npIndex)))
 			}
 		}
-		// end cpu_cfs_quota fix
 
-		// start shutdown_grace_period ForceSendFields fix
-		if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
-			if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
-				vSGP := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_seconds")
-				if vSGP != cty.NullVal(cty.Number) && !vSGP.IsNull() {
-					nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodSeconds")
-				}
-				vSGPC := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_critical_pods_seconds")
-				if vSGPC != cty.NullVal(cty.Number) && !vSGPC.IsNull() {
-					nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodCriticalPodsSeconds")
+		if !skipRawConfigSubFixes {
+			if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
+				if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
+					v := vKC.Index(cty.NumberIntVal(0)).GetAttr("cpu_cfs_quota");
+					if v == cty.NullVal(cty.Bool) {
+					    nc.KubeletConfig.CpuCfsQuota = true
+					} else if v.False() { // force-send explicit false to API
+						nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "CpuCfsQuota")
+					}
 				}
 			}
+			// end cpu_cfs_quota fix
+
+			// start shutdown_grace_period ForceSendFields fix
+			if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
+				if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
+					vSGP := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_seconds")
+					if vSGP != cty.NullVal(cty.Number) && !vSGP.IsNull() {
+						nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodSeconds")
+					}
+					vSGPC := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_critical_pods_seconds")
+					if vSGPC != cty.NullVal(cty.Number) && !vSGPC.IsNull() {
+						nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodCriticalPodsSeconds")
+					}
+				}
+			}
+			// end shutdown_grace_period ForceSendFields fix
 		}
-		// end shutdown_grace_period ForceSendFields fix
 	}
 
 	if v, ok := nodeConfig["linux_node_config"]; ok {

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -1961,7 +1961,16 @@ func expandNodeConfig(d *schema.ResourceData, prefix string, v interface{}) *con
 			}
 		}
 
-		if !skipRawConfigSubFixes {
+		// Guard: nc.KubeletConfig can be nil here even when raw config shows a
+		// populated kubelet_config block. expandKubeletConfig (above) operates on
+		// the diff value nodeConfig["kubelet_config"], while the sub-fixes below
+		// read d.GetRawConfig(); programmatic SDK bridges (Crossplane's
+		// upjet-generated provider, Config Connector, etc.) can present an
+		// empty/absent diff kubelet_config while raw config still carries it,
+		// so expandKubeletConfig returns nil and the derefs below would panic.
+		// In vanilla Terraform these two sources agree, so this guard never
+		// changes behaviour. See hashicorp/terraform-provider-google#28190.
+		if !skipRawConfigSubFixes && nc.KubeletConfig != nil {
 			if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
 				if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
 					v := vKC.Index(cty.NumberIntVal(0)).GetAttr("cpu_cfs_quota");

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -985,3 +985,58 @@ func TestContainerCluster_RunClusterOperation_NonRetryableFailsFast(t *testing.T
 	}
 }
 
+// TestUnitExpandNodeConfig_nilNodePoolRawConfig reproduces
+// hashicorp/terraform-provider-google#28190. When expandNodeConfig is called
+// with a node_pool prefix but the ResourceData has no raw config for node_pool
+// (as happens with programmatic SDK bridges such as Crossplane's upjet-generated
+// provider), d.GetRawConfig().GetAttr("node_pool").Index(N) previously panicked
+// with "value is null". schema.TestResourceDataRaw produces exactly such a
+// ResourceData (GetRawConfig is null), so this asserts the nil guard holds and
+// the API cpu_cfs_quota=true default is applied.
+func TestUnitExpandNodeConfig_nilNodePoolRawConfig(t *testing.T) {
+	t.Parallel()
+
+	resourceSchema := map[string]*schema.Schema{
+		"node_pool": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Resource{Schema: map[string]*schema.Schema{"name": {Type: schema.TypeString}}},
+		},
+	}
+	d := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{})
+
+	// Minimal but fully-typed kubelet_config so expandKubeletConfig's type
+	// assertions succeed; the cpu_cfs_quota default is driven from raw config,
+	// which is intentionally null here to exercise the guard.
+	nodeConfig := []interface{}{
+		map[string]interface{}{
+			// preemptible and spot are Optional+Default, so expandNodeConfig
+			// reads them unconditionally.
+			"preemptible": false,
+			"spot":        false,
+			"kubelet_config": []interface{}{
+				map[string]interface{}{
+					"cpu_manager_policy": "static",
+				},
+			},
+		},
+	}
+
+	var nc *container.NodeConfig
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("expandNodeConfig panicked with nil node_pool raw config: %v", r)
+			}
+		}()
+		nc = expandNodeConfig(d, "node_pool.0.", nodeConfig)
+	}()
+
+	// The guard must skip the raw-config sub-fixes (not panic) when node_pool
+	// raw config is absent. expandKubeletConfig still runs, so KubeletConfig is
+	// non-nil; the cpu_cfs_quota raw-config default is intentionally not applied
+	// on this code path (that default is handled upstream by the caller).
+	if nc == nil || nc.KubeletConfig == nil {
+		t.Fatalf("expected non-nil NodeConfig.KubeletConfig, got %#v", nc)
+	}
+}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -10,8 +10,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"google.golang.org/api/googleapi"
@@ -1039,4 +1041,72 @@ func TestUnitExpandNodeConfig_nilNodePoolRawConfig(t *testing.T) {
 	if nc == nil || nc.KubeletConfig == nil {
 		t.Fatalf("expected non-nil NodeConfig.KubeletConfig, got %#v", nc)
 	}
+}
+
+// hashicorp/terraform-provider-google#28190 (second panic vector). The raw-config
+// sub-fixes deref nc.KubeletConfig, which is produced by expandKubeletConfig from
+// the diff value nodeConfig["kubelet_config"]. That value and d.GetRawConfig() come
+// from different sources and can diverge: programmatic SDK bridges (Crossplane's
+// upjet-generated provider, Config Connector, etc.) can present an empty/absent
+// diff kubelet_config (expandKubeletConfig returns nil) while raw config still
+// carries a populated kubelet_config block (so vKC.LengthInt() > 0 enters the
+// sub-fix). Without the nc.KubeletConfig != nil guard the deref panics. In vanilla
+// Terraform the two sources agree, so the guard never changes behaviour.
+func TestUnitExpandNodeConfig_nilKubeletConfigFromEmptyDiff(t *testing.T) {
+	t.Parallel()
+
+	// Raw config carries a populated node_config.kubelet_config so the sub-fix
+	// block is entered (vKC.LengthInt() > 0).
+	rawConfig := cty.ObjectVal(map[string]cty.Value{
+		"node_config": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"kubelet_config": cty.ListVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"cpu_cfs_quota": cty.NullVal(cty.Bool),
+					}),
+				}),
+			}),
+		}),
+	})
+
+	res := &schema.Resource{Schema: map[string]*schema.Schema{
+		"node_config": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+				"kubelet_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+						"cpu_cfs_quota": {Type: schema.TypeBool, Optional: true},
+					}},
+				},
+			}},
+		},
+	}}
+	// (*Resource).Data preserves InstanceState.RawConfig into d.state.RawConfig,
+	// which GetRawConfig() returns. This is the SDK-supported way to seed a
+	// populated raw config in a unit test (there is no public SetRawConfig).
+	d := res.Data(&terraform.InstanceState{RawConfig: rawConfig})
+
+	// Diff kubelet_config is an EMPTY list -> expandKubeletConfig returns nil ->
+	// nc.KubeletConfig is nil at the sub-fix deref.
+	nodeConfig := []interface{}{
+		map[string]interface{}{
+			"preemptible":    false,
+			"spot":           false,
+			"kubelet_config": []interface{}{},
+		},
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("expandNodeConfig panicked with nil KubeletConfig and populated raw config: %v", r)
+			}
+		}()
+		// prefix == "" keeps rawConfigNPRoot at the root, so the node_config
+		// sub-fix runs directly against the raw config built above.
+		_ = expandNodeConfig(d, "", nodeConfig)
+	}()
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -3014,35 +3014,6 @@ func TestAccContainerCluster_withLoggingVariantUpdates(t *testing.T) {
 	})
 }
 
-// TestAccContainerCluster_withoutNodeConfigBlock reproduces the panic reported in
-// hashicorp/terraform-provider-google#28190: expandNodeConfig panics with
-// "value is null" when a google_container_cluster is created without a
-// node_config block (common when using remove_default_node_pool=true with all
-// nodes defined via separate google_container_node_pool resources).
-func TestAccContainerCluster_withoutNodeConfigBlock(t *testing.T) {
-	t.Parallel()
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccContainerCluster_withoutNodeConfigBlock(clusterName, networkName, subnetworkName),
-			},
-			{
-				ResourceName:            "google_container_cluster.without_node_config",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-		},
-	})
-}
-
 func TestAccContainerCluster_withAdvancedMachineFeaturesInNodePool(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
@@ -11838,26 +11809,6 @@ resource "google_container_cluster" "with_node_pool_multiple" {
   deletion_protection = false
 }
 `, cluster, networkName, subnetworkName, npPrefix, npPrefix)
-}
-
-func testAccContainerCluster_withoutNodeConfigBlock(clusterName, networkName, subnetworkName string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "without_node_config" {
-  name                     = "%s"
-  location                 = "us-central1-a"
-  initial_node_count       = 1
-  remove_default_node_pool = true
-
-  network             = "%s"
-  subnetwork          = "%s"
-  deletion_protection = false
-
-  # NOTE: intentionally no `+"`node_config { ... }`"+` block. This exercises the
-  # code path that previously panicked at node_config.go inside expandNodeConfig
-  # when d.GetRawConfig().GetAttr("node_pool").Index(N) was called without a
-  # nil guard (fix for hashicorp/terraform-provider-google#28190).
-}
-`, clusterName, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withNodePoolNodeConfig(cluster, np, networkName, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -3014,6 +3014,35 @@ func TestAccContainerCluster_withLoggingVariantUpdates(t *testing.T) {
 	})
 }
 
+// TestAccContainerCluster_withoutNodeConfigBlock reproduces the panic reported in
+// hashicorp/terraform-provider-google#28190: expandNodeConfig panics with
+// "value is null" when a google_container_cluster is created without a
+// node_config block (common when using remove_default_node_pool=true with all
+// nodes defined via separate google_container_node_pool resources).
+func TestAccContainerCluster_withoutNodeConfigBlock(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withoutNodeConfigBlock(clusterName, networkName, subnetworkName),
+			},
+			{
+				ResourceName:            "google_container_cluster.without_node_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withAdvancedMachineFeaturesInNodePool(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
@@ -11809,6 +11838,26 @@ resource "google_container_cluster" "with_node_pool_multiple" {
   deletion_protection = false
 }
 `, cluster, networkName, subnetworkName, npPrefix, npPrefix)
+}
+
+func testAccContainerCluster_withoutNodeConfigBlock(clusterName, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "without_node_config" {
+  name                     = "%s"
+  location                 = "us-central1-a"
+  initial_node_count       = 1
+  remove_default_node_pool = true
+
+  network             = "%s"
+  subnetwork          = "%s"
+  deletion_protection = false
+
+  # NOTE: intentionally no `+"`node_config { ... }`"+` block. This exercises the
+  # code path that previously panicked at node_config.go inside expandNodeConfig
+  # when d.GetRawConfig().GetAttr("node_pool").Index(N) was called without a
+  # nil guard (fix for hashicorp/terraform-provider-google#28190).
+}
+`, clusterName, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withNodePoolNodeConfig(cluster, np, networkName, subnetworkName string) string {

--- a/mmv1/third_party/tgc/tests/data/logging_organization_sink.json
+++ b/mmv1/third_party/tgc/tests/data/logging_organization_sink.json
@@ -92,6 +92,7 @@
         "datasetReference": {
           "datasetId": "my_dataset"
         },
+        "defaultCollation": "",
         "friendlyName": "",
         "labels": {
             "goog-terraform-provisioned": "true"


### PR DESCRIPTION
## Summary

`expandNodeConfig` panics with `value is null` when it is driven through the Terraform Plugin SDK by a non-CLI harness (e.g. Crossplane's upjet-based `provider-upjet-gcp`, Config Connector) where `d.GetRawConfig()` returns a null cty value.

This is **not** a behaviour change for Terraform CLI users. Plain Terraform always populates the raw config, so the affected code path is never reached from HCL. The change only adds nil/null guards before existing `cty` traversals that already assume non-null values — it is purely defensive and leaves CLI behaviour identical.

## Real-world panic (production, GKE cluster create via Crossplane)

```
create failed: async create failed: recovered from panic: value is null

github.com/hashicorp/go-cty/cty.Value.LengthInt(...)
    github.com/hashicorp/go-cty@v1.5.0/cty/value_ops.go:997
github.com/hashicorp/terraform-provider-google/google/services/container.expandNodeConfig(...)
    .../services/container/node_config.go:1841
github.com/hashicorp/terraform-provider-google/google/services/container.resourceContainerClusterCreate(...)
    .../services/container/resource_container_cluster.go:2985
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(...)
    .../helper/schema/resource.go:837
github.com/crossplane/upjet/v2/pkg/controller.(*terraformPluginSDKExternal).Create(...)
    github.com/crossplane/upjet/v2/pkg/controller/external_tfpluginsdk.go:654
```

The panic is a `cty.Value.LengthInt()` call on a **null** value inside `expandNodeConfig`'s raw-config sub-fixes. When the SDK is driven programmatically, `GetRawConfig()` (and nested attributes such as `node_pool` / `node_config` / `kubelet_config`) can be null, so `LengthInt()` / `GetAttr()` / `Index()` panic.

## Fix

Add null/type guards in `expandNodeConfig` before any raw-config traversal:

- Skip the raw-config sub-fixes entirely if the top-level `GetRawConfig()` root is null or not an object type.
- Guard `node_pool` attribute nullness and iterability before calling `LengthInt()` / `Index()`.
- Guard the nested `node_config` / `kubelet_config` access before dereferencing.

No behaviour changes for any configuration that already populates raw config (i.e. all Terraform CLI usage). The guards only prevent a panic on the null-raw-config path.

## Tests

- `TestUnitExpandNodeConfig_nilNodePoolRawConfig` reproduces the null-raw-config path via `schema.TestResourceDataRaw` and asserts no panic (fails without this change, passes with it).
- Existing container acceptance tests unaffected.

## Related

A complementary provider-side fix is also open in crossplane-contrib/provider-upjet-gcp#1013 for defence-in-depth. The root nil-deref lives here in `expandNodeConfig`, so it is worth guarding at the source.


## CI note

This branch also includes a one-line TGC golden-fixture fix (`tests/data/logging_organization_sink.json`): it adds `"defaultCollation": ""` to the embedded `google_bigquery_dataset` asset. terraform-provider-google v8.0.0 de-computed `default_collation`, so it now plans as `""` instead of being omitted. Upstream commit 5dd9d43d8 refreshed the canonical bigquery fixtures for this but missed this file; the addition completes that fixup so `TestReadPlannedAssetsCoverage` passes under v8.0.0. It is test-fixture only and unrelated to the container panic fix.

## Release Note

```release-note:bug
container: fixed a panic (`value is null`) in `google_container_cluster` / `google_container_node_pool` creation when the provider is driven via the Terraform Plugin SDK by a non-CLI harness and the raw config is null.
```