### PR TITLE
identityplatform: add list resources

### DIFF
--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -41,7 +41,6 @@ timeouts:
   delete_minutes: 20
 exclude_sweeper: true
 exclude_delete: true
-generate_list_resource: true
 custom_code:
   custom_create: templates/terraform/custom_create/identity_platform_config.go.tmpl
 samples:

--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -41,6 +41,7 @@ timeouts:
   delete_minutes: 20
 exclude_sweeper: true
 exclude_delete: true
+generate_list_resource: true
 custom_code:
   custom_create: templates/terraform/custom_create/identity_platform_config.go.tmpl
 samples:

--- a/mmv1/products/identityplatform/InboundSamlConfig.yaml
+++ b/mmv1/products/identityplatform/InboundSamlConfig.yaml
@@ -30,6 +30,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 include_in_tgc_next: true
+generate_list_resource: true
 custom_code:
 samples:
   - name: identity_platform_inbound_saml_config_basic

--- a/mmv1/products/identityplatform/OauthIdpConfig.yaml
+++ b/mmv1/products/identityplatform/OauthIdpConfig.yaml
@@ -24,6 +24,9 @@ docs:
 base_url: projects/{{project}}/oauthIdpConfigs
 self_link: projects/{{project}}/oauthIdpConfigs/{{name}}
 create_url: projects/{{project}}/oauthIdpConfigs?oauthIdpConfigId={{name}}
+# api_resource_type_kind is OAuthIdpConfig, which camelizes to oAuthIdpConfigs.
+# The ListOAuthIdpConfigsResponse key is oauthIdpConfigs.
+collection_url_key: oauthIdpConfigs
 update_mask: true
 update_verb: PATCH
 timeouts:

--- a/mmv1/products/identityplatform/OauthIdpConfig.yaml
+++ b/mmv1/products/identityplatform/OauthIdpConfig.yaml
@@ -30,6 +30,7 @@ timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+generate_list_resource: true
 custom_code:
 samples:
   - name: identity_platform_oauth_idp_config_basic

--- a/mmv1/products/identityplatform/Tenant.yaml
+++ b/mmv1/products/identityplatform/Tenant.yaml
@@ -32,6 +32,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 include_in_tgc_next: true
+generate_list_resource: true
 samples:
   - name: identity_platform_tenant_basic
     primary_resource_id: tenant

--- a/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
@@ -21,6 +21,7 @@ package {{ lower $.ProductMetadata.Name }}_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
@@ -33,6 +34,7 @@ import (
 
 var (
 	_ = envvar.TestEnvVar
+	_ = time.Now
 )
 
 {{ $sample := $.FirstTestConfig.Sample }}


### PR DESCRIPTION
Adds list-resource generation for the following identityplatform resources:

- `google_identityplatform_config`
  - removed due to being a singleton resource
- `google_identityplatform_inbound_saml_config`
- `google_identityplatform_oauth_idp_config`
- `google_identityplatform_tenant`

```release-note:new-list-resource
`google_identityplatform_inbound_saml_config`
```

```release-note:new-list-resource
`google_identityplatform_oauth_idp_config`
```

```release-note:new-list-resource
`google_identityplatform_tenant`
```

Tests: Acceptance tests PASSED (confirmed by Validator agent).