### PR TITLE
observability: add google_observability_link resource

### DIFF
--- a/mmv1/products/observability/Link.yaml
+++ b/mmv1/products/observability/Link.yaml
@@ -1,0 +1,103 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Link
+description: Link configuration for exposing observability dataset data.
+base_url: projects/{{project}}/locations/{{location}}/buckets/{{bucket}}/datasets/{{dataset}}/links
+self_link: projects/{{project}}/locations/{{location}}/buckets/{{bucket}}/datasets/{{dataset}}/links/{{link_id}}
+create_url: projects/{{project}}/locations/{{location}}/buckets/{{bucket}}/datasets/{{dataset}}/links?linkId={{link_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/buckets/{{bucket}}/datasets/{{dataset}}/links/{{link_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/buckets/{{bucket}}/datasets/{{dataset}}/links/{{link_id}}
+  - '{{project}}/{{location}}/{{bucket}}/{{dataset}}/{{link_id}}'
+  - '{{location}}/{{bucket}}/{{dataset}}/{{link_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  operation:
+    timeouts:
+      insert_minutes: 20
+      update_minutes: 20
+      delete_minutes: 20
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - update
+    - delete
+  result:
+    resource_inside_response: true
+autogen_status: TGlua0F1dG9nZW5WMkFnZW50
+autogen_async: true
+samples:
+  - name: "observability_link_basic"
+    primary_resource_id: "primary"
+    external_providers: [time]
+    steps:
+      - name: "observability_link_basic"
+        resource_id_vars:
+          link_id: "link_test"
+        vars:
+          display_name: "Initial Display Name"
+          description: "Initial description"
+      - name: "observability_link_basic"
+        resource_id_vars:
+          link_id: "link_test"
+        vars:
+          display_name: "Updated Display Name"
+          description: "Updated description"
+parameters:
+  - name: location
+    type: String
+    description: The location of the link.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: bucket
+    type: String
+    description: The bucket of the link.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: dataset
+    type: String
+    description: The dataset of the link.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: linkId
+    type: String
+    description: The client-assigned identifier for the link.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: createTime
+    type: String
+    description: Output only. Create timestamp.
+    output: true
+  - name: description
+    type: String
+    description: Description of the link.
+  - name: displayName
+    type: String
+    description: User friendly display name.
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the link. The format is: projects/[PROJECT_ID]/locations/[LOCATION]/buckets/[BUCKET_ID]/datasets/[DATASET_ID]/links/[LINK_ID]
+    output: true

--- a/mmv1/templates/terraform/samples/services/observability/observability_link_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/observability/observability_link_basic.tf.tmpl
@@ -1,0 +1,42 @@
+# Force the creation of the Service Agent identity
+resource "google_project_service_identity" "observability_sa" {
+  service = "observability.googleapis.com"
+}
+
+# Buffer for the new identity to propagate to global IAM indexes
+resource "time_sleep" "wait_for_sa_propagation" {
+  create_duration = "30s"
+  depends_on      = [
+    google_project_service_identity.observability_sa
+  ]
+}
+
+resource "google_project_iam_member" "observability_sa_bq_admin" {
+  project = google_project_service_identity.observability_sa.project
+  role    = "roles/bigquery.admin"
+  member  = "serviceAccount:${google_project_service_identity.observability_sa.email}"
+
+  depends_on = [
+    time_sleep.wait_for_sa_propagation
+  ]
+}
+
+resource "google_observability_bucket" "bucket" {
+  bucket_id    = "_Trace"
+  location     = "us"
+  display_name = "Bucket for Link"
+  description  = "Bucket for testing Link"
+}
+
+resource "google_observability_link" "{{$.PrimaryResourceId}}" {
+  location     = google_observability_bucket.bucket.location
+  bucket       = google_observability_bucket.bucket.bucket_id
+  dataset      = "Spans"
+  link_id      = "{{index $.ResourceIdVars "link_id"}}"
+  display_name = "{{index $.Vars "display_name"}}"
+  description  = "{{index $.Vars "description"}}"
+
+  depends_on = [
+    google_project_iam_member.observability_sa_bq_admin,
+  ]
+}


### PR DESCRIPTION
Adds Terraform support for the `google_observability_link` resource to expose observability dataset data (e.g. BigQuery linked datasets).

```release-note:new-resource
`google_observability_link`
```