### PR TITLE
cloudsecuritycompliance: add nested parameter_spec fields to google_cloud_security_compliance_cloud_control

### DIFF
--- a/mmv1/products/cloudsecuritycompliance/CloudControl.yaml
+++ b/mmv1/products/cloudsecuritycompliance/CloudControl.yaml
@@ -178,6 +178,36 @@ properties:
                     - name: numberValue
                       type: Double
                       description: Represents a double value.
+                    - name: oneofValue
+                      type: NestedObject
+                      description: Sub-parameter values.
+                      properties:
+                        - name: name
+                          type: String
+                          description: The name of the parameter.
+                        - name: parameterValue
+                          type: NestedObject
+                          description: The value of the parameter.
+                          properties:
+                            - name: boolValue
+                              type: Boolean
+                              description: Represents a boolean value.
+                            - name: numberValue
+                              type: Double
+                              description: Represents a double value.
+                            - name: stringListValue
+                              type: NestedObject
+                              description: A list of strings.
+                              properties:
+                                - name: values
+                                  type: Array
+                                  description: The strings in the list.
+                                  required: true
+                                  item_type:
+                                    type: String
+                            - name: stringValue
+                              type: String
+                              description: Represents a string value.
                     - name: stringListValue
                       type: NestedObject
                       description: A list of strings.
@@ -273,6 +303,36 @@ properties:
                           - name: numberValue
                             type: Double
                             description: Represents a double value.
+                          - name: oneofValue
+                            type: NestedObject
+                            description: Sub-parameter values.
+                            properties:
+                              - name: name
+                                type: String
+                                description: The name of the parameter.
+                              - name: parameterValue
+                                type: NestedObject
+                                description: The value of the parameter.
+                                properties:
+                                  - name: boolValue
+                                    type: Boolean
+                                    description: Represents a boolean value.
+                                  - name: numberValue
+                                    type: Double
+                                    description: Represents a double value.
+                                  - name: stringListValue
+                                    type: NestedObject
+                                    description: A list of strings.
+                                    properties:
+                                      - name: values
+                                        type: Array
+                                        description: The strings in the list.
+                                        required: true
+                                        item_type:
+                                          type: String
+                                  - name: stringValue
+                                    type: String
+                                    description: Represents a string value.
                           - name: stringListValue
                             type: NestedObject
                             description: A list of strings.
@@ -373,6 +433,36 @@ properties:
                                     - name: numberValue
                                       type: Double
                                       description: Represents a double value.
+                                    - name: oneofValue
+                                      type: NestedObject
+                                      description: Sub-parameter values.
+                                      properties:
+                                        - name: name
+                                          type: String
+                                          description: The name of the parameter.
+                                        - name: parameterValue
+                                          type: NestedObject
+                                          description: The value of the parameter.
+                                          properties:
+                                            - name: boolValue
+                                              type: Boolean
+                                              description: Represents a boolean value.
+                                            - name: numberValue
+                                              type: Double
+                                              description: Represents a double value.
+                                            - name: stringListValue
+                                              type: NestedObject
+                                              description: A list of strings.
+                                              properties:
+                                                - name: values
+                                                  type: Array
+                                                  description: The strings in the list.
+                                                  required: true
+                                                  item_type:
+                                                    type: String
+                                            - name: stringValue
+                                              type: String
+                                              description: Represents a string value.
                                     - name: stringListValue
                                       type: NestedObject
                                       description: A list of strings.
@@ -419,6 +509,196 @@ properties:
                         type: String
                         description: Regex Pattern to match the value(s) of parameter.
                         required: true
