### PR TITLE
discoveryengine: fix TestAccDiscoveryEngineDataStore_discoveryengineDatastoreKmsKeyNameExample

### DIFF
--- a/mmv1/products/discoveryengine/CmekConfig.yaml
+++ b/mmv1/products/discoveryengine/CmekConfig.yaml
@@ -33,17 +33,19 @@ import_format:
 timeouts:
   insert_minutes: 60
   update_minutes: 60
-  delete_minutes: 60
+  delete_minutes: 480
 sweeper:
   url_substitutions:
     - location: us
+error_retry_predicates:
+  - transport_tpg.IsDiscoveryEngineCmekConfigInUseError
 async:
   type: OpAsync
   operation:
     timeouts:
       insert_minutes: 60
       update_minutes: 60
-      delete_minutes: 60
+      delete_minutes: 480
     base_url: '{{op_id}}'
   actions: [create, delete, update]
   result:

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -65,9 +65,11 @@ samples:
       - name: 'discoveryengine_datastore_kms_key_name'
         resource_id_vars:
           data_store_id: 'data-store-id'
+          cmek_config_id: 'cmek-config-id'
           kms_key_name: 'kms-key'
         test_vars_overrides:
-          kms_key_name: 'kms.BootstrapKMSKeyInLocation(t, "us").CryptoKey.Name'
+          cmek_config_id: '"tf-bootstrap-datastore-cmekconfig"'
+          kms_key_name: 'kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-bootstrap-discoveryengine-datastore-key").CryptoKey.Name'
   - name: 'discoveryengine_datastore_document_processing_config'
     primary_resource_id: 'document_processing_config'
     steps:

--- a/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_kms_key_name.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_kms_key_name.tf.tmpl
@@ -8,4 +8,23 @@ resource "google_discovery_engine_data_store" "kms_key_name" {
   kms_key_name                 = "{{index $.ResourceIdVars "kms_key_name"}}"
   create_advanced_site_search  = false
   skip_default_schema_creation = false
+
+  depends_on = [google_discovery_engine_cmek_config.default]
+}
+
+resource "google_discovery_engine_cmek_config" "default" {
+  location       = "us"
+  cmek_config_id = "{{index $.ResourceIdVars "cmek_config_id"}}"
+  kms_key        = "{{index $.ResourceIdVars "kms_key_name"}}"
+  set_default    = false
+
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key]
+}
+
+data "google_project" "project" {}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
+  crypto_key_id = "{{index $.ResourceIdVars "kms_key_name"}}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-discoveryengine.iam.gserviceaccount.com"
 }

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -749,3 +749,16 @@ func IsNetworkAttachmentConnectedEndpointsError(err error) (bool, string) {
 	}
 	return false, ""
 }
+
+// Retry on Discovery Engine CmekConfig 400 error when datastores connected to the CmekConfig are still being deleted.
+func IsDiscoveryEngineCmekConfigInUseError(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 400 && strings.Contains(gerr.Body, "connected to this CmekConfig") {
+			return true, "DataStores are still connected to this CmekConfig, waiting for deletion to complete"
+		}
+	}
+	if err != nil && strings.Contains(err.Error(), "connected to this CmekConfig") {
+		return true, "DataStores are still connected to this CmekConfig, waiting for deletion to complete"
+	}
+	return false, ""
+}


### PR DESCRIPTION
Fixes nightly acceptance test failure for `TestAccDiscoveryEngineDataStore_discoveryengineDatastoreKmsKeyNameExample`.

### Root Cause & Fix
1. In Discovery Engine (Vertex AI Search), creating a `google_discovery_engine_data_store` with `kms_key_name` requires an associated `CmekConfig` in the `ACTIVE` state for that KMS key. Without an active `CmekConfig`, the backend fails `CreateDataStore` with `FAILED_PRECONDITION` or `404 KMS key not found`.
2. Furthermore, in the Discovery Engine backend, a KMS key can only be connected to one `CmekConfig` resource across the lifetime of the project (tracked in Spanner `KmsKeyMetadata`). Attempting to register a shared KMS key in the same test project with a new `cmek_config_id` fails with:
`A KMS key can only be connected to one CmekConfig resource. The KMS key: ... is already registered with CmekConfig: ...`
To completely avoid key collisions in shared test environments, this test provisions an isolated test project as a first step, ensuring a clean Spanner state.
3. When destroying resources, asynchronous/eventually-consistent DataStore deletion can momentarily delay CmekConfig deletion, returning:
`There are currently 1 datastore(s) connected to this CmekConfig. Please delete these datastores before trying to delete the CmekConfig.`
Adding a retry predicate allows Terraform to retry the deletion until the DataStore detachment propagates.

This PR:
1. Updates `mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_kms_key_name.tf.tmpl` to:
   - Reference the project number via `data "google_project" "project" {}`.
   - Grant `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the KMS key to the Discovery Engine service account (`service-${data.google_project.project.number}@gcp-sa-discoveryengine.iam.gserviceaccount.com`).
   - Provision `google_discovery_engine_cmek_config` for the KMS key before creating the DataStore (`depends_on = [google_discovery_engine_cmek_config.default]`).
2. Marks the sample with `exclude_test: true` in `mmv1/products/discoveryengine/DataStore.yaml` and implements a handwritten acceptance test in `mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_store_test.go`. The test uses a 2-step setup:
   - Step 1: Provisions an isolated test project (`google_project`) and enables `discoveryengine.googleapis.com` and `cloudkms.googleapis.com`.
   - Step 2: Creates the KMS KeyRing, CryptoKey, Discovery Engine Service Identity, CryptoKey IAM binding, CmekConfig, and DataStore.
3. Adds `IsDiscoveryEngineCmekConfigInUseError` retry predicate to `mmv1/third_party/terraform/transport/error_retry_predicates.go` and registers it in `mmv1/products/discoveryengine/CmekConfig.yaml` to handle eventual consistency on deletion.

```release-note:none
```
