### PR TITLE
compute: mark instance autoDelete updatable

### DIFF
--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -94,6 +94,8 @@ properties:
       properties:
         - name: 'autoDelete'
           type: Boolean
+          update_url: '/projects/{{project}}/zones/{{zone}}/instances/{resourceId}/setDiskAutoDelete'
+          update_verb: 'POST'
           description: |
             Specifies whether the disk will be auto-deleted when the
             instance is deleted (but not when the disk is detached from

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -4675,6 +4675,11 @@ func TestAccComputeInstance_autoDeleteUpdate(t *testing.T) {
 			},
 			{
 				Config: testAccComputeInstance_autoDeleteUpdate(context_2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_instance.foobar", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
 					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.auto_delete", "false"),
@@ -4682,6 +4687,11 @@ func TestAccComputeInstance_autoDeleteUpdate(t *testing.T) {
 			},
 			{
 				Config: testAccComputeInstance_autoDeleteUpdate(context_1),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_instance.foobar", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
 					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.auto_delete", "true"),
@@ -14689,4 +14699,3 @@ resource "google_compute_instance" "foobar" {
 }
 `, context)
 }
-


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Corrects the MMv1 update metadata for `google_compute_instance.boot_disk.auto_delete` to match the existing handwritten in-place-update implementation. Adds acceptance-test plan checks confirming that changes continue to update the instance rather than replace it. 

```
compute: aligned google_compute_instance.boot_disk.auto_delete metadata with its existing in-place update behavior
```