+              - name: subParameters
+                type: Array
+                description: The parameter spec of the cloud control.
+                item_type:
+                  type: NestedObject
+                  properties:
+                    - name: defaultValue
+                      type: NestedObject
+                      description: Possible parameter value types.
+                      properties:
+                        - name: boolValue
+                          type: Boolean
+                          description: Represents a boolean value.
+                        - name: numberValue
+                          type: Double
+                          description: Represents a double value.
+                        - name: oneofValue
+                          type: NestedObject
+                          description: Sub-parameter values.
+                          properties:
+                            - name: name
+                              type: String
+                              description: The name of the parameter.
+                            - name: parameterValue
+                              type: NestedObject
+                              description: The value of the parameter.
+                              properties:
+                                - name: boolValue
+                                  type: Boolean
+                                  description: Represents a boolean value.
+                                - name: numberValue
+                                  type: Double
+                                  description: Represents a double value.
+                                - name: stringListValue
+                                  type: NestedObject
+                                  description: A list of strings.
+                                  properties:
+                                    - name: values
+                                      type: Array
+                                      description: The strings in the list.
+                                      required: true
+                                      item_type:
+                                        type: String
+                                - name: stringValue
+                                  type: String
+                                  description: Represents a string value.
+                        - name: stringListValue
+                          type: NestedObject
+                          description: A list of strings.
+                          properties:
+                            - name: values
+                              type: Array
+                              description: The strings in the list.
+                              required: true
+                              item_type:
+                                type: String
+                        - name: stringValue
+                          type: String
+                          description: Represents a string value.
+                    - name: description
+                      type: String
+                      description: The description of the parameter. The maximum length is 2000 characters.
+                    - name: displayName
+                      type: String
+                      description: The display name of the parameter. The maximum length is 200 characters.
+                    - name: isRequired
+                      type: Boolean
+                      description: if the parameter is required
+                      required: true
+                    - name: name
+                      type: String
+                      description: The name of the parameter.
+                      required: true
+                    - name: substitutionRules
+                      type: Array
+                      description: List of parameter substitutions.
+                      item_type:
+                        type: NestedObject
+                        properties:
+                          - name: attributeSubstitutionRule
+                            type: NestedObject
+                            description: Attribute at the given path is substituted entirely.
+                            properties:
+                              - name: attribute
+                                type: String
+                                description: |-
+                                  Fully qualified proto attribute path (in dot notation).
+                                  Example: rules[0].cel_expression.resource_types_values
+                          - name: placeholderSubstitutionRule
+                            type: NestedObject
+                            description: Placeholder is substituted in the rendered string.
+                            properties:
+                              - name: attribute
+                                type: String
+                                description: Fully qualified proto attribute path (e.g., dot notation)
+                    - name: validation
+                      type: NestedObject
+                      description: Validation of the parameter.
+                      properties:
+                        - name: allowedValues
+                          type: NestedObject
+                          description: Allowed set of values for the parameter.
+                          properties:
+                            - name: values
+                              type: Array
+                              description: List of allowed values for the parameter.
+                              required: true
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: boolValue
+                                    type: Boolean
+                                    description: Represents a boolean value.
+                                  - name: numberValue
+                                    type: Double
+                                    description: Represents a double value.
+                                  - name: oneofValue
+                                    type: NestedObject
+                                    description: Sub-parameter values.
+                                    properties:
+                                      - name: name
+                                        type: String
+                                        description: The name of the parameter.
+                                      - name: parameterValue
+                                        type: NestedObject
+                                        description: The value of the parameter.
+                                        properties:
+                                          - name: boolValue
+                                            type: Boolean
+                                            description: Represents a boolean value.
+                                          - name: numberValue
+                                            type: Double
+                                            description: Represents a double value.
+                                          - name: stringListValue
+                                            type: NestedObject
+                                            description: A list of strings.
+                                            properties:
+                                              - name: values
+                                                type: Array
+                                                description: The strings in the list.
+                                                required: true
+                                                item_type:
+                                                  type: String
+                                          - name: stringValue
+                                            type: String
+                                            description: Represents a string value.
+                                  - name: stringListValue
+                                    type: NestedObject
+                                    description: A list of strings.
+                                    properties:
+                                      - name: values
+                                        type: Array
+                                        description: The strings in the list.
+                                        required: true
+                                        item_type:
+                                          type: String
+                                  - name: stringValue
+                                    type: String
+                                    description: Represents a string value.
+                        - name: intRange
+                          type: NestedObject
+                          description: Number range for number parameters.
+                          properties:
+                            - name: max
+                              type: String
+                              description: Maximum allowed value for the numeric parameter (inclusive).
+                              required: true
+                            - name: min
+                              type: String
+                              description: Minimum allowed value for the numeric parameter (inclusive).
+                              required: true
+                        - name: regexpPattern
+                          type: NestedObject
+                          description: Regular Expression Validator for parameter values.
+                          properties:
+                            - name: pattern
+                              type: String
+                              description: Regex Pattern to match the value(s) of parameter.
+                              required: true
+                    - name: valueType
+                      type: String
+                      description: |-
+                        Parameter value type.
+                        Possible values:
+                        STRING
+                        BOOLEAN
+                        STRINGLIST
+                        NUMBER
+                        ONEOF
+                      required: true
               - name: valueType
                 type: String
                 description: |-
@@ -468,6 +748,36 @@ properties:
                               - name: numberValue
                                 type: Double
                                 description: Represents a double value.
+                              - name: oneofValue
+                                type: NestedObject
+                                description: Sub-parameter values.
+                                properties:
+                                  - name: name
+                                    type: String
+                                    description: The name of the parameter.
+                                  - name: parameterValue
+                                    type: NestedObject
+                                    description: The value of the parameter.
+                                    properties:
+                                      - name: boolValue
+                                        type: Boolean
+                                        description: Represents a boolean value.
+                                      - name: numberValue
+                                        type: Double
+                                        description: Represents a double value.
+                                      - name: stringListValue
+                                        type: NestedObject
+                                        description: A list of strings.
+                                        properties:
+                                          - name: values
+                                            type: Array
+                                            description: The strings in the list.
+                                            required: true
+                                            item_type:
+                                              type: String
+                                      - name: stringValue
+                                        type: String
+                                        description: Represents a string value.
                               - name: stringListValue
                                 type: NestedObject
                                 description: A list of strings.

