### PR TITLE
ces: add proactive_execution_enabled to ces_guardrail code_callback

### DIFF
--- a/mmv1/products/ces/Guardrail.yaml
+++ b/mmv1/products/ces/Guardrail.yaml
@@ -175,6 +175,15 @@ properties:
             description: |-
               Whether the callback is disabled. Disabled callbacks are ignored by the
               agent.
+          - name: proactiveExecutionEnabled
+            type: Boolean
+            description: |-
+              If enabled, the callback will also be executed on intermediate model
+              outputs. This setting only affects after model callback.
+              **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+              executed after receiving all model responses. Enabling proactive execution
+              may have negative implication on the execution cost and latency, and
+              should only be enabled in rare situations.
           - name: pythonCode
             type: String
             required: true
@@ -193,6 +202,15 @@ properties:
             description: |-
               Whether the callback is disabled. Disabled callbacks are ignored by the
               agent.
+          - name: proactiveExecutionEnabled
+            type: Boolean
+            description: |-
+              If enabled, the callback will also be executed on intermediate model
+              outputs. This setting only affects after model callback.
+              **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+              executed after receiving all model responses. Enabling proactive execution
+              may have negative implication on the execution cost and latency, and
+              should only be enabled in rare situations.
           - name: pythonCode
             type: String
             required: true
@@ -211,6 +229,15 @@ properties:
             description: |-
               Whether the callback is disabled. Disabled callbacks are ignored by the
               agent.
+          - name: proactiveExecutionEnabled
+            type: Boolean
+            description: |-
+              If enabled, the callback will also be executed on intermediate model
+              outputs. This setting only affects after model callback.
+              **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+              executed after receiving all model responses. Enabling proactive execution
+              may have negative implication on the execution cost and latency, and
+              should only be enabled in rare situations.
           - name: pythonCode
             type: String
             required: true
@@ -229,6 +256,15 @@ properties:
             description: |-
               Whether the callback is disabled. Disabled callbacks are ignored by the
               agent.
+          - name: proactiveExecutionEnabled
+            type: Boolean
+            description: |-
+              If enabled, the callback will also be executed on intermediate model
+              outputs. This setting only affects after model callback.
+              **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+              executed after receiving all model responses. Enabling proactive execution
+              may have negative implication on the execution cost and latency, and
+              should only be enabled in rare situations.
           - name: pythonCode
             type: String
             required: true

--- a/mmv1/templates/terraform/samples/services/ces/ces_guardrail_code_callback.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_guardrail_code_callback.tf.tmpl
@@ -47,6 +47,7 @@ resource "google_ces_guardrail" "ces_guardrail_code_callback" {
         description = "Example callback"
         disabled    = true
         python_code = "def callback(context):\n    return {'override': False}"
+        proactive_execution_enabled = true
     }
   }
 }

--- a/mmv1/third_party/terraform/services/ces/ces_guardrail_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_guardrail_test.go
@@ -469,21 +469,25 @@ resource "google_ces_guardrail" "ces_guardrail_code_callback" {
         description = "Example callback"
         disabled    = false
         python_code = "def callback(context):\n    return {'override': true}"
+        proactive_execution_enabled = false
     }
     after_agent_callback {
         description = "Example callback"
         disabled    = true
         python_code = "def callback(context):\n    return {'override': true}"
+        proactive_execution_enabled = false
     }
     before_model_callback {
         description = "Example callback"
         disabled    = true
         python_code = "def callback(context):\n    return {'override': true}"
+        proactive_execution_enabled = false
     }
     after_model_callback {
         description = "Example callback"
         disabled    = true
         python_code = "def callback(context):\n    return {'override': true}"
+        proactive_execution_enabled = false
     }
   }
 }
@@ -526,21 +530,25 @@ resource "google_ces_guardrail" "ces_guardrail_code_callback" {
         description = "Example callback updated"
         disabled    = true
         python_code = "def callback(context):\n    return {'override': False}"
+        proactive_execution_enabled = true
     }
     after_agent_callback {
         description = "Example callback updated"
         disabled    = true
         python_code = "def callback(context):\n    return {'override': False}"
+        proactive_execution_enabled = true
     }
     before_model_callback {
         description = "Example callback updated"
         disabled    = true
         python_code = "def callback(context):\n    return {'override': False}"
+        proactive_execution_enabled = true
     }
     after_model_callback {
         description = "Example callback updated"
         disabled    = true
         python_code = "def callback(context):\n    return {'override': False}"
+        proactive_execution_enabled = true
     }
   }
 }


### PR DESCRIPTION
Add support for `proactive_execution_enabled` on `code_callback` callbacks in `google_ces_guardrail`.

reference: b/550548731

```release-note:enhancement
ces: added `proactive_execution_enabled` field to `google_ces_guardrail`
```
