### PR TITLE
escape version/digest in artifact registry data source request paths

### DIFF
--- a/mmv1/third_party/terraform/services/artifactregistry/artifact_registry_resource_ref.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/artifact_registry_resource_ref.go
@@ -1,0 +1,20 @@
+package artifactregistry
+
+import "net/url"
+
+// artifactResourceRef builds the trailing "{name}{sep}{version}" path component
+// of an Artifact Registry resource URL from caller-supplied identifiers (an
+// image_name/package_name/artifact_id and its tag or digest).
+//
+// The name keeps the query-escaping the data sources already applied. The
+// version/digest was previously interpolated raw, so a value carrying "/", "?"
+// or "#" could add path segments, a query string, or a fragment to the request
+// URL and reach a different resource than the one configured. Path-escaping it
+// leaves a valid semver or "sha256:<hex>" digest unchanged while neutralizing
+// those characters.
+func artifactResourceRef(name, sep, version string) string {
+	if version == "" {
+		return url.QueryEscape(name)
+	}
+	return url.QueryEscape(name) + sep + url.PathEscape(version)
+}

--- a/mmv1/third_party/terraform/services/artifactregistry/artifact_registry_resource_ref_internal_test.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/artifact_registry_resource_ref_internal_test.go
@@ -1,0 +1,58 @@
+package artifactregistry
+
+import "testing"
+
+func TestArtifactResourceRef(t *testing.T) {
+	cases := []struct {
+		name    string
+		refName string
+		sep     string
+		version string
+		want    string
+	}{
+		{
+			name:    "npm semver left intact",
+			refName: "my-package",
+			sep:     ":",
+			version: "1.2.3",
+			want:    "my-package:1.2.3",
+		},
+		{
+			name:    "docker digest keeps its colon",
+			refName: "my-image",
+			sep:     "@",
+			version: "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+			want:    "my-image@sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+		},
+		{
+			name:    "no version escapes only the name",
+			refName: "krane/debug",
+			sep:     ":",
+			version: "",
+			want:    "krane%2Fdebug",
+		},
+		{
+			name:    "traversal in version is neutralized",
+			refName: "my-package",
+			sep:     ":",
+			version: "1.0.0/../../otherRepo/npmPackages/evil",
+			want:    "my-package:1.0.0%2F..%2F..%2FotherRepo%2FnpmPackages%2Fevil",
+		},
+		{
+			name:    "query and fragment in version are neutralized",
+			refName: "my-image",
+			sep:     "@",
+			version: "sha256:abc?alt=media#frag",
+			want:    "my-image@sha256:abc%3Falt=media%23frag",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := artifactResourceRef(tc.refName, tc.sep, tc.version)
+			if got != tc.want {
+				t.Errorf("artifactResourceRef(%q, %q, %q) = %q, want %q", tc.refName, tc.sep, tc.version, got, tc.want)
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_docker_image.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_docker_image.go
@@ -108,8 +108,7 @@ func DataSourceArtifactRegistryDockerImageRead(d *schema.ResourceData, meta inte
 	if digest != "" {
 		// fetch image by digest
 		// https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.dockerImages/get
-		imageUrlSafe := url.QueryEscape(imageName)
-		urlRequest, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf(transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/dockerImages/%s@%s", imageUrlSafe, digest))
+		urlRequest, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf(transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/dockerImages/%s", artifactResourceRef(imageName, "@", digest)))
 		if err != nil {
 			return fmt.Errorf("Error setting api endpoint")
 		}

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_maven_artifact.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_maven_artifact.go
@@ -93,8 +93,7 @@ func DataSourceArtifactRegistryMavenArtifactRead(d *schema.ResourceData, meta in
 	if version != "" {
 		// fetch package by version
 		// https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.mavenArtifacts/get
-		packageUrlSafe := url.QueryEscape(packageName)
-		urlRequest, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf(transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/mavenArtifacts/%s:%s", packageUrlSafe, version))
+		urlRequest, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf(transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/mavenArtifacts/%s", artifactResourceRef(packageName, ":", version)))
 		if err != nil {
 			return fmt.Errorf("Error setting api endpoint")
 		}

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_npm_package.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_npm_package.go
@@ -96,8 +96,7 @@ func DataSourceArtifactRegistryNpmPackageRead(d *schema.ResourceData, meta inter
 	if version != "" {
 		// fetch package by version
 		// https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.npmPackages/get
-		packageUrlSafe := url.QueryEscape(packageName)
-		urlRequest, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf(transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/npmPackages/%s:%s", packageUrlSafe, version))
+		urlRequest, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf(transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/npmPackages/%s", artifactResourceRef(packageName, ":", version)))
 		if err != nil {
 			return fmt.Errorf("Error setting api endpoint")
 		}

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_python_package.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_python_package.go
@@ -89,8 +89,7 @@ func DataSourceArtifactRegistryPythonPackageRead(d *schema.ResourceData, meta in
 	if version != "" {
 		// fetch package by version
 		// https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.pythonPackages/get
-		packageUrlSafe := url.QueryEscape(packageName)
-		urlRequest, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf(transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/pythonPackages/%s:%s", packageUrlSafe, version))
+		urlRequest, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf(transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/pythonPackages/%s", artifactResourceRef(packageName, ":", version)))
 		if err != nil {
 			return fmt.Errorf("Error setting api endpoint")
 		}


### PR DESCRIPTION
Repro: set `image_name = "img@sha256:abc/../../otherRepo/dockerImages/x"` on `google_artifact_registry_docker_image`, or a `package_name`/`artifact_id` whose version segment contains `/`, `?`, or `#`, on the npm/python/maven data sources. The name half of the resource path is URL-escaped but the version/digest half is not, so the `../` walks out of the `dockerImages/<name>` segment and the GET resolves to a different resource than the one configured.

Cause: the by-version/by-digest lookup is built as `.../npmPackages/%s:%s` (and `.../dockerImages/%s@%s`) with only the name passed through `url.QueryEscape` while the version/digest is interpolated raw. These identifiers can arrive from a module input, tfvars, or remote data, so the raw segment lets a caller-supplied value add path segments, a query string, or a fragment to the request URL.

Fix: route the trailing `{name}{sep}{version}` component through one helper that keeps the name's query-escaping and path-escapes the version/digest. A valid semver or `sha256:<hex>` digest is unchanged; `/`, `?`, and `#` are percent-encoded.

```release-note:bug
artifactregistry: fixed request path construction in the `google_artifact_registry_docker_image`, `google_artifact_registry_npm_package`, `google_artifact_registry_python_package`, and `google_artifact_registry_maven_artifact` data sources so a `version`/`digest` segment containing URL metacharacters no longer alters the request path
```
