### PR TITLE
vertexai: promote context_spec to GA on reasoning_engine

### DIFF
--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -149,10 +149,8 @@ samples:
           - 'deletion_policy'
   - name: 'vertex_ai_reasoning_engine_granular_ttl'
     primary_resource_id: 'reasoning_engine'
-    min_version: beta
     steps:
       - name: 'vertex_ai_reasoning_engine_granular_ttl'
-        min_version: beta
         resource_id_vars:
           name: 're-gran-ttl'
         ignore_read_extra:
@@ -950,7 +948,6 @@ properties:
             description: |-
               Optional. The service account that the Cloud Build builder runs as.
   - name: 'contextSpec'
-    min_version: 'beta'
     type: NestedObject
     default_from_api: true
     description: |-

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_granular_ttl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_granular_ttl.tf.tmpl
@@ -2,7 +2,6 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
   display_name = "{{index $.ResourceIdVars "name"}}"
   description  = "Reasoning engine with granular ttl"
   region       = "us-central1"
-  provider     = google-beta
 
   context_spec {
     memory_bank_config {
@@ -25,6 +24,4 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
   }
 }
 
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -811,6 +811,7 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 }
 `, context)
 }
+{{- end }}
 
 func TestAccVertexAIReasoningEngine_memoryGenerationTriggerUpdate(t *testing.T) {
 	t.Parallel()
@@ -821,7 +822,7 @@ func TestAccVertexAIReasoningEngine_memoryGenerationTriggerUpdate(t *testing.T) 
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -846,12 +847,9 @@ func TestAccVertexAIReasoningEngine_memoryGenerationTriggerUpdate(t *testing.T) 
 
 func testAccVertexAIReasoningEngine_memoryGenerationTriggerFixedInterval(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}
 
 resource "google_vertex_ai_reasoning_engine" "primary" {
-  provider     = google-beta
   display_name = "tf-test-reasoning-engine-%{random_suffix}"
   description  = "Reasoning engine testing memory generation triggers"
   region       = "us-central1"
@@ -877,12 +875,9 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 
 func testAccVertexAIReasoningEngine_memoryGenerationTriggerEventCount(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}
 
 resource "google_vertex_ai_reasoning_engine" "primary" {
-  provider     = google-beta
   display_name = "tf-test-reasoning-engine-%{random_suffix}"
   description  = "Reasoning engine testing memory generation triggers"
   region       = "us-central1"
@@ -916,7 +911,7 @@ func TestAccVertexAIReasoningEngine_customizationConfigsUpdate(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckVertexAIReasoningEngineDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -941,12 +936,9 @@ func TestAccVertexAIReasoningEngine_customizationConfigsUpdate(t *testing.T) {
 
 func testAccVertexAIReasoningEngine_customizationConfigsBefore(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}
 
 resource "google_vertex_ai_reasoning_engine" "primary" {
-  provider     = google-beta
   display_name = "tf-test-reasoning-engine-%{random_suffix}"
   description  = "Reasoning engine testing customization configs update"
   region       = "us-central1"
@@ -1059,12 +1051,9 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 
 func testAccVertexAIReasoningEngine_customizationConfigsAfter(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}
 
 resource "google_vertex_ai_reasoning_engine" "primary" {
-  provider     = google-beta
   display_name = "tf-test-reasoning-engine-%{random_suffix}"
   description  = "Reasoning engine testing customization configs update"
   region       = "us-central1"
@@ -1174,7 +1163,6 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
 }
 `, context)
 }
-{{- end }}
 
 func TestAccVertexAIReasoningEngine_agentGatewayConfig(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Promote `context_spec` to GA on `google_vertex_ai_reasoning_engine`.

reference: b/550544674

```release-note:enhancement
vertexai: added `context_spec` field to `google_vertex_ai_reasoning_engine` (ga)
```
