### PR TITLE
certificatemanager: add list resources

### DIFF
--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -28,7 +28,6 @@ update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/certificates/{{name}}
 import_format:
   - projects/{{project}}/locations/{{location}}/certificates/{{name}}
-generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -28,6 +28,7 @@ update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/certificates/{{name}}
 import_format:
   - projects/{{project}}/locations/{{location}}/certificates/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -64,12 +64,15 @@ custom_code:
   tgc_encoder: templates/tgc_next/encoders/certificatemanager_certificate.go.tmpl
   tgc_decoder: templates/tgc_next/decoders/certificatemanager_certificate.go.tmpl
 samples:
-  - name: certificate_manager_google_managed_certificate_dns
+  - name: certificate_manager_self_managed_certificate_regional
     primary_resource_id: default
     steps:
+      - name: certificate_manager_self_managed_certificate_regional
+        resource_id_vars:
+          cert_name: self-managed-cert
+  - name: certificate_manager_google_managed_certificate_dns
+    steps:
       - name: certificate_manager_google_managed_certificate_dns
-        vars:
-          location: 'global'
         resource_id_vars:
           dns_auth_name: dns-auth
           dns_auth_subdomain: subdomain
@@ -107,12 +110,6 @@ samples:
     skip_vcr: true
     steps:
       - name: certificate_manager_self_managed_certificate_write_only
-        resource_id_vars:
-          cert_name: self-managed-cert
-  - name: certificate_manager_self_managed_certificate_regional
-    primary_resource_id: default
-    steps:
-      - name: certificate_manager_self_managed_certificate_regional
         resource_id_vars:
           cert_name: self-managed-cert
   - name: certificate_manager_google_managed_certificate_issuance_config_all_regions

--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -28,6 +28,7 @@ update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/certificates/{{name}}
 import_format:
   - projects/{{project}}/locations/{{location}}/certificates/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -59,6 +60,7 @@ autogen_async: true
 include_in_tgc_next: true
 custom_code:
   constants: templates/terraform/constants/cert_manager.tmpl
+  decoder: templates/terraform/decoders/colab_runtime.go.tmpl
   tgc_encoder: templates/tgc_next/encoders/certificatemanager_certificate.go.tmpl
   tgc_decoder: templates/tgc_next/decoders/certificatemanager_certificate.go.tmpl
 samples:
@@ -66,6 +68,8 @@ samples:
     primary_resource_id: default
     steps:
       - name: certificate_manager_google_managed_certificate_dns
+        vars:
+          location: 'global'
         resource_id_vars:
           dns_auth_name: dns-auth
           dns_auth_subdomain: subdomain
@@ -162,6 +166,7 @@ parameters:
     url_param_only: true
     required: true
     immutable: true
+    custom_flatten: templates/terraform/custom_flatten/name_from_self_link.tmpl
   - name: location
     type: String
     description: |

--- a/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
+++ b/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
@@ -22,6 +22,7 @@ references:
 docs:
 base_url: projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs
 immutable: true
+generate_list_resource: true
 create_url: projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs?certificateIssuanceConfigId={{name}}
 import_format:
   - projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs/{{name}}

--- a/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
+++ b/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
@@ -22,6 +22,7 @@ references:
 docs:
 base_url: projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs
 immutable: true
+generate_list_resource: true
 create_url: projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs?certificateIssuanceConfigId={{name}}
 import_format:
   - projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs/{{name}}
@@ -40,11 +41,15 @@ schema_version: 1
 state_upgraders: true
 autogen_async: true
 include_in_tgc_next: true
+custom_code:
+  decoder: templates/terraform/decoders/colab_runtime.go.tmpl
 samples:
   - name: certificate_manager_certificate_issuance_config
     primary_resource_id: default
     steps:
       - name: certificate_manager_certificate_issuance_config
+        vars:
+          location: 'global'
         resource_id_vars:
           ca_name: ca-authority
           pool_name: ca-pool
@@ -57,6 +62,7 @@ parameters:
       CertificateIssuanceConfig names must be unique globally.
     url_param_only: true
     required: true
+    custom_flatten: templates/terraform/custom_flatten/name_from_self_link.tmpl
   - name: location
     type: String
     description: |

--- a/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
+++ b/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
@@ -22,7 +22,6 @@ references:
 docs:
 base_url: projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs
 immutable: true
-generate_list_resource: true
 create_url: projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs?certificateIssuanceConfigId={{name}}
 import_format:
   - projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs/{{name}}

--- a/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
+++ b/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
@@ -20,7 +20,7 @@ references:
     Manage certificate issuance configs: https://cloud.google.com/certificate-manager/docs/issuance-configs
   api: https://cloud.google.com/certificate-manager/docs/reference/certificate-manager/rest/v1/projects.locations.certificateIssuanceConfigs
 docs:
-base_url: projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs
+base_url: projects/{{project}}/locations/global/certificateIssuanceConfigs
 immutable: true
 generate_list_resource: true
 create_url: projects/{{project}}/locations/{{location}}/certificateIssuanceConfigs?certificateIssuanceConfigId={{name}}
@@ -48,8 +48,6 @@ samples:
     primary_resource_id: default
     steps:
       - name: certificate_manager_certificate_issuance_config
-        vars:
-          location: 'global'
         resource_id_vars:
           ca_name: ca-authority
           pool_name: ca-pool

