### PR TITLE
Add refresh_frequency field to dlp discovery config

### DIFF
--- a/mmv1/products/dlp/DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/DiscoveryConfig.yaml
@@ -469,6 +469,13 @@ properties:
                         - UPDATE_FREQUENCY_NEVER
                         - UPDATE_FREQUENCY_DAILY
                         - UPDATE_FREQUENCY_MONTHLY
+                - name: refreshFrequency
+                  type: Enum
+                  description: Frequency at which profiles should be updated, regardless of whether the underlying resource has changed. Defaults to never.
+                  enum_values:
+                    - UPDATE_FREQUENCY_NEVER
+                    - UPDATE_FREQUENCY_DAILY
+                    - UPDATE_FREQUENCY_MONTHLY
                 - name: inspectTemplateModifiedCadence
                   type: NestedObject
                   description: Governs when to update data profiles when the inspection rules defined by the `InspectTemplate` change. If not set, changing the template will not cause a data profile to update.

--- a/mmv1/templates/terraform/samples/services/dlp/dlp_discovery_config_conditions_cadence.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dlp/dlp_discovery_config_conditions_cadence.tf.tmpl
@@ -23,6 +23,7 @@ resource "google_data_loss_prevention_discovery_config" "{{$.PrimaryResourceId}}
                 inspect_template_modified_cadence {
                     frequency = "UPDATE_FREQUENCY_DAILY"
                 }
+                refresh_frequency = "UPDATE_FREQUENCY_DAILY"
             }
         }
     }

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
@@ -891,6 +891,7 @@ resource "google_data_loss_prevention_discovery_config" "basic" {
 				inspect_template_modified_cadence {
 					frequency = "UPDATE_FREQUENCY_DAILY"
 				}
+				refresh_frequency = "UPDATE_FREQUENCY_DAILY"
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23802

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dlp: added `big_query_target.cadence.refresh_frequency` field to `google_data_loss_prevention_discovery_config` resource
```
