### PR TITLE
Fix ContainerNodePool defaulting cpu_cfs_quota to false in TGC/KCC

### DIFF
--- a/mmv1/third_party/tgc_next/pkg/services/container/node_config.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/node_config.go
@@ -1805,6 +1805,13 @@ func expandNodeConfig(d tpgresource.TerraformResourceData, prefix string, v inte
 
 			if vNC := rawConfigNPRoot.GetAttr("node_config"); vNC.LengthInt() > 0 {
 				if vKC := vNC.Index(cty.NumberIntVal(0)).GetAttr("kubelet_config"); vKC.LengthInt() > 0 {
+					v := vKC.Index(cty.NumberIntVal(0)).GetAttr("cpu_cfs_quota")
+					if v == cty.NullVal(cty.Bool) {
+						nc.KubeletConfig.CpuCfsQuota = true
+					} else if v.False() {
+						nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "CpuCfsQuota")
+					}
+
 					vSGP := vKC.Index(cty.NumberIntVal(0)).GetAttr("shutdown_grace_period_seconds")
 					if vSGP != cty.NullVal(cty.Number) && !vSGP.IsNull() {
 						nc.KubeletConfig.ForceSendFields = append(nc.KubeletConfig.ForceSendFields, "ShutdownGracePeriodSeconds")


### PR DESCRIPTION
### Description
When `kubeletConfig` is defined on a GKE node pool in Config Connector (KCC) or `terraform_google_conversion` (TGC) without explicitly setting `cpuCfsQuota`, the field was evaluated to `false` because Terraform Plugin SDK maps populate the Go zero-value (`false`) for omitted boolean fields. This caused TGC/KCC to force-send `cpuCfsQuota: false` to the GKE Cluster Manager API.

PR #15268 fixed this for the standalone Terraform CLI provider by inspecting `d.GetRawConfig()`, but this logic was omitted from `tgc_next`, leaving KCC vulnerable to the bug.

### Changes
Ports the `cpu_cfs_quota` raw configuration check from `node_config.go.tmpl` into `tgc_next/pkg/services/container/node_config.go` (`expandNodeConfig`) so that:
- When omitted or null, `nc.KubeletConfig.CpuCfsQuota` is explicitly set to `true` (matching native GKE behavior).
- When explicitly set to `false`, `CpuCfsQuota` is appended to `ForceSendFields`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15767
Ref b/553981933, b/300067081, b/395145072

```release-note:bug
container: fixed an issue where omitting `cpu_cfs_quota` in `kubelet_config` defaulted to `false` in `terraform-google-conversion` (TGC) / Config Connector
```
