### PR TITLE
tgc: update logging_organization_sink fixture for default_collation

### DIFF
--- a/mmv1/third_party/tgc/tests/data/logging_organization_sink.json
+++ b/mmv1/third_party/tgc/tests/data/logging_organization_sink.json
@@ -93,6 +93,7 @@
           "datasetId": "my_dataset"
         },
         "friendlyName": "",
+        "defaultCollation": "",
         "labels": {
             "goog-terraform-provisioned": "true"
         },


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes `TestReadPlannedAssetsCoverage/logging_organization_sink` on main. The BigQuery dataset nested  was missing `defaultCollation: ""`, which conversion now emits.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
