### PR TITLE
databasemigrationservice: fix display_name in test configs

### DIFF
--- a/mmv1/products/databasemigrationservice/PrivateConnection.yaml
+++ b/mmv1/products/databasemigrationservice/PrivateConnection.yaml
@@ -43,6 +43,7 @@ async:
     resource_inside_response: false
 autogen_async: true
 custom_code:
+error_retry_predicates: ['transport_tpg.IsDatabaseMigrationServiceOperationTimeoutError']
 samples:
   - name: database_migration_service_private_connection
     primary_resource_id: default

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_alloydb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_alloydb.tf.tmpl
@@ -23,7 +23,7 @@ resource "google_service_networking_connection" "vpc_connection" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "profile"}}"
-  display_name = "{{index $.ResourceIdVars "profile"}}_display"
+  display_name = "{{index $.ResourceIdVars "profile"}}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_cloudsql.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_cloudsql.tf.tmpl
@@ -31,7 +31,7 @@ resource "google_sql_user" "sqldb_user" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "from_profile"}}"
-  display_name          = "{{index $.ResourceIdVars "from_profile"}}_display"
+  display_name          = "{{index $.ResourceIdVars "from_profile"}}-display"
   labels = { 
     foo = "bar"
   }
@@ -56,7 +56,7 @@ resource "google_database_migration_service_connection_profile" "{{$.PrimaryReso
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}_destination" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "to_profile"}}"
-  display_name          = "{{index $.ResourceIdVars "to_profile"}}_displayname"
+  display_name          = "{{index $.ResourceIdVars "to_profile"}}-displayname"
   labels = { 
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_alloydb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_alloydb.tf.tmpl
@@ -46,7 +46,7 @@ resource "google_compute_network" "default" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_mysql.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_mysql.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_postgres.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_postgres.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_oracle.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_oracle.tf.tmpl
@@ -1,7 +1,7 @@
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "profile"}}"
-  display_name = "{{index $.ResourceIdVars "profile"}}_display"
+  display_name = "{{index $.ResourceIdVars "profile"}}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres.tf.tmpl
@@ -26,7 +26,7 @@ resource "google_sql_user" "sqldb_user" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "profile"}}"
-  display_name = "{{index $.ResourceIdVars "profile"}}_display"
+  display_name = "{{index $.ResourceIdVars "profile"}}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres_no_ssl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres_no_ssl.tf.tmpl
@@ -26,7 +26,7 @@ resource "google_sql_user" "sqldb_user" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "profile"}}"
-  display_name = "{{index $.ResourceIdVars "profile"}}_display"
+  display_name = "{{index $.ResourceIdVars "profile"}}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres_required_ssl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres_required_ssl.tf.tmpl
@@ -26,7 +26,7 @@ resource "google_sql_user" "sqldb_user" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "profile"}}"
-  display_name = "{{index $.ResourceIdVars "profile"}}_display"
+  display_name = "{{index $.ResourceIdVars "profile"}}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_mysql_to_mysql.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_mysql_to_mysql.tf.tmpl
@@ -29,7 +29,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "source_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "source_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "source_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -63,7 +63,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -80,7 +80,7 @@ resource "google_compute_network" "default" {
 resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   migration_job_id = "{{index $.ResourceIdVars "migration_id"}}"
-  display_name = "{{index $.ResourceIdVars "migration_id"}}_display"
+  display_name = "{{index $.ResourceIdVars "migration_id"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_alloydb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_alloydb.tf.tmpl
@@ -29,7 +29,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "source_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "source_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "source_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -95,7 +95,7 @@ resource "google_compute_network" "default" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -108,7 +108,7 @@ resource "google_database_migration_service_connection_profile" "destination_cp"
 resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   migration_job_id = "{{index $.ResourceIdVars "migration_id"}}"
-  display_name = "{{index $.ResourceIdVars "migration_id"}}_display"
+  display_name = "{{index $.ResourceIdVars "migration_id"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_postgres.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_postgres.tf.tmpl
@@ -29,7 +29,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "source_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "source_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "source_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -63,7 +63,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -76,7 +76,7 @@ resource "google_database_migration_service_connection_profile" "destination_cp"
 resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   migration_job_id = "{{index $.ResourceIdVars "migration_id"}}"
-  display_name = "{{index $.ResourceIdVars "migration_id"}}_display"
+  display_name = "{{index $.ResourceIdVars "migration_id"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_postgres_objects.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_postgres_objects.tf.tmpl
@@ -29,7 +29,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "source_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "source_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "source_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -63,7 +63,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -76,7 +76,7 @@ resource "google_database_migration_service_connection_profile" "destination_cp"
 resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceId}}" {
   location         = "us-central1"
   migration_job_id = "{{index $.ResourceIdVars "migration_id"}}"
-  display_name     = "{{index $.ResourceIdVars "migration_id"}}_display"
+  display_name     = "{{index $.ResourceIdVars "migration_id"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_postgres_objects.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_postgres_objects.tf.tmpl
@@ -97,10 +97,8 @@ resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceI
       }
       object_configs {
         object_identifier {
-          type     = "TABLE"
+          type     = "DATABASE"
           database = "my_other_database"
-          schema   = "public"
-          table    = "users"
         }
       }
     }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_private_connection.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_private_connection.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_database_migration_service_private_connection" "{{$.PrimaryResourceId}}" {
