### PR TITLE
gemini: add mutations_enabled to google_gemini_gemini_gcp_enablement_setting

### DIFF
--- a/mmv1/products/gemini/GeminiGcpEnablementSetting.yaml
+++ b/mmv1/products/gemini/GeminiGcpEnablementSetting.yaml
@@ -80,3 +80,6 @@ properties:
       Possible values:
       GROUNDING_WITH_GOOGLE_SEARCH
       WEB_GROUNDING_FOR_ENTERPRISE
+  - name: mutationsEnabled
+    type: Boolean
+    description: Whether resource mutations should be enabled.

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gemini_gcp_enablement_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gemini_gcp_enablement_setting_basic.tf.tmpl
@@ -4,4 +4,5 @@ resource "google_gemini_gemini_gcp_enablement_setting" "{{$.PrimaryResourceId}}"
     labels = {"my_key": "my_value"}
     enable_customer_data_sharing = true
     web_grounding_type = "WEB_GROUNDING_FOR_ENTERPRISE"
+    mutations_enabled = true
 }

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_test.go
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_test.go
@@ -53,6 +53,7 @@ resource "google_gemini_gemini_gcp_enablement_setting" "example" {
     labels = {"my_key" = "my_value"}
     enable_customer_data_sharing = true
 	web_grounding_type = "WEB_GROUNDING_FOR_ENTERPRISE"
+	mutations_enabled = true
 }
 `, context)
 }
@@ -64,6 +65,7 @@ resource "google_gemini_gemini_gcp_enablement_setting" "example" {
     labels = {"my_key" = "my_value"}
     enable_customer_data_sharing = false
 	web_grounding_type = "GROUNDING_WITH_GOOGLE_SEARCH"
+	mutations_enabled = false
 }
 `, context)
 }


### PR DESCRIPTION
Adds missing field `mutations_enabled` to `google_gemini_gemini_gcp_enablement_setting`.

reference: b/550544320

```release-note:enhancement
gemini: added `mutations_enabled` field to `google_gemini_gemini_gcp_enablement_setting`
```
