### PR TITLE
vertexai: promote build_spec to GA for google_vertex_ai_reasoning_engine

### DIFF
--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -937,7 +937,6 @@ properties:
           function: 'validation.StringIsJSON'
       - name: 'buildSpec'
         type: NestedObject
-        min_version: 'beta'
         description: |-
           Optional. Configuration for building container image.
         properties:

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_full.tf.tmpl
@@ -39,6 +39,10 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
     class_methods   = jsonencode(local.class_methods)
     service_account = google_service_account.service_account.email
 
+    build_spec {
+      service_account = google_service_account.service_account.email
+    }
+
     deployment_spec {
       min_instances         = 1
       max_instances         = 3


### PR DESCRIPTION
Promote `build_spec` (including `service_account` and `worker_pool`) to GA for `google_vertex_ai_reasoning_engine`.

Fixes https://b.corp.google.com/issues/548697273

Fixes the current TestAccVertexAIReasoningEngine_vertexAiReasoningEngineUpdate failure as well. (Currently failing due to this field not being GA.)

```release-note:enhancement
vertexai: promoted `build_spec` to GA in `google_vertex_ai_reasoning_engine`
```
