### PR TITLE
ces: add blob field to google_ces_example

### DIFF
--- a/mmv1/products/ces/Example.yaml
+++ b/mmv1/products/ces/Example.yaml
@@ -116,6 +116,18 @@ properties:
                       handle the conversation from this point forward.
                       Format: `projects/{project}/locations/{location}/apps/{app}/agents/{agent}`
                     required: true
+              - name: blob
+                type: NestedObject
+                description: Represents a blob input or output in the conversation.
+                properties:
+                  - name: data
+                    type: String
+                    description: Raw bytes of the blob.
+                    required: true
+                  - name: mimeType
+                    type: String
+                    description: The IANA standard MIME type of the source data.
+                    required: true
               - name: image
                 type: NestedObject
                 description: Represents an image input or output in the conversation.

--- a/mmv1/third_party/terraform/services/ces/ces_example_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_example_test.go
@@ -153,6 +153,12 @@ resource "google_ces_example" "my-example" {
             }
         }
         chunks {
+            blob {
+                mime_type = "text/plain"
+                data = base64encode("This is some sample plain text blob data.")
+            }
+        }
+        chunks {
             image {
                 mime_type = "image/png"
                 data = base64encode("This is some fake image binary data.")
@@ -319,6 +325,12 @@ resource "google_ces_example" "my-example" {
         chunks {
             agent_transfer {
                 target_agent = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/agents/${google_ces_agent.ces_child_agent.agent_id}"
+            }
+        }
+        chunks {
+            blob {
+                mime_type = "text/plain"
+                data = base64encode("This is some updated sample plain text blob data.")
             }
         }
         chunks {


### PR DESCRIPTION
Add support for `blob` field in `google_ces_example`.

reference: b/550548624

```release-note:enhancement
ces: added `blob` field to `google_ces_example`
```
