### PR TITLE
Post failure improvements

### DIFF
--- a/docs/content/develop/custom-code.md
+++ b/docs/content/develop/custom-code.md
@@ -184,19 +184,29 @@ CRUD operations can be modified with pre/post hooks. This code will be injected 
 - Use `pre_delete` to detach a disk before deleting it.
 - Use `post_import` to parse attributes from the import ID and call `d.Set("field")` so that the resource can be read from the API.
 
-### Custom create error handling
+### Custom error handling
 
 ```yaml
 custom_code:
   post_create_failure: templates/terraform/post_create_failure/PRODUCT_RESOURCE.go.tmpl
+  post_update_failure: templates/terraform/post_update_failure/PRODUCT_RESOURCE.go.tmpl
+  post_delete_failure: templates/terraform/post_delete_failure/PRODUCT_RESOURCE.go.tmpl
 ```
 
-Use `custom_code.post_create_failure` to inject code that runs if a Create request to the API returns an error.
+Use `custom_code.post_create_failure`, `custom_code.post_update_failure`, or `custom_code.post_delete_failure` to inject code that runs if a Create, Update, or Delete request to the API returns an error.
 
-The post_create_failure code will be wrapped in a function like:
+The failure hook code will be wrapped in functions like:
 
 ```go
 func resourceProductResourcePostCreateFailure(d *schema.ResourceData, meta interface{}) {
+    // Your code will be injected here.
+}
+
+func resourceProductResourcePostUpdateFailure(d *schema.ResourceData, meta interface{}) {
+    // Your code will be injected here.
+}
+
+func resourceProductResourcePostDeleteFailure(d *schema.ResourceData, meta interface{}) {
     // Your code will be injected here.
 }
 ```

--- a/docs/content/develop/custom-code.md
+++ b/docs/content/develop/custom-code.md
@@ -198,23 +198,24 @@ Use `custom_code.post_create_failure`, `custom_code.post_update_failure`, or `cu
 The failure hook code will be wrapped in functions like:
 
 ```go
