### PR TITLE
container: preserve explicit STANDARD PMU plans

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -1323,7 +1323,6 @@ func schemaNodeConfig() *schema.Schema {
 							"performance_monitoring_unit": {
 								Type: schema.TypeString,
 								Optional: true,
-								DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("STANDARD"),
 								ValidateFunc: verify.ValidateEnum([]string{"ARCHITECTURAL", "STANDARD", "ENHANCED"}),
 								Description: `Level of Performance Monitoring Unit (PMU) requested. If unset, no access to the PMU is assumed.`,
 							},

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -1323,6 +1323,7 @@ func schemaNodeConfig() *schema.Schema {
 							"performance_monitoring_unit": {
 								Type: schema.TypeString,
 								Optional: true,
+								ForceNew: true,
 								ValidateFunc: verify.ValidateEnum([]string{"ARCHITECTURAL", "STANDARD", "ENHANCED"}),
 								Description: `Level of Performance Monitoring Unit (PMU) requested. If unset, no access to the PMU is assumed.`,
 							},

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -263,6 +263,19 @@ func schemaTaintConfig() *schema.Schema {
 	}
 }
 
+func containerPerformanceMonitoringUnitDiffSuppress(_ string, old, new string, d *schema.ResourceData) bool {
+	// DiffSuppressFunc runs during planning, before IsNewResource is marked during apply.
+	// An empty ID identifies a resource that does not exist in state yet.
+	if d == nil || d.Id() == "" {
+		return false
+	}
+
+	// Existing resources may have recorded an empty value after the suppressor from
+	// https://github.com/GoogleCloudPlatform/magic-modules/pull/17887 omitted an
+	// explicitly configured STANDARD value during creation.
+	return (old == "" && new == "STANDARD") || (old == "STANDARD" && new == "")
+}
+
 func schemaNodeConfig() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
@@ -1321,11 +1334,11 @@ func schemaNodeConfig() *schema.Schema {
 								Description: `Whether the node should have nested virtualization enabled.`,
 							},
 							"performance_monitoring_unit": {
-								Type: schema.TypeString,
-								Optional: true,
-								ForceNew: true,
-								ValidateFunc: verify.ValidateEnum([]string{"ARCHITECTURAL", "STANDARD", "ENHANCED"}),
-								Description: `Level of Performance Monitoring Unit (PMU) requested. If unset, no access to the PMU is assumed.`,
+								Type:             schema.TypeString,
+								Optional:         true,
+								ValidateFunc:     verify.ValidateEnum([]string{"ARCHITECTURAL", "STANDARD", "ENHANCED"}),
+								DiffSuppressFunc: containerPerformanceMonitoringUnitDiffSuppress,
+								Description:      `Level of Performance Monitoring Unit (PMU) requested. If unset, no access to the PMU is assumed. For existing node pools with no PMU, setting STANDARD may not produce a diff; recreate the node pool to apply it.`,
 							},
 						},
 					},

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_internal_test.go.tmpl
@@ -38,6 +38,17 @@ func TestPerformanceMonitoringUnitStandardPlan(t *testing.T) {
 	}
 }
 
+func TestPerformanceMonitoringUnitChangeRequiresReplacement(t *testing.T) {
+	t.Parallel()
+
+	nodeConfigResource := schemaNodeConfig().Elem.(*schema.Resource)
+	advancedMachineFeatures := nodeConfigResource.Schema["advanced_machine_features"].Elem.(*schema.Resource)
+	pmu := advancedMachineFeatures.Schema["performance_monitoring_unit"]
+	if !pmu.ForceNew {
+		t.Fatal("performance_monitoring_unit changes must require node pool replacement")
+	}
+}
+
 func TestUnitFlattenNodePool(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_internal_test.go.tmpl
@@ -1,11 +1,13 @@
 package container
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 {{ if eq $.TargetVersionName `ga` }}
@@ -38,14 +40,70 @@ func TestPerformanceMonitoringUnitStandardPlan(t *testing.T) {
 	}
 }
 