-	display_name          = "dbms_pc"
+	display_name          = "dbms-pc"
 	location              = "us-west1"
 	private_connection_id = "{{index $.ResourceIdVars "private_connection_id"}}"
 

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_private_connection_psc.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_private_connection_psc.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_database_migration_service_private_connection" "{{$.PrimaryResourceId}}" {
-	display_name          = "dbms_pc"
+	display_name          = "dbms-pc"
 	location              = "us-west1"
 	private_connection_id = "{{index $.ResourceIdVars "private_connection_id"}}"
 

--- a/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_connection_profile_test.go
@@ -125,7 +125,7 @@ data "google_compute_network" "default" {
 resource "google_database_migration_service_connection_profile" "alloydbprofile" {
   location = "us-central1"
   connection_profile_id = "tf-test-my-profileid%{random_suffix}"
-  display_name = "tf-test-my-profileid%{random_suffix}_display"
+  display_name = "tf-test-my-profileid%{random_suffix}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_migration_job_test.go
+++ b/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_migration_job_test.go
@@ -80,7 +80,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "tf-test-source-cp%{random_suffix}"
-  display_name          = "tf-test-source-cp%{random_suffix}_display"
+  display_name          = "tf-test-source-cp%{random_suffix}-display"
   labels = {
     foo = "bar"
   }
@@ -114,7 +114,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "tf-test-destination-cp%{random_suffix}"
-  display_name          = "tf-test-destination-cp%{random_suffix}_display"
+  display_name          = "tf-test-destination-cp%{random_suffix}-display"
   labels = {
     foo = "bar"
   }
@@ -131,7 +131,7 @@ resource "google_compute_network" "default" {
 resource "google_database_migration_service_migration_job" "mysqltomysql" {
   location              = "us-central1"
   migration_job_id = "tf-test-my-migrationid%{random_suffix}"
-  display_name = "tf-test-my-migrationid%{random_suffix}_display"
+  display_name = "tf-test-my-migrationid%{random_suffix}-display"
   labels = {
     foo = "bar"
   }
@@ -188,7 +188,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "tf-test-source-cp%{random_suffix}"
-  display_name          = "tf-test-source-cp%{random_suffix}_display"
+  display_name          = "tf-test-source-cp%{random_suffix}-display"
   labels = {
     foo = "bar"
   }
@@ -222,7 +222,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "tf-test-destination-cp%{random_suffix}"
-  display_name          = "tf-test-destination-cp%{random_suffix}_display"
+  display_name          = "tf-test-destination-cp%{random_suffix}-display"
   labels = {
     foo = "bar"
   }
@@ -239,7 +239,7 @@ resource "google_compute_network" "default" {
 resource "google_database_migration_service_migration_job" "mysqltomysql" {
   location              = "us-central1"
   migration_job_id = "tf-test-my-migrationid%{random_suffix}"
-  display_name = "tf-test-my-migrationid%{random_suffix}_display"
+  display_name = "tf-test-my-migrationid%{random_suffix}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -749,3 +749,16 @@ func IsNetworkAttachmentConnectedEndpointsError(err error) (bool, string) {
 	}
 	return false, ""
 }
+
+// Retry on Database Migration Service operation timeout error.
+func IsDatabaseMigrationServiceOperationTimeoutError(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if strings.Contains(gerr.Body, "Operation timed out") {
+			return true, "Database Migration Service operation timed out, retrying"
+		}
+	}
+	if err != nil && strings.Contains(err.Error(), "Operation timed out") {
+		return true, "Database Migration Service operation timed out, retrying"
+	}
+	return false, ""
+}

--- a/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
@@ -276,3 +276,14 @@ func TestExternalIpServiceNotActive(t *testing.T) {
 		t.Errorf("Error not detected as retryable")
 	}
 }
+
+func TestIsDatabaseMigrationServiceOperationTimeoutError(t *testing.T) {
+	err := googleapi.Error{
+		Code: 400,
+		Body: "Operation timed out.",
+	}
+	isRetryable, _ := IsDatabaseMigrationServiceOperationTimeoutError(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}


### PR DESCRIPTION
Fix Database Migration Service tests, samples, and deletion issues:

1. **`display_name` validation**: Replace invalid underscore (`_`) characters in `display_name` fields with hyphens (`-`) across test configurations and sample templates, satisfying API validation (`^[a-zA-Z][a-zA-Z0-9 -]*$`) and resolving `"The field display_name can't contain special characters."` errors.
2. **Object filtering type**: Update `database_migration_service_migration_job_postgres_to_postgres_objects` sample template to use database-level filtering (`type = "DATABASE"`) instead of table-level filtering, resolving `"Schema and table level filtering is not supported."` errors.
3. **Private connection deletion retry**: Add `IsDatabaseMigrationServiceOperationTimeoutError` retry predicate to `google_database_migration_service_private_connection` to handle and retry when the backend operation returns `"Operation timed out."` during deletion.

```release-note:none
```