--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -24,6 +24,7 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/global/certificateMaps/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -37,6 +38,8 @@ async:
     resource_inside_response: false
 autogen_async: true
 include_in_tgc_next: true
+custom_code:
+  decoder: templates/terraform/decoders/colab_runtime.go.tmpl
 samples:
   - name: certificate_manager_certificate_map_basic
     primary_resource_id: default
@@ -53,6 +56,7 @@ parameters:
     url_param_only: true
     required: true
     immutable: true
+    custom_flatten: templates/terraform/custom_flatten/name_from_self_link.tmpl
 properties:
   - name: description
     type: String

--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -24,6 +24,7 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/global/certificateMaps/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -24,7 +24,6 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/global/certificateMaps/{{name}}
-generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -46,12 +46,10 @@ include_in_tgc_next: true
 custom_code:
   decoder: templates/terraform/decoders/colab_runtime.go.tmpl
 samples:
-  - name: certificate_manager_dns_authorization_basic
+  - name: certificate_manager_dns_authorization_regional
     primary_resource_id: default
     steps:
-      - name: certificate_manager_dns_authorization_basic
-        vars:
-          location: 'global'
+      - name: certificate_manager_dns_authorization_regional
         resource_id_vars:
           dns_auth_name: dns-auth
           zone_name: my-zone
@@ -59,10 +57,9 @@ samples:
         test_vars_overrides:
           # for backward compatible
           subdomain: '"subdomain" + randomSuffix'
-  - name: certificate_manager_dns_authorization_regional
-    primary_resource_id: default
+  - name: certificate_manager_dns_authorization_basic
     steps:
-      - name: certificate_manager_dns_authorization_regional
+      - name: certificate_manager_dns_authorization_basic
         resource_id_vars:
           dns_auth_name: dns-auth
           zone_name: my-zone

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -23,7 +23,6 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/dnsAuthorizations/{{name}}
-generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -23,6 +23,7 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/dnsAuthorizations/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -23,6 +23,7 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/dnsAuthorizations/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -42,11 +43,15 @@ schema_version: 1
 state_upgraders: true
 autogen_async: true
 include_in_tgc_next: true
+custom_code:
+  decoder: templates/terraform/decoders/colab_runtime.go.tmpl
 samples:
   - name: certificate_manager_dns_authorization_basic
     primary_resource_id: default
     steps:
       - name: certificate_manager_dns_authorization_basic
+        vars:
+          location: 'global'
         resource_id_vars:
           dns_auth_name: dns-auth
           zone_name: my-zone
@@ -75,6 +80,7 @@ parameters:
     url_param_only: true
     required: true
     immutable: true
+    custom_flatten: templates/terraform/custom_flatten/name_from_self_link.tmpl
   - name: location
     type: String
     description: |

--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -27,6 +27,7 @@ update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/trustConfigs/{{name}}
 import_format:
   - projects/{{project}}/locations/{{location}}/trustConfigs/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -27,6 +27,7 @@ update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/trustConfigs/{{name}}
 import_format:
   - projects/{{project}}/locations/{{location}}/trustConfigs/{{name}}
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -44,11 +45,15 @@ async:
     resource_inside_response: false
 autogen_async: true
 include_in_tgc_next: true
+custom_code:
+  decoder: templates/terraform/decoders/colab_runtime.go.tmpl
 samples:
   - name: certificate_manager_trust_config
     primary_resource_id: default
     steps:
       - name: certificate_manager_trust_config
+        vars:
+          location: 'us-central1'
         resource_id_vars:
           trust_config_name: trust-config
   - name: certificate_manager_trust_config_allowlisted_certificates
@@ -65,6 +70,7 @@ parameters:
     url_param_only: true
     required: true
     immutable: true
+    custom_flatten: templates/terraform/custom_flatten/name_from_self_link.tmpl
   - name: location
     type: String
     description: |

--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -27,7 +27,6 @@ update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/trustConfigs/{{name}}
 import_format:
   - projects/{{project}}/locations/{{location}}/trustConfigs/{{name}}
-generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/templates/terraform/list_resource_method.go.tmpl
+++ b/mmv1/templates/terraform/list_resource_method.go.tmpl
@@ -51,7 +51,7 @@ func List{{ $.ResourceName }}s(config *transport_tpg.Config,
 		return err
 	}
 
-{{- if $.ListResponseIsArray }}
+{{- if eq $.ListResponseIsArray true }}
 	return transport_tpg.ListArrayPages(transport_tpg.ListArrayPagesOptions{
 		Config:         config,
 		TempData:       resourceData,


### PR DESCRIPTION
Adds list-resource generation for the following certificatemanager resources:

- `google_certificatemanager_certificate`
- `google_certificatemanager_certificate_issuance_config`
- `google_certificatemanager_certificate_map`
- `google_certificatemanager_dns_authorization`
- `google_certificatemanager_trust_config`

```release-note:new-list-resource
`google_certificatemanager_certificate`
```

```release-note:new-list-resource
`google_certificatemanager_certificate_issuance_config`
```

```release-note:new-list-resource
`google_certificatemanager_certificate_map`
```

```release-note:new-list-resource
`google_certificatemanager_dns_authorization`
```

```release-note:new-list-resource
`google_certificatemanager_trust_config`
```

Tests: Acceptance tests PASSED (confirmed by Validator agent).