### PR TITLE
Add Terraform support for GMK public clusters and bootstrapAddress

### DIFF
--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -70,6 +70,13 @@ samples:
           key_ring_name: 'example-key-ring'
         test_vars_overrides:
           key_name: 'kms.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+  - name: 'managedkafka_cluster_public'
+    primary_resource_id: 'example'
+    tgc_skip_test: 'Test data unavailable in CAI yet'
+    steps:
+      - name: 'managedkafka_cluster_public'
+        resource_id_vars:
+          cluster_id: 'my-cluster'
 parameters:
   - name: 'location'
     type: String
@@ -106,6 +113,16 @@ properties:
                   description: "Name of the VPC subnet from which the cluster is accessible. Both broker and bootstrap server IP addresses and DNS entries are automatically created in the subnet. There can only be one subnet per network, and the subnet must be located in the same region as the cluster. The project may differ. The name of the subnet must be in the format `projects/PROJECT_ID/regions/REGION/subnetworks/SUBNET`."
                   required: true
                   diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+          - name: 'publicClusterConfig'
+            type: NestedObject
+            description: "Public connection configuration for the Kafka cluster."
+            properties:
+              - name: 'allowedSourceIpRanges'
+                type: Array
+                description: "A list of IPv4 addresses or CIDR ranges that are allowed to connect to the cluster."
+                required: true
+                item_type:
+                  type: String
       - name: 'kmsKey'
         type: String
         description: "The Cloud KMS Key name to use for encryption. The key must be located in the same region as the cluster and cannot be changed. Must be in the format `projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY`."
@@ -158,6 +175,23 @@ properties:
     type: String
     description: "The current state of the cluster. Possible values: `STATE_UNSPECIFIED`, `CREATING`, `ACTIVE`, `DELETING`."
     output: true
+  - name: 'publicClusterDetails'
+    type: NestedObject
+    description: "Details of the public cluster feature for the Kafka cluster."
+    output: true
+    properties:
+      - name: 'discoveryDnsRecords'
+        type: Array
+        description: "DNS discovery records that resolve to all of the external IP addresses associated with the public cluster."
+        output: true
+        item_type:
+          type: String
+      - name: 'externalIpAddresses'
+        type: Array
+        description: "All of the external IP addresses associated with the public cluster used for configuring egress firewall rules to a public cluster."
+        output: true
+        item_type:
+          type: String
   - name: 'tlsConfig'
     type: NestedObject
     default_from_api: true

--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -192,6 +192,10 @@ properties:
         output: true
         item_type:
           type: String
+  - name: 'bootstrapAddress'
+    type: String
+    description: "The bootstrap address of the Kafka cluster. Use port :9092 for SASL connection and :9192 for mTLS connection"
+    output: true
   - name: 'tlsConfig'
     type: NestedObject
     default_from_api: true

--- a/mmv1/templates/terraform/samples/services/managedkafka/managedkafka_cluster_public.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/managedkafka/managedkafka_cluster_public.tf.tmpl
@@ -1,0 +1,24 @@
+resource "google_managed_kafka_cluster" "{{$.PrimaryResourceId}}" {
+  cluster_id = "{{index $.ResourceIdVars "cluster_id"}}"
+  location = "us-central1"
+  capacity_config {
+    vcpu_count = 3
+    memory_bytes = 3221225472
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.project.number}/regions/us-central1/subnetworks/default"
+      }
+      public_cluster_config {
+        allowed_source_ip_ranges = ["192.168.1.0/24"]
+      }
+    }
+  }
+  rebalance_config {
+    mode = "AUTO_REBALANCE_ON_SCALE_UP"
+  }
+}
+
+data "google_project" "project" {
+}


### PR DESCRIPTION
Porting changes from cl/917852714 to add public_cluster_config, public_cluster_details, and bootstrap_address to the google_managed_kafka_cluster resource in Magic Modules.

```release-note:enhancement
managedkafka: added `public_cluster_config`, `public_cluster_details`, and `bootstrap_address` fields to `google_managed_kafka_cluster` resource
```