-func TestPerformanceMonitoringUnitChangeRequiresReplacement(t *testing.T) {
+func TestPerformanceMonitoringUnitExistingResourcePlan(t *testing.T) {
 	t.Parallel()
 
 	nodeConfigResource := schemaNodeConfig().Elem.(*schema.Resource)
 	advancedMachineFeatures := nodeConfigResource.Schema["advanced_machine_features"].Elem.(*schema.Resource)
 	pmu := advancedMachineFeatures.Schema["performance_monitoring_unit"]
-	if !pmu.ForceNew {
-		t.Fatal("performance_monitoring_unit changes must require node pool replacement")
+	resource := &schema.Resource{Schema: map[string]*schema.Schema{
+		"performance_monitoring_unit": pmu,
+	}}
+	state := &terraform.InstanceState{
+		ID: "existing",
+		Attributes: map[string]string{
+			"performance_monitoring_unit": "",
+		},
+	}
+	config := terraform.NewResourceConfigRaw(map[string]interface{}{
+		"performance_monitoring_unit": "STANDARD",
+	})
+
+	diff, err := resource.Diff(context.Background(), state, config, nil)
+	if err != nil {
+		t.Fatalf("planning existing resource: %s", err)
+	}
+	if diff != nil {
+		t.Fatalf("existing resource unexpectedly planned empty to STANDARD change: %#v", diff.Attributes)
+	}
+}
+
+func TestPerformanceMonitoringUnitDiffSuppress(t *testing.T) {
+	t.Parallel()
+
+	nodeConfigResource := schemaNodeConfig().Elem.(*schema.Resource)
+	advancedMachineFeatures := nodeConfigResource.Schema["advanced_machine_features"].Elem.(*schema.Resource)
+	pmu := advancedMachineFeatures.Schema["performance_monitoring_unit"]
+	if pmu.ForceNew {
+		t.Fatal("performance_monitoring_unit must not unexpectedly replace existing node pools")
+	}
+	if pmu.DiffSuppressFunc == nil {
+		t.Fatal("performance_monitoring_unit must have a compatibility diff suppressor")
+	}
+
+	newResource := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
+	existingResource := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
+	existingResource.SetId("existing")
+
+	cases := map[string]struct {
+		old, new string
+		data     *schema.ResourceData
+		want     bool
+	}{
+		"new resource preserves standard":                       {old: "", new: "STANDARD", data: newResource, want: false},
+		"existing resource suppresses empty to standard":        {old: "", new: "STANDARD", data: existingResource, want: true},
+		"existing resource suppresses standard to empty":        {old: "STANDARD", new: "", data: existingResource, want: true},
+		"existing resource preserves empty to architectural":    {old: "", new: "ARCHITECTURAL", data: existingResource, want: false},
+		"existing resource preserves architectural to standard": {old: "ARCHITECTURAL", new: "STANDARD", data: existingResource, want: false},
+		"nil resource does not suppress":                         {old: "", new: "STANDARD", data: nil, want: false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := pmu.DiffSuppressFunc("performance_monitoring_unit", tc.old, tc.new, tc.data); got != tc.want {
+				t.Fatalf("DiffSuppressFunc(%q, %q) = %t, want %t", tc.old, tc.new, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_internal_test.go.tmpl
@@ -15,6 +15,29 @@ import (
 {{ end }}
 )
 
+func TestPerformanceMonitoringUnitStandardPlan(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
+		"node_config": schemaNodeConfig(),
+	}, map[string]interface{}{
+		"node_config": []interface{}{
+			map[string]interface{}{
+				"advanced_machine_features": []interface{}{
+					map[string]interface{}{
+						"threads_per_core":            2,
+						"performance_monitoring_unit": "STANDARD",
+					},
+				},
+			},
+		},
+	})
+
+	if got := d.Get("node_config.0.advanced_machine_features.0.performance_monitoring_unit"); got != "STANDARD" {
+		t.Fatalf("performance_monitoring_unit = STANDARD planned as %q", got)
+	}
+}
+
 func TestUnitFlattenNodePool(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1348,6 +1348,8 @@ sole_tenant_config {
 
 * `performance_monitoring_unit` - (Optional) Defines the performance monitoring unit [PMU](https://cloud.google.com/compute/docs/pmu-overview) level. Valid values are `ARCHITECTURAL`, `STANDARD`, or `ENHANCED`. Defaults to off.
 
+~> **Note:** Early 8.x provider versions dropped an explicitly configured `STANDARD` value when creating the resource. On affected node pools the diff stays suppressed and this field cannot be updated in place, so enabling `STANDARD` requires recreating the node pool.
+
 <a name="nested_ephemeral_storage_config"></a>The `ephemeral_storage_config` block supports:
 
 * `local_ssd_count` (Required) - Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD is 375 GB in size. If zero, it means to disable using local SSDs as ephemeral storage.


### PR DESCRIPTION
Explicit `STANDARD` PMU settings in GKE node configuration were treated as equivalent to an unset value. Because unset disables PMU for GKE, the provider could omit the requested level when creating a node pool or cluster.

This regression was introduced by [Magic Modules #17887](https://github.com/GoogleCloudPlatform/magic-modules/pull/17887) and generated downstream in [terraform-provider-google #28004](https://github.com/hashicorp/terraform-provider-google/pull/28004). That change fixed [terraform-provider-google #24761](https://github.com/hashicorp/terraform-provider-google/issues/24761), where the Compute Engine API began returning `STANDARD` when Compute resources omitted the field. The same suppression was also applied to Container node configuration, although GKE uses different omission semantics.

Minimal reproduction:

```hcl
resource "google_container_node_pool" "example" {
  name     = "example"
  cluster  = google_container_cluster.example.name
  location = "us-central1-a"

  node_config {
    machine_type = "c4-standard-4"

    advanced_machine_features {
      threads_per_core            = 2
      performance_monitoring_unit = "STANDARD"
    }
  }
}
```

The compatibility fix distinguishes creation from existing state:

- New resources preserve explicit `STANDARD` in the plan and create request.
- Existing resources continue suppressing empty ↔ `STANDARD` differences, avoiding surprise diffs for resources created by affected provider versions.

This does not add `ForceNew`. Users who want to enable `STANDARD` on an affected existing resource must explicitly recreate it, as documented on the field. The Compute instance and instance-template behavior remains unchanged.

Tests:
- `./.agents/skills/utils/run-pre-gen-checks/scripts/run_pre_gen_checks.sh`
- Generated GA and beta providers
- `go test ./google/services/container -run '^TestPerformanceMonitoringUnit' -count=1`
- `go test ./google-beta/services/container -run '^TestPerformanceMonitoringUnit' -count=1`
- `make build` in both generated providers
- Schema validation reports no breaking changes and no missing documentation

```release-note:bug
container: fixed explicit `STANDARD` performance monitoring unit settings being omitted when creating GKE resources
```