--- a/mmv1/third_party/terraform/services/cloudsecuritycompliance/resource_cloud_security_compliance_cloud_control_test.go
+++ b/mmv1/third_party/terraform/services/cloudsecuritycompliance/resource_cloud_security_compliance_cloud_control_test.go
@@ -371,6 +371,93 @@ resource "google_cloud_security_compliance_cloud_control" "example" {
 			}
 		}
 	}
+	parameter_spec {
+		name         = "nested-oneof-parameter"
+		display_name = "Nested Oneof Parameter"
+		description  = "A parameter testing nested oneof_value and subParameters"
+		value_type   = "ONEOF"
+		is_required  = true
+		
+		default_value {
+			oneof_value {
+				name = "test-nested-oneof"
+				parameter_value {
+					oneof_value {
+						name = "inner-oneof"
+						parameter_value {
+							string_value = "nested-val"
+						}
+					}
+				}
+			}
+		}
+		
+		validation {
+			allowed_values {
+				values {
+					oneof_value {
+						name = "test-nested-oneof"
+						parameter_value {
+							oneof_value {
+								name = "inner-oneof"
+								parameter_value {
+									string_value = "nested-val"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		sub_parameters {
+			name         = "sub-nested-oneof"
+			display_name = "Sub Nested Oneof"
+			description  = "A sub-parameter for nested oneof"
+			value_type   = "ONEOF"
+			is_required  = true
+			default_value {
+				oneof_value {
+					name = "sub-test-nested-oneof"
+					parameter_value {
+						oneof_value {
+							name = "sub-inner-oneof"
+							parameter_value {
+								string_value = "sub-nested-val"
+							}
+						}
+					}
+				}
+			}
+			validation {
+				allowed_values {
+					values {
+						oneof_value {
+							name = "sub-test-nested-oneof"
+							parameter_value {
+								oneof_value {
+									name = "sub-inner-oneof"
+									parameter_value {
+										string_value = "sub-nested-val"
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			sub_parameters {
+				name         = "nested-sub-param"
+				display_name = "Nested Sub Parameter"
+				description  = "Testing sub_parameters within sub_parameters"
+				value_type   = "STRING"
+				is_required  = true
+				default_value {
+					string_value = "nested-sub-val"
+				}
+			}
+		}
+	}
 }
 `, context)
 }
@@ -737,6 +824,94 @@ resource "google_cloud_security_compliance_cloud_control" "example" {
               }
             }
           }
+        }
+      }
+    }
+  }
+
+  parameter_spec {
+    name         = "nested-oneof-parameter"
+    display_name = "Updated Nested Oneof Parameter"
+    description  = "An updated parameter testing nested oneof_value and subParameters"
+    value_type   = "ONEOF"
+    is_required  = true
+
+    default_value {
+      oneof_value {
+        name = "updated-test-nested-oneof"
+        parameter_value {
+          oneof_value {
+            name = "updated-inner-oneof"
+            parameter_value {
+              string_value = "updated-nested-val"
+            }
+          }
+        }
+      }
+    }
+
+    validation {
+      allowed_values {
+        values {
+          oneof_value {
+            name = "updated-test-nested-oneof"
+            parameter_value {
+              oneof_value {
+                name = "updated-inner-oneof"
+                parameter_value {
+                  string_value = "updated-nested-val"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    sub_parameters {
+      name         = "sub-nested-oneof"
+      display_name = "Updated Sub Nested Oneof"
+      description  = "An updated sub-parameter for nested oneof"
+      value_type   = "ONEOF"
+      is_required  = true
+      default_value {
+        oneof_value {
+          name = "updated-sub-test-nested-oneof"
+          parameter_value {
+            oneof_value {
+              name = "updated-sub-inner-oneof"
+              parameter_value {
+                string_value = "updated-sub-nested-val"
+              }
+            }
+          }
+        }
+      }
+      validation {
+        allowed_values {
+          values {
+            oneof_value {
+              name = "updated-sub-test-nested-oneof"
+              parameter_value {
+                oneof_value {
+                  name = "updated-sub-inner-oneof"
+                  parameter_value {
+                    string_value = "updated-sub-nested-val"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      sub_parameters {
+        name         = "nested-sub-param"
+        display_name = "Updated Nested Sub Parameter"
+        description  = "Updated testing sub_parameters within sub_parameters"
+        value_type   = "STRING"
+        is_required  = true
+        default_value {
+          string_value = "updated-nested-sub-val"
         }
       }
     }


### PR DESCRIPTION
Add nested `parameter_spec` fields to `google_cloud_security_compliance_cloud_control`.

reference: b/550549356

```release-note:enhancement
cloudsecuritycompliance: added `parameter_spec.sub_parameters.sub_parameters` and nested `oneof_value` fields to `google_cloud_security_compliance_cloud_control`
```
