### PR TITLE
cloudrunv2: add source_code, base_image_uri, build_info to google_cloud_run_v2_worker_pool

### DIFF
--- a/mmv1/products/cloudrunv2/WorkerPool.yaml
+++ b/mmv1/products/cloudrunv2/WorkerPool.yaml
@@ -684,6 +684,73 @@ properties:
                       description: |-
                         Optional. Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md ). If this is not specified, the default behavior is defined by gRPC
                       type: String
+            - name: 'baseImageUri'
+              type: String
+              description: |-
+                Base image for this container. If set, it indicates that the service is enrolled into automatic base image update.
+            - name: 'buildInfo'
+              type: NestedObject
+              description: |-
+                The build info of the container image.
+              output: true
+              properties:
+                - name: 'functionTarget'
+                  type: String
+                  description: |-
+                    Entry point of the function when the image is a Cloud Run function.
+                  output: true
+                - name: 'source_location'
+                  type: String
+                  description: |-
+                    Source code location of the image.
+                  output: true
+            - name: 'sourceCode'
+              type: NestedObject
+              description: |-
+                Location of the source.
+              properties:
+                - name: 'cloudStorageSource'
+                  type: NestedObject
+                  description: |-
+                    Cloud Storage source.
+                  properties:
+                    - name: 'bucket'
+                      type: String
+                      description: |-
+                        The Cloud Storage bucket name.
+                      required: true
+                    - name: 'object'
+                      type: String
+                      description: |-
+                        The Cloud Storage object name.
+                      required: true
+                    - name: 'generation'
+                      type: String
+                      description: |-
+                        The Cloud Storage object generation. This is an int64 value. As with most Google APIs, its JSON representation will be a string instead of an integer.
+                - name: 'inlinedSource'
+                  type: NestedObject
+                  description: |-
+                    Inlined source.
+                  properties:
+                    - name: 'sources'
+                      type: Array
+                      description: |-
+                        The source code.
+                      required: true
+                      item_type:
+                        type: NestedObject
+                        properties:
+                          - name: 'filename'
+                            type: String
+                            description: |-
+                              The relative path of the file to the root of the source directory.
+                            required: true
+                          - name: 'content'
+                            type: String
+                            description: |-
+                              Represents the exact, literal, and complete source code of the file.
+                            required: true
       - name: 'volumes'
         type: Array
         description: |-

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/cloudrunv2"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/storage"
 )
 
 func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolFullUpdate(t *testing.T) {
@@ -604,5 +605,137 @@ resource "google_cloud_run_v2_worker_pool" "default" {
   }
 }
 
+`, context)
+}
+
+func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolSourceCodeUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckCloudRunV2WorkerPoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolSourceCode(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_worker_pool.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+			},
+			{
+				Config: testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolSourceCodeUpdate(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_worker_pool.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolSourceCode(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_storage_bucket" "sourcebucket" {
+  provider                    = google-beta
+  name                        = "tf-test-worker-pool-src%{random_suffix}"
+  location                    = "US"
+  uniform_bucket_level_access = true
+  force_destroy               = true
+}
+
+resource "google_storage_bucket_object" "source_tar_1" {
+  provider = google-beta
+  name     = "source-1.tar.gz"
+  bucket   = google_storage_bucket.sourcebucket.name
+  source   = "./test-fixtures/cr-zip-nodejs-hello.tar.gz"
+}
+
+resource "google_storage_bucket_object" "source_tar_2" {
+  provider = google-beta
+  name     = "source-2.tar.gz"
+  bucket   = google_storage_bucket.sourcebucket.name
+  source   = "./test-fixtures/cr-zip-py-hello.tar.gz"
+}
+
+resource "google_cloud_run_v2_worker_pool" "default" {
+  provider            = google-beta
+  name                = "tf-test-cloudrun-worker-pool%{random_suffix}"
+  location            = "us-central1"
+  deletion_protection = false
+
+  template {
+    containers {
+      image          = "scratch"
+      base_image_uri = "us-central1-docker.pkg.dev/serverless-runtimes/google-24-full/runtimes/nodejs24"
+      command        = ["node"]
+      args           = ["index.js"]
+      source_code {
+        cloud_storage_source {
+          bucket     = google_storage_bucket.sourcebucket.name
+          object     = google_storage_bucket_object.source_tar_1.name
+          generation = google_storage_bucket_object.source_tar_1.generation
+        }
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolSourceCodeUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_storage_bucket" "sourcebucket" {
+  provider                    = google-beta
+  name                        = "tf-test-worker-pool-src%{random_suffix}"
+  location                    = "US"
+  uniform_bucket_level_access = true
+  force_destroy               = true
+}
+
+resource "google_storage_bucket_object" "source_tar_1" {
+  provider = google-beta
+  name     = "source-1.tar.gz"
+  bucket   = google_storage_bucket.sourcebucket.name
+  source   = "./test-fixtures/cr-zip-nodejs-hello.tar.gz"
+}
+
+resource "google_storage_bucket_object" "source_tar_2" {
+  provider = google-beta
+  name     = "source-2.tar.gz"
+  bucket   = google_storage_bucket.sourcebucket.name
+  source   = "./test-fixtures/cr-zip-py-hello.tar.gz"
+}
+
+resource "google_cloud_run_v2_worker_pool" "default" {
+  provider            = google-beta
+  name                = "tf-test-cloudrun-worker-pool%{random_suffix}"
+  location            = "us-central1"
+  deletion_protection = false
+
+  template {
+    containers {
+      image          = "scratch"
+      base_image_uri = "us-central1-docker.pkg.dev/serverless-runtimes/google-22-full/runtimes/python313"
+      command        = ["python"]
+      args           = ["main.py"]
+      source_code {
+        cloud_storage_source {
+          bucket     = google_storage_bucket.sourcebucket.name
+          object     = google_storage_bucket_object.source_tar_2.name
+          generation = google_storage_bucket_object.source_tar_2.generation
+        }
+      }
+    }
+  }
+}
 `, context)
 }


### PR DESCRIPTION
Adds missing fields `source_code`, `base_image_uri`, and `build_info` to `google_cloud_run_v2_worker_pool`.

reference: b/550543067

```release-note:enhancement
cloudrunv2: added `source_code`, `base_image_uri`, and `build_info` fields to `google_cloud_run_v2_worker_pool`
```
