### PR TITLE
ces: add unredacted_bigquery_export_settings to google_ces_app

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -460,6 +460,25 @@ properties:
               detection of sensitive data types.
               Format:
               `projects/{project}/locations/{location}/inspectTemplates/{inspect_template}`
+      - name: unredactedBigqueryExportSettings
+        type: NestedObject
+        description: |-
+          Settings to describe the BigQuery export behaviors for the app for
+          unredacted conversation data.
+        properties:
+          - name: dataset
+            type: String
+            description: The BigQuery dataset to export the data to.
+          - name: enabled
+            type: Boolean
+            description: Indicates whether the BigQuery export is enabled.
+          - name: project
+            type: String
+            description: |-
+              The project ID of the BigQuery dataset to export the data to.
+              Note: If the BigQuery dataset is in a different project from the app, you should grant
+              roles/bigquery.admin role to the CES service agent service-<PROJECT-
+              NUMBER>@gcp-sa-ces.iam.gserviceaccount.com.
   - name: metadata
     type: KeyValuePairs
     description: |-

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -862,6 +862,29 @@ properties:
                       Format:
                       `projects/{project}/locations/{location}/inspectTemplates/{inspect_template}`
                     output: true
+              - name: unredactedBigqueryExportSettings
+                type: NestedObject
+                description: |-
+                  Settings to describe the BigQuery export behaviors for the app for
+                  unredacted conversation data.
+                output: true
+                properties:
+                  - name: dataset
+                    type: String
+                    description: The BigQuery dataset to export the data to.
+                    output: true
+                  - name: enabled
+                    type: Boolean
+                    description: Indicates whether the BigQuery export is enabled.
+                    output: true
+                  - name: project
+                    type: String
+                    description: |-
+                      The project ID of the BigQuery dataset to export the data to.
+                      Note: If the BigQuery dataset is in a different project from the app, you should grant
+                      roles/bigquery.admin role to the CES service agent service-<PROJECT-
+                      NUMBER>@gcp-sa-ces.iam.gserviceaccount.com.
+                    output: true
           - name: metadata
             type: KeyValuePairs
             description: |-

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -130,6 +130,12 @@ resource "google_ces_app" "ces_app_basic" {
       project = "projects/fake-project"
     }
 
+    unredacted_bigquery_export_settings {
+      dataset = "projects/fake-project/datasets/fake-dataset/tables/fake-table"
+      enabled = false
+      project = "projects/fake-project"
+    }
+
     cloud_logging_settings {
       enable_cloud_logging = true
     }
@@ -337,6 +343,12 @@ resource "google_ces_app" "ces_app_basic" {
       dataset = "projects/fake-project/datasets/fake-dataset/tables/fake-table"
       enabled = true
       project = "projects/fake-project"
+    }
+
+    unredacted_bigquery_export_settings {
+      dataset = "projects/fake-project/datasets/fake-dataset/tables/fake-table-updated"
+      enabled = true
+      project = "projects/fake-project-updated"
     }
 
     cloud_logging_settings {


### PR DESCRIPTION
Adds missing field `unredacted_bigquery_export_settings` to `google_ces_app`.

reference: b/549921874

```release-note:enhancement
ces: added `unredacted_bigquery_export_settings` field to `google_ces_app`
```