-func resourceProductResourcePostCreateFailure(d *schema.ResourceData, meta interface{}) {
+func resourceProductResourcePostCreateFailure(d *schema.ResourceData, meta interface{}, err error) error {
     // Your code will be injected here.
 }
 
-func resourceProductResourcePostUpdateFailure(d *schema.ResourceData, meta interface{}) {
+func resourceProductResourcePostUpdateFailure(d *schema.ResourceData, meta interface{}, err error) error {
     // Your code will be injected here.
 }
 
-func resourceProductResourcePostDeleteFailure(d *schema.ResourceData, meta interface{}) {
+func resourceProductResourcePostDeleteFailure(d *schema.ResourceData, meta interface{}, err error) error {
     // Your code will be injected here.
 }
 ```
 
-The parameters the function receives are:
+The parameters the functions receive are:
 
 - `d`: Terraform resource data. Use `d.Get("field_name")` to get a field's current value.
 - `meta`: Can be cast to a Config object (which can make API calls) using `meta.(*transport_tpg.Config)`
+- `err`: The error returned by the API call or operation. The hook should return an error (either `err` or a modified error).
 
 ### Custom retry handling
 

--- a/docs/content/develop/custom-code.md
+++ b/docs/content/develop/custom-code.md
@@ -199,14 +199,17 @@ The failure hook code will be wrapped in functions like:
 
 ```go
 func resourceProductResourcePostCreateFailure(d *schema.ResourceData, meta interface{}, err error) error {
+    log.Printf("[DEBUG] Error before post_create_failure hook: %v", err)
     // Your code will be injected here.
 }
 
 func resourceProductResourcePostUpdateFailure(d *schema.ResourceData, meta interface{}, err error) error {
+    log.Printf("[DEBUG] Error before post_update_failure hook: %v", err)
     // Your code will be injected here.
 }
 
 func resourceProductResourcePostDeleteFailure(d *schema.ResourceData, meta interface{}, err error) error {
+    log.Printf("[DEBUG] Error before post_delete_failure hook: %v", err)
     // Your code will be injected here.
 }
 ```

--- a/mmv1/api/resource/custom_code.go
+++ b/mmv1/api/resource/custom_code.go
@@ -111,6 +111,11 @@ type CustomCode struct {
 	// false.
 	PostUpdate string `yaml:"post_update,omitempty"`
 
+	// This code is run after the Update call fails before the error is
+	// returned. It's placed in the Update function directly without
+	// modification.
+	PostUpdateFailure string `yaml:"post_update_failure,omitempty"`
+
 	// This code replaces the entire contents of the Update call. It
 	// should be used for resources that don't have normal update
 	// semantics that cannot be supported well by other MM features.
@@ -123,6 +128,11 @@ type CustomCode struct {
 
 	// This code is run just after the Delete call happens.
 	PostDelete string `yaml:"post_delete,omitempty"`
+
+	// This code is run after the Delete call fails before the error is
+	// returned. It's placed in the Delete function directly without
+	// modification.
+	PostDeleteFailure string `yaml:"post_delete_failure,omitempty"`
 
 	// This code replaces the entire delete method.  Since the delete
 	// method's function header can't be changed, the template

--- a/mmv1/api/resource/custom_code.go
+++ b/mmv1/api/resource/custom_code.go
@@ -82,8 +82,7 @@ type CustomCode struct {
 	PostCreate string `yaml:"post_create,omitempty"`
 
 	// This code is run after the Create call fails before the error is
-	// returned. It's placed in the Create function directly without
-	// modification.
+	// returned. It is wrapped in a function.
 	PostCreateFailure string `yaml:"post_create_failure,omitempty"`
 
 	// This code replaces the entire contents of the Create call. It
@@ -112,8 +111,7 @@ type CustomCode struct {
 	PostUpdate string `yaml:"post_update,omitempty"`
 
 	// This code is run after the Update call fails before the error is
-	// returned. It's placed in the Update function directly without
-	// modification.
+	// returned. It is wrapped in a function.
 	PostUpdateFailure string `yaml:"post_update_failure,omitempty"`
 
 	// This code replaces the entire contents of the Update call. It
@@ -130,8 +128,7 @@ type CustomCode struct {
 	PostDelete string `yaml:"post_delete,omitempty"`
 
 	// This code is run after the Delete call fails before the error is
-	// returned. It's placed in the Delete function directly without
-	// modification.
+	// returned. It is wrapped in a function.
 	PostDeleteFailure string `yaml:"post_delete_failure,omitempty"`
 
 	// This code replaces the entire delete method.  Since the delete

--- a/mmv1/templates/terraform/post_create/gke_hub_rollout_sequence.go.tmpl
+++ b/mmv1/templates/terraform/post_create/gke_hub_rollout_sequence.go.tmpl
@@ -54,6 +54,5 @@ if err := func() error {
 	}
 	return nil
 }(); err != nil {
-	resourceGKEHub2RolloutSequencePostCreateFailure(d, meta)
-	return err
+	return resourceGKEHub2RolloutSequencePostCreateFailure(d, meta, err)
 }

--- a/mmv1/templates/terraform/post_create_failure/delete_on_failure.go.tmpl
+++ b/mmv1/templates/terraform/post_create_failure/delete_on_failure.go.tmpl
@@ -12,3 +12,4 @@ if cleanErr = resource{{$.ResourceName}}Read(d, meta); cleanErr == nil {
 if cleanErr != nil {
 	log.Printf("[WARN] Could not confirm cleanup of {{$.Name}} if created in error state: %v", cleanErr)
 }
+return err

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -398,7 +398,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
     })
     if err != nil {
 {{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) -}}
-        resource{{ $.ResourceName -}}PostCreateFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
 {{- end}}
         return fmt.Errorf("Error creating {{ $.Name -}}: %s", err)
     }
@@ -436,7 +436,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
         d.Timeout(schema.TimeoutCreate))
     if err != nil {
 {{if $.CustomCode.PostCreateFailure -}}
-        resource{{ $.ResourceName -}}PostCreateFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
 {{- end}}
 {{-          if not $.TaintResourceOnFailedCreate -}}
         // The resource didn't actually create
@@ -516,7 +516,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 
     if err != nil {
 {{if $.CustomCode.PostCreateFailure -}}
-        resource{{ $.ResourceName -}}PostCreateFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
 {{ end}}
 {{-          if not $.TaintResourceOnFailedCreate -}}
         // The resource didn't actually create
@@ -542,7 +542,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 
 {{-        else }}
 {{- if $.CustomCode.PostCreateFailure -}}
-        resource{{ $.ResourceName -}}PostCreateFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
 {{- end}}
         return fmt.Errorf("Error waiting to create {{ $.Name -}}: %s", err)
 {{- end}}
@@ -1050,7 +1050,7 @@ if len(updateMask) > 0 {
 
     if err != nil {
 {{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
-        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
 {{- end}}
         return fmt.Errorf("Error updating {{ $.Name }} %q: %s", d.Id(), err)
     } else {
@@ -1069,7 +1069,7 @@ if len(updateMask) > 0 {
 
     if err != nil {
 {{- if $.CustomCode.PostUpdateFailure -}}
-        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
 {{- end}}
         return err
     }
@@ -1083,7 +1083,7 @@ if len(updateMask) > 0 {
         log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name -}} %q finished updating: %q", d.Id(), err)
 {{                      else -}}
 {{- if $.CustomCode.PostUpdateFailure -}}
-        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
 {{- end}}
         return err
 {{-                     end}}
@@ -1247,7 +1247,7 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
         })
         if err != nil {
 {{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
-            resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+            err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
 {{- end}}
             return fmt.Errorf("Error updating {{ $.Name }} %q: %s", d.Id(), err)
         } else {
@@ -1265,7 +1265,7 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 	        d.Timeout(schema.TimeoutUpdate))
 	    if err != nil {
 {{- if $.CustomCode.PostUpdateFailure -}}
-	        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+	        err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
 {{- end}}
 	        return err
 	    }
@@ -1276,7 +1276,7 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 	        log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name -}} %q finished updating: %q", d.Id(), err)
 {{-                          else -}}
 {{- if $.CustomCode.PostUpdateFailure -}}
-	        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+	        err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
 {{- end}}
 	        return err
 {{-                         end}}
@@ -1421,7 +1421,7 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
     })
     if err != nil {
 {{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) -}}
-        resource{{ $.ResourceName -}}PostDeleteFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
 {{- end}}
         return transport_tpg.HandleNotFoundError(err, d, "{{ $.Name }}")
     }
@@ -1433,7 +1433,7 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name }} %q finished updating: %q", d.Id(), err)
             {{- else }}
 {{- if $.CustomCode.PostDeleteFailure -}}
-        resource{{ $.ResourceName -}}PostDeleteFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
 {{- end}}
         return fmt.Errorf("Error waiting to delete {{ $.Name }}: %s", err)
             {{- end }}
@@ -1449,7 +1449,7 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
 
     if err != nil {
 {{- if $.CustomCode.PostDeleteFailure -}}
-        resource{{ $.ResourceName -}}PostDeleteFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
 {{- end}}
         return err
     }
@@ -1533,17 +1533,17 @@ func resource{{ $.ResourceName -}}Decoder(d *schema.ResourceData, meta interface
 }
 {{- end }}
 {{- if $.CustomCode.PostCreateFailure }}
-func resource{{ $.ResourceName -}}PostCreateFailure(d *schema.ResourceData, meta interface{}) {
+func resource{{ $.ResourceName -}}PostCreateFailure(d *schema.ResourceData, meta interface{}, err error) error {
     {{- customTemplate $ $.CustomCode.PostCreateFailure false -}}
 }
 {{- end }}
 {{- if $.CustomCode.PostUpdateFailure }}
-func resource{{ $.ResourceName -}}PostUpdateFailure(d *schema.ResourceData, meta interface{}) {
+func resource{{ $.ResourceName -}}PostUpdateFailure(d *schema.ResourceData, meta interface{}, err error) error {
     {{- customTemplate $ $.CustomCode.PostUpdateFailure false -}}
 }
 {{- end }}
 {{- if $.CustomCode.PostDeleteFailure }}
-func resource{{ $.ResourceName -}}PostDeleteFailure(d *schema.ResourceData, meta interface{}) {
+func resource{{ $.ResourceName -}}PostDeleteFailure(d *schema.ResourceData, meta interface{}, err error) error {
     {{- customTemplate $ $.CustomCode.PostDeleteFailure false -}}
 }
 {{- end }}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -397,9 +397,9 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{- end}}
     })
     if err != nil {
-{{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) -}}
+{{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) }}
         err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
         return fmt.Errorf("Error creating {{ $.Name -}}: %s", err)
     }
 {{- /* Set computed resource properties required for building the ID from create API response (as long as Create doesn't use an async operation) */}}
@@ -435,9 +435,9 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
     config, res, &opRes, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }},{{if $.ProductMetadata.Version.RepEnabled }} location,{{ end -}}{{ end -}} "Creating {{ $.Name -}}", userAgent,
         d.Timeout(schema.TimeoutCreate))
     if err != nil {
-{{if $.CustomCode.PostCreateFailure -}}
+{{- if $.CustomCode.PostCreateFailure }}
         err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
 {{-          if not $.TaintResourceOnFailedCreate -}}
         // The resource didn't actually create
         d.SetId("")
@@ -515,9 +515,9 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
         d.Timeout(schema.TimeoutCreate))
 
     if err != nil {
-{{if $.CustomCode.PostCreateFailure -}}
+{{- if $.CustomCode.PostCreateFailure }}
         err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
-{{ end}}
+{{ end -}}
 {{-          if not $.TaintResourceOnFailedCreate -}}
         // The resource didn't actually create
         d.SetId("")
@@ -540,10 +540,10 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 
         log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name }} %q finished updating: %q", d.Id(), err)
 
-{{-        else }}
-{{- if $.CustomCode.PostCreateFailure -}}
+{{-        else -}}
+{{- if $.CustomCode.PostCreateFailure }}
         err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
         return fmt.Errorf("Error waiting to create {{ $.Name -}}: %s", err)
 {{- end}}
     }
@@ -1049,9 +1049,9 @@ if len(updateMask) > 0 {
     })
 
     if err != nil {
-{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
+{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) }}
         err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
         return fmt.Errorf("Error updating {{ $.Name }} %q: %s", d.Id(), err)
     } else {
         log.Printf("[DEBUG] Finished updating {{ $.Name }} %q: %#v", d.Id(), res)
@@ -1068,9 +1068,9 @@ if len(updateMask) > 0 {
         d.Timeout(schema.TimeoutUpdate))
 
     if err != nil {
-{{- if $.CustomCode.PostUpdateFailure -}}
+{{- if $.CustomCode.PostUpdateFailure }}
         err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
         return err
     }
 {{-             if not $.FieldSpecificUpdateMethods }}
@@ -1082,9 +1082,9 @@ if len(updateMask) > 0 {
 {{                      if $.GetAsync.SuppressError -}}
         log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name -}} %q finished updating: %q", d.Id(), err)
 {{                      else -}}
-{{- if $.CustomCode.PostUpdateFailure -}}
+{{- if $.CustomCode.PostUpdateFailure }}
         err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
         return err
 {{-                     end}}
     }
@@ -1246,9 +1246,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 			Headers:   headers,
         })
         if err != nil {
-{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
+{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) }}
             err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
             return fmt.Errorf("Error updating {{ $.Name }} %q: %s", d.Id(), err)
         } else {
         log.Printf("[DEBUG] Finished updating {{ $.Name }} %q: %#v", d.Id(), res)
@@ -1264,9 +1264,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 	        config, res, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}}{{if $.ProductMetadata.Version.RepEnabled }} location,{{ end -}} "Updating {{ $.Name -}}", userAgent,
 	        d.Timeout(schema.TimeoutUpdate))
 	    if err != nil {
-{{- if $.CustomCode.PostUpdateFailure -}}
+{{- if $.CustomCode.PostUpdateFailure }}
 	        err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
 	        return err
 	    }
 {{-                      else if $.GetAsync.IsA "PollAsync" -}}
@@ -1275,9 +1275,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 {{-                          if $.GetAsync.SuppressError -}}
 	        log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name -}} %q finished updating: %q", d.Id(), err)
 {{-                          else -}}
-{{- if $.CustomCode.PostUpdateFailure -}}
+{{- if $.CustomCode.PostUpdateFailure }}
 	        err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
 	        return err
 {{-                         end}}
         }
@@ -1420,9 +1420,9 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         {{- end }}
     })
     if err != nil {
-{{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) -}}
+{{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) }}
         err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
-{{- end}}
+{{- end -}}
         return transport_tpg.HandleNotFoundError(err, d, "{{ $.Name }}")
     }
     {{ if and $.GetAsync ($.GetAsync.Allow "Delete") -}}
@@ -1431,10 +1431,10 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
     if err != nil {
             {{- if $.Async.SuppressError }}
         log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name }} %q finished updating: %q", d.Id(), err)
-            {{- else }}
-{{- if $.CustomCode.PostDeleteFailure -}}
+            {{- else -}}
+{{- if $.CustomCode.PostDeleteFailure }}
         err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
-{{- end}}
+{{- end -}}
         return fmt.Errorf("Error waiting to delete {{ $.Name }}: %s", err)
             {{- end }}
     }
@@ -1448,9 +1448,9 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         d.Timeout(schema.TimeoutDelete))
 
     if err != nil {
-{{- if $.CustomCode.PostDeleteFailure -}}
+{{- if $.CustomCode.PostDeleteFailure }}
         err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
-{{- end}}
+{{- end -}}
         return err
     }
     {{- end }}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -1534,17 +1534,20 @@ func resource{{ $.ResourceName -}}Decoder(d *schema.ResourceData, meta interface
 {{- end }}
 {{- if $.CustomCode.PostCreateFailure }}
 func resource{{ $.ResourceName -}}PostCreateFailure(d *schema.ResourceData, meta interface{}, err error) error {
-    {{- customTemplate $ $.CustomCode.PostCreateFailure false -}}
+    log.Printf("[DEBUG] Error before post_create_failure hook: %v", err)
+    {{ customTemplate $ $.CustomCode.PostCreateFailure false -}}
 }
 {{- end }}
 {{- if $.CustomCode.PostUpdateFailure }}
 func resource{{ $.ResourceName -}}PostUpdateFailure(d *schema.ResourceData, meta interface{}, err error) error {
-    {{- customTemplate $ $.CustomCode.PostUpdateFailure false -}}
+    log.Printf("[DEBUG] Error before post_update_failure hook: %v", err)
+    {{ customTemplate $ $.CustomCode.PostUpdateFailure false -}}
 }
 {{- end }}
 {{- if $.CustomCode.PostDeleteFailure }}
 func resource{{ $.ResourceName -}}PostDeleteFailure(d *schema.ResourceData, meta interface{}, err error) error {
-    {{- customTemplate $ $.CustomCode.PostDeleteFailure false -}}
+    log.Printf("[DEBUG] Error before post_delete_failure hook: %v", err)
+    {{ customTemplate $ $.CustomCode.PostDeleteFailure false -}}
 }
 {{- end }}
 {{- if and $.SchemaVersion $.StateUpgraders }}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -397,9 +397,9 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{- end}}
     })
     if err != nil {
-{{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) }}
+{{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) -}}
         err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
-{{- end -}}
+{{- end}}
         return fmt.Errorf("Error creating {{ $.Name -}}: %s", err)
     }
 {{- /* Set computed resource properties required for building the ID from create API response (as long as Create doesn't use an async operation) */}}
@@ -435,9 +435,9 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
     config, res, &opRes, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }},{{if $.ProductMetadata.Version.RepEnabled }} location,{{ end -}}{{ end -}} "Creating {{ $.Name -}}", userAgent,
         d.Timeout(schema.TimeoutCreate))
     if err != nil {
-{{- if $.CustomCode.PostCreateFailure }}
+{{if $.CustomCode.PostCreateFailure -}}
         err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
-{{- end -}}
+{{- end}}
 {{-          if not $.TaintResourceOnFailedCreate -}}
         // The resource didn't actually create
         d.SetId("")
@@ -515,9 +515,9 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
         d.Timeout(schema.TimeoutCreate))
 
     if err != nil {
-{{- if $.CustomCode.PostCreateFailure }}
+{{if $.CustomCode.PostCreateFailure -}}
         err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
-{{ end -}}
+{{ end}}
 {{-          if not $.TaintResourceOnFailedCreate -}}
         // The resource didn't actually create
         d.SetId("")
@@ -540,10 +540,10 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 
         log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name }} %q finished updating: %q", d.Id(), err)
 
-{{-        else -}}
-{{- if $.CustomCode.PostCreateFailure }}
+{{-        else }}
+{{- if $.CustomCode.PostCreateFailure -}}
         err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
-{{- end -}}
+{{- end}}
         return fmt.Errorf("Error waiting to create {{ $.Name -}}: %s", err)
 {{- end}}
     }
@@ -1049,9 +1049,9 @@ if len(updateMask) > 0 {
     })
 
     if err != nil {
-{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) }}
+{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
         err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end -}}
+{{- end}}
         return fmt.Errorf("Error updating {{ $.Name }} %q: %s", d.Id(), err)
     } else {
         log.Printf("[DEBUG] Finished updating {{ $.Name }} %q: %#v", d.Id(), res)
@@ -1068,9 +1068,9 @@ if len(updateMask) > 0 {
         d.Timeout(schema.TimeoutUpdate))
 
     if err != nil {
-{{- if $.CustomCode.PostUpdateFailure }}
+{{- if $.CustomCode.PostUpdateFailure -}}
         err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end -}}
+{{- end}}
         return err
     }
 {{-             if not $.FieldSpecificUpdateMethods }}
@@ -1082,9 +1082,9 @@ if len(updateMask) > 0 {
 {{                      if $.GetAsync.SuppressError -}}
         log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name -}} %q finished updating: %q", d.Id(), err)
 {{                      else -}}
-{{- if $.CustomCode.PostUpdateFailure }}
+{{- if $.CustomCode.PostUpdateFailure -}}
         err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end -}}
+{{ end -}}
         return err
 {{-                     end}}
     }
@@ -1246,9 +1246,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 			Headers:   headers,
         })
         if err != nil {
-{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) }}
+{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
             err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end -}}
+{{- end}}
             return fmt.Errorf("Error updating {{ $.Name }} %q: %s", d.Id(), err)
         } else {
         log.Printf("[DEBUG] Finished updating {{ $.Name }} %q: %#v", d.Id(), res)
@@ -1264,9 +1264,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 	        config, res, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}}{{if $.ProductMetadata.Version.RepEnabled }} location,{{ end -}} "Updating {{ $.Name -}}", userAgent,
 	        d.Timeout(schema.TimeoutUpdate))
 	    if err != nil {
-{{- if $.CustomCode.PostUpdateFailure }}
+{{- if $.CustomCode.PostUpdateFailure -}}
 	        err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end -}}
+{{- end}}
 	        return err
 	    }
 {{-                      else if $.GetAsync.IsA "PollAsync" -}}
@@ -1275,9 +1275,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 {{-                          if $.GetAsync.SuppressError -}}
 	        log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name -}} %q finished updating: %q", d.Id(), err)
 {{-                          else -}}
-{{- if $.CustomCode.PostUpdateFailure }}
+{{- if $.CustomCode.PostUpdateFailure -}}
 	        err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end -}}
+{{ end -}}
 	        return err
 {{-                         end}}
         }
@@ -1420,9 +1420,9 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         {{- end }}
     })
     if err != nil {
-{{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) }}
+{{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) -}}
         err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
-{{- end -}}
+{{- end}}
         return transport_tpg.HandleNotFoundError(err, d, "{{ $.Name }}")
     }
     {{ if and $.GetAsync ($.GetAsync.Allow "Delete") -}}
@@ -1431,10 +1431,10 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
     if err != nil {
             {{- if $.Async.SuppressError }}
         log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name }} %q finished updating: %q", d.Id(), err)
-            {{- else -}}
-{{- if $.CustomCode.PostDeleteFailure }}
+            {{- else }}
+{{- if $.CustomCode.PostDeleteFailure -}}
         err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
-{{- end -}}
+{{- end}}
         return fmt.Errorf("Error waiting to delete {{ $.Name }}: %s", err)
             {{- end }}
     }
@@ -1448,9 +1448,9 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         d.Timeout(schema.TimeoutDelete))
 
     if err != nil {
-{{- if $.CustomCode.PostDeleteFailure }}
+{{- if $.CustomCode.PostDeleteFailure -}}
         err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
-{{- end -}}
+{{- end}}
         return err
     }
     {{- end }}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -1049,6 +1049,9 @@ if len(updateMask) > 0 {
     })
 
     if err != nil {
+{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
+        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+{{- end}}
         return fmt.Errorf("Error updating {{ $.Name }} %q: %s", d.Id(), err)
     } else {
         log.Printf("[DEBUG] Finished updating {{ $.Name }} %q: %#v", d.Id(), res)
@@ -1065,6 +1068,9 @@ if len(updateMask) > 0 {
         d.Timeout(schema.TimeoutUpdate))
 
     if err != nil {
+{{- if $.CustomCode.PostUpdateFailure -}}
+        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+{{- end}}
         return err
     }
 {{-             if not $.FieldSpecificUpdateMethods }}
@@ -1076,6 +1082,9 @@ if len(updateMask) > 0 {
 {{                      if $.GetAsync.SuppressError -}}
         log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name -}} %q finished updating: %q", d.Id(), err)
 {{                      else -}}
+{{- if $.CustomCode.PostUpdateFailure -}}
+        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+{{- end}}
         return err
 {{-                     end}}
     }
@@ -1237,6 +1246,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 			Headers:   headers,
         })
         if err != nil {
+{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
+            resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+{{- end}}
             return fmt.Errorf("Error updating {{ $.Name }} %q: %s", d.Id(), err)
         } else {
         log.Printf("[DEBUG] Finished updating {{ $.Name }} %q: %#v", d.Id(), res)
@@ -1252,6 +1264,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 	        config, res, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}}{{if $.ProductMetadata.Version.RepEnabled }} location,{{ end -}} "Updating {{ $.Name -}}", userAgent,
 	        d.Timeout(schema.TimeoutUpdate))
 	    if err != nil {
+{{- if $.CustomCode.PostUpdateFailure -}}
+	        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+{{- end}}
 	        return err
 	    }
 {{-                      else if $.GetAsync.IsA "PollAsync" -}}
@@ -1260,6 +1275,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 {{-                          if $.GetAsync.SuppressError -}}
 	        log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name -}} %q finished updating: %q", d.Id(), err)
 {{-                          else -}}
+{{- if $.CustomCode.PostUpdateFailure -}}
+	        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+{{- end}}
 	        return err
 {{-                         end}}
         }
@@ -1402,6 +1420,9 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         {{- end }}
     })
     if err != nil {
+{{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) -}}
+        resource{{ $.ResourceName -}}PostDeleteFailure(d, meta)
+{{- end}}
         return transport_tpg.HandleNotFoundError(err, d, "{{ $.Name }}")
     }
     {{ if and $.GetAsync ($.GetAsync.Allow "Delete") -}}
@@ -1411,6 +1432,9 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
             {{- if $.Async.SuppressError }}
         log.Printf("[ERROR] Unable to confirm eventually consistent {{ $.Name }} %q finished updating: %q", d.Id(), err)
             {{- else }}
+{{- if $.CustomCode.PostDeleteFailure -}}
+        resource{{ $.ResourceName -}}PostDeleteFailure(d, meta)
+{{- end}}
         return fmt.Errorf("Error waiting to delete {{ $.Name }}: %s", err)
             {{- end }}
     }
@@ -1424,6 +1448,9 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         d.Timeout(schema.TimeoutDelete))
 
     if err != nil {
+{{- if $.CustomCode.PostDeleteFailure -}}
+        resource{{ $.ResourceName -}}PostDeleteFailure(d, meta)
+{{- end}}
         return err
     }
     {{- end }}
@@ -1508,6 +1535,16 @@ func resource{{ $.ResourceName -}}Decoder(d *schema.ResourceData, meta interface
 {{- if $.CustomCode.PostCreateFailure }}
 func resource{{ $.ResourceName -}}PostCreateFailure(d *schema.ResourceData, meta interface{}) {
     {{- customTemplate $ $.CustomCode.PostCreateFailure false -}}
+}
+{{- end }}
+{{- if $.CustomCode.PostUpdateFailure }}
+func resource{{ $.ResourceName -}}PostUpdateFailure(d *schema.ResourceData, meta interface{}) {
+    {{- customTemplate $ $.CustomCode.PostUpdateFailure false -}}
+}
+{{- end }}
+{{- if $.CustomCode.PostDeleteFailure }}
+func resource{{ $.ResourceName -}}PostDeleteFailure(d *schema.ResourceData, meta interface{}) {
+    {{- customTemplate $ $.CustomCode.PostDeleteFailure false -}}
 }
 {{- end }}
 {{- if and $.SchemaVersion $.StateUpgraders }}

--- a/mmv1/templates/terraform/resource_fw.go.tmpl
+++ b/mmv1/templates/terraform/resource_fw.go.tmpl
@@ -306,9 +306,9 @@ func (r *{{$.ResourceName}}FWResource) Create(ctx context.Context, req resource.
 {{- end}}
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
-{{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) -}}
+{{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) }}
         err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
         return 
     }
 
@@ -526,9 +526,9 @@ func (r *{{$.ResourceName}}FWResource) Update(ctx context.Context, req resource.
 {{- end}}
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
-{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
+{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) }}
         err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end}}
+{{- end -}}
         return 
     }
 
@@ -670,9 +670,9 @@ func (r *{{$.ResourceName}}FWResource) Delete(ctx context.Context, req resource.
 {{- end}}
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
-{{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) -}}
+{{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) }}
         err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
-{{- end}}
+{{- end -}}
 		diags.AddError(fmt.Sprintf("Error deleting {{ $.Name -}}: %s", data.Id.ValueString()), err.Error())
         return 
     }

--- a/mmv1/templates/terraform/resource_fw.go.tmpl
+++ b/mmv1/templates/terraform/resource_fw.go.tmpl
@@ -306,9 +306,9 @@ func (r *{{$.ResourceName}}FWResource) Create(ctx context.Context, req resource.
 {{- end}}
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
-{{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) }}
+{{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) -}}
         err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
-{{- end -}}
+{{- end}}
         return 
     }
 
@@ -526,9 +526,9 @@ func (r *{{$.ResourceName}}FWResource) Update(ctx context.Context, req resource.
 {{- end}}
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
-{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) }}
+{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
         err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
-{{- end -}}
+{{- end}}
         return 
     }
 
@@ -670,9 +670,9 @@ func (r *{{$.ResourceName}}FWResource) Delete(ctx context.Context, req resource.
 {{- end}}
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
-{{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) }}
+{{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) -}}
         err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
-{{- end -}}
+{{- end}}
 		diags.AddError(fmt.Sprintf("Error deleting {{ $.Name -}}: %s", data.Id.ValueString()), err.Error())
         return 
     }

--- a/mmv1/templates/terraform/resource_fw.go.tmpl
+++ b/mmv1/templates/terraform/resource_fw.go.tmpl
@@ -526,6 +526,9 @@ func (r *{{$.ResourceName}}FWResource) Update(ctx context.Context, req resource.
 {{- end}}
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
+{{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
+        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+{{- end}}
         return 
     }
 
@@ -667,6 +670,9 @@ func (r *{{$.ResourceName}}FWResource) Delete(ctx context.Context, req resource.
 {{- end}}
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
+{{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) -}}
+        resource{{ $.ResourceName -}}PostDeleteFailure(d, meta)
+{{- end}}
 		diags.AddError(fmt.Sprintf("Error deleting {{ $.Name -}}: %s", data.Id.ValueString()), err.Error())
         return 
     }

--- a/mmv1/templates/terraform/resource_fw.go.tmpl
+++ b/mmv1/templates/terraform/resource_fw.go.tmpl
@@ -307,7 +307,7 @@ func (r *{{$.ResourceName}}FWResource) Create(ctx context.Context, req resource.
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 {{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) -}}
-        resource{{ $.ResourceName -}}PostCreateFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostCreateFailure(d, meta, err)
 {{- end}}
         return 
     }
@@ -527,7 +527,7 @@ func (r *{{$.ResourceName}}FWResource) Update(ctx context.Context, req resource.
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 {{- if and ($.CustomCode.PostUpdateFailure) (not $.GetAsync) -}}
-        resource{{ $.ResourceName -}}PostUpdateFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostUpdateFailure(d, meta, err)
 {{- end}}
         return 
     }
@@ -671,7 +671,7 @@ func (r *{{$.ResourceName}}FWResource) Delete(ctx context.Context, req resource.
     }, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 {{- if and ($.CustomCode.PostDeleteFailure) (not $.GetAsync) -}}
-        resource{{ $.ResourceName -}}PostDeleteFailure(d, meta)
+        err = resource{{ $.ResourceName -}}PostDeleteFailure(d, meta, err)
 {{- end}}
 		diags.AddError(fmt.Sprintf("Error deleting {{ $.Name -}}: %s", data.Id.ValueString()), err.Error())
         return 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This extends post_create_failure to all CUD operation types and enables standardized error manipulation (not just handling).

This was a gap when working on https://github.com/GoogleCloudPlatform/magic-modules/pull/18735. The workaround would've been fully custom operation code.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
