### PR TITLE
dataprocmetastore: fix TestAccDataprocMetastoreService_dataprocMetastoreServicePrivateServiceConnectExample

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -111,6 +111,7 @@ samples:
           metastore_service_name: metastore-metadata
   - name: dataproc_metastore_service_private_service_connect
     primary_resource_id: default
+    external_providers: [time]
     steps:
       - name: dataproc_metastore_service_private_service_connect
         resource_id_vars:
@@ -121,6 +122,7 @@ samples:
     primary_resource_id: default
     min_version: beta
     exclude_test: true
+    external_providers: [time]
     steps:
       - name: dataproc_metastore_service_private_service_connect_custom_routes
         min_version: beta

--- a/mmv1/templates/terraform/samples/services/metastore/dataproc_metastore_service_private_service_connect.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/metastore/dataproc_metastore_service_private_service_connect.tf.tmpl
@@ -11,10 +11,12 @@ resource "google_compute_subnetwork" "subnet" {
   private_ip_google_access = true
 }
 
-resource "time_sleep" "wait_60_seconds" {
+# Destroy subnetwork 10 minutes after metastore service is deleted.
+# It guarantees that the background PSC IP address cleanup has completed.
+resource "time_sleep" "wait_10_minutes" {
   depends_on = [google_compute_subnetwork.subnet]
 
-  destroy_duration = "60s"
+  destroy_duration = "10m"
 }
 
 resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
@@ -32,5 +34,5 @@ resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
     }
   }
 
-  depends_on = [time_sleep.wait_60_seconds]
+  depends_on = [time_sleep.wait_10_minutes]
 }

--- a/mmv1/templates/terraform/samples/services/metastore/dataproc_metastore_service_private_service_connect.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/metastore/dataproc_metastore_service_private_service_connect.tf.tmpl
@@ -11,6 +11,12 @@ resource "google_compute_subnetwork" "subnet" {
   private_ip_google_access = true
 }
 
+resource "time_sleep" "wait_60_seconds" {
+  depends_on = [google_compute_subnetwork.subnet]
+
+  destroy_duration = "60s"
+}
+
 resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
   service_id = "{{index $.ResourceIdVars "metastore_service_name"}}"
   location   = "us-central1"
@@ -25,4 +31,6 @@ resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
       subnetwork = google_compute_subnetwork.subnet.id
     }
   }
+
+  depends_on = [time_sleep.wait_60_seconds]
 }

--- a/mmv1/templates/terraform/samples/services/metastore/dataproc_metastore_service_private_service_connect_custom_routes.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/metastore/dataproc_metastore_service_private_service_connect_custom_routes.tf.tmpl
@@ -13,6 +13,12 @@ resource "google_compute_subnetwork" "subnet" {
   private_ip_google_access = true
 }
 
+resource "time_sleep" "wait_60_seconds" {
+  depends_on = [google_compute_subnetwork.subnet]
+
+  destroy_duration = "60s"
+}
+
 resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
   provider   = google-beta
   service_id = "{{index $.ResourceIdVars "metastore_service_name"}}"
@@ -28,4 +34,6 @@ resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
     }
     custom_routes_enabled = true
   }
+
+  depends_on = [time_sleep.wait_60_seconds]
 }

--- a/mmv1/templates/terraform/samples/services/metastore/dataproc_metastore_service_private_service_connect_custom_routes.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/metastore/dataproc_metastore_service_private_service_connect_custom_routes.tf.tmpl
@@ -13,10 +13,12 @@ resource "google_compute_subnetwork" "subnet" {
   private_ip_google_access = true
 }
 
-resource "time_sleep" "wait_60_seconds" {
+# Destroy subnetwork 10 minutes after metastore service is deleted.
+# It guarantees that the background PSC IP address cleanup has completed.
+resource "time_sleep" "wait_10_minutes" {
   depends_on = [google_compute_subnetwork.subnet]
 
-  destroy_duration = "60s"
+  destroy_duration = "10m"
 }
 
 resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
@@ -35,5 +37,5 @@ resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
     custom_routes_enabled = true
   }
 
-  depends_on = [time_sleep.wait_60_seconds]
+  depends_on = [time_sleep.wait_10_minutes]
 }


### PR DESCRIPTION
Fixes nightly acceptance test failure for `TestAccDataprocMetastoreService_dataprocMetastoreServicePrivateServiceConnectExample`.

### Root Cause & Fix

When a `google_dataproc_metastore_service` is configured with `network_config.consumers.subnetwork` to use Private Service Connect, an IP address (`metastore-addr-*`) is implicitly created within the subnetwork. When Terraform destroys the resources during post-test cleanup, it deletes the Dataproc Metastore Service first and then immediately attempts to delete the subnetwork. However, the background PSC IP address cleanup occurs asynchronously on the GCP backend (typically taking ~5-6 minutes)—resulting in a `400 resourceInUseByAnotherResource` error during subnetwork teardown.

This change:
* Adds a `time_sleep` resource with a 10-minute `destroy_duration` between the subnetwork and the Dataproc Metastore Service in both `dataproc_metastore_service_private_service_connect.tf.tmpl` and `dataproc_metastore_service_private_service_connect_custom_routes.tf.tmpl`. This delays subnetwork deletion by 10 minutes after the Metastore Service is destroyed, giving the GCP backend sufficient time to release the PSC address and ensuring clean teardown.
* Adds `external_providers: [time]` to both sample definitions in `mmv1/products/metastore/Service.yaml` so that the generated acceptance test registers the `hashicorp/time` provider factory.

```release-note:none
```
