### PR TITLE
monitoring: clarify selected_regions cost and set 3-checker minimum in uptime check examples

### DIFF
--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -149,7 +149,7 @@ properties:
                 - REGEX_MATCH
   - name: selectedRegions
     type: Array
-    description: The list of regions from which the check will be run. Some regions contain one location, and others contain more than one. If this field is specified, enough regions to include a minimum of 3 locations must be provided, or an error message is returned. Not specifying this field will result in uptime checks running from all regions.
+    description: The list of regions from which the check will be run. Some regions contain one location, and others contain more than one. If this field is specified, enough regions to include a minimum of 3 locations must be provided, or an error message is returned. Not specifying this field will result in uptime checks running from all 6 available checker locations (USA_OREGON, USA_IOWA, USA_VIRGINIA, EUROPE, SOUTH_AMERICA, ASIA_PACIFIC), which incurs 6 probe executions per period. To meet the 3-location API minimum and avoid 6x checker executions, you can specify `["USA"]` (covering Oregon, Iowa, and Virginia) or any 3 individual checker locations.
     item_type:
       type: String
   - name: logCheckFailures

--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -149,7 +149,7 @@ properties:
                 - REGEX_MATCH
   - name: selectedRegions
     type: Array
-    description: The list of regions from which the check will be run. Some regions contain one location, and others contain more than one. If this field is specified, enough regions to include a minimum of 3 locations must be provided, or an error message is returned. Not specifying this field will result in uptime checks running from all 6 available checker locations (USA_OREGON, USA_IOWA, USA_VIRGINIA, EUROPE, SOUTH_AMERICA, ASIA_PACIFIC), which incurs 6 probe executions per period. To meet the 3-location API minimum and avoid 6x checker executions, you can specify `["USA"]` (covering Oregon, Iowa, and Virginia) or any 3 individual checker locations.
+    description: The list of regions from which the check will be run. Some regions contain one location, and others contain more than one. If this field is specified, enough regions to include a minimum of 3 locations must be provided, or an error message is returned. Not specifying this field will result in uptime checks running from all available checker locations, where each location executes a probe each period. To meet the 3-location API minimum with the fewest checker executions, you can specify `["USA"]` (which covers 3 locations) or any 3 individual checker locations. For details on checker regions and location counts, see https://cloud.google.com/monitoring/uptime-checks. For execution pricing details, see https://cloud.google.com/monitoring/pricing.
     item_type:
       type: String
   - name: logCheckFailures

--- a/mmv1/templates/terraform/samples/services/monitoring/uptime_check_config_http.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/monitoring/uptime_check_config_http.tf.tmpl
@@ -1,6 +1,7 @@
 resource "google_monitoring_uptime_check_config" "{{$.PrimaryResourceId}}" {
   display_name       = "{{index $.ResourceIdVars "display_name"}}"
   timeout            = "60s"
+  selected_regions   = ["USA"]
   log_check_failures = true
   user_labels  = {
     example-key = "example-value"

--- a/mmv1/templates/terraform/samples/services/monitoring/uptime_check_config_https.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/monitoring/uptime_check_config_https.tf.tmpl
@@ -1,6 +1,7 @@
 resource "google_monitoring_uptime_check_config" "{{$.PrimaryResourceId}}" {
   display_name = "{{index $.ResourceIdVars "display_name"}}"
   timeout = "60s"
+  selected_regions = ["USA"]
 
   http_check {
     path = "/some-path"


### PR DESCRIPTION
Clarify documentation on `selected_regions` for `google_monitoring_uptime_check_config` and set `selected_regions = ["USA"]` in canonical documentation examples.

- Explains in the schema description that leaving `selected_regions` unset defaults to all 6 available regional checkers (USA_OREGON, USA_IOWA, USA_VIRGINIA, EUROPE, SOUTH_AMERICA, ASIA_PACIFIC), which incurs 6 probe executions per period.
- Documents the 3-location API minimum and points out that specifying `["USA"]` covers 3 locations.
- Sets `selected_regions = ["USA"]` in `uptime_check_config_http` and `uptime_check_config_https` sample templates so users copy-pasting documentation examples default to the lowest-cost valid configuration.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28764

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none