### PR TITLE
gemini: add gemini_enterprise_project and release_channel to google_gemini_gemini_gcp_enablement_setting

### DIFF
--- a/mmv1/products/gemini/GeminiGcpEnablementSetting.yaml
+++ b/mmv1/products/gemini/GeminiGcpEnablementSetting.yaml
@@ -83,3 +83,18 @@ properties:
   - name: mutationsEnabled
     type: Boolean
     description: Whether resource mutations should be enabled.
+  - name: geminiEnterpriseProject
+    type: String
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+    description: |-
+      The Gemini enterprise project for this setting.
+      Format: projects/{project}
+      The `{project}` segment can be the project ID or project number.
+  - name: releaseChannel
+    type: Enum
+    diff_suppress_func: 'tpgresource.EmptyOrDefaultStringSuppress("CHANNEL_TYPE_UNSPECIFIED")'
+    description: |-
+      Specifies the release channel for Gemini features. The release channel determines which set of features are available to the user.
+    enum_values:
+      - 'STABLE'
+      - 'EXPERIMENTAL'

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gemini_gcp_enablement_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gemini_gcp_enablement_setting_basic.tf.tmpl
@@ -5,4 +5,5 @@ resource "google_gemini_gemini_gcp_enablement_setting" "{{$.PrimaryResourceId}}"
     enable_customer_data_sharing = true
     web_grounding_type = "WEB_GROUNDING_FOR_ENTERPRISE"
     mutations_enabled = true
+    release_channel = "EXPERIMENTAL"
 }

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_test.go
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/gemini"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 )
 
 func TestAccGeminiGeminiGcpEnablementSetting_geminiGeminiGcpEnablementSettingBasicExample_update(t *testing.T) {
@@ -47,6 +48,9 @@ func TestAccGeminiGeminiGcpEnablementSetting_geminiGeminiGcpEnablementSettingBas
 }
 func testAccGeminiGeminiGcpEnablementSetting_geminiGeminiGcpEnablementSettingBasicExample_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
 resource "google_gemini_gemini_gcp_enablement_setting" "example" {
     gemini_gcp_enablement_setting_id = "%{setting_id}"
     location = "global"
@@ -54,11 +58,16 @@ resource "google_gemini_gemini_gcp_enablement_setting" "example" {
     enable_customer_data_sharing = true
 	web_grounding_type = "WEB_GROUNDING_FOR_ENTERPRISE"
 	mutations_enabled = true
+    release_channel = "EXPERIMENTAL"
+    gemini_enterprise_project = "projects/${data.google_project.project.project_id}"
 }
 `, context)
 }
 func testAccGeminiGeminiGcpEnablementSetting_geminiGeminiGcpEnablementSettingBasicExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
 resource "google_gemini_gemini_gcp_enablement_setting" "example" {
     gemini_gcp_enablement_setting_id = "%{setting_id}"
     location = "global"
@@ -66,6 +75,8 @@ resource "google_gemini_gemini_gcp_enablement_setting" "example" {
     enable_customer_data_sharing = false
 	web_grounding_type = "GROUNDING_WITH_GOOGLE_SEARCH"
 	mutations_enabled = false
+    release_channel = "STABLE"
+    gemini_enterprise_project = "projects/${data.google_project.project.number}"
 }
 `, context)
 }


### PR DESCRIPTION
Adds missing fields `gemini_enterprise_project` and `release_channel` to `google_gemini_gemini_gcp_enablement_setting`.

reference: b/550549339

```release-note:enhancement
gemini: added `gemini_enterprise_project` and `release_channel` fields to `google_gemini_gemini_gcp_enablement_setting`
```
