### PR TITLE
oracledatabase: fix TestAccOracleDatabaseDbServers_basic

### DIFF
--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_db_servers.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_db_servers.go
@@ -153,7 +153,11 @@ func DataSourceOracleDatabaseDbServersRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("error setting dbserver: %s", err)
 	}
 
-	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/cloudExadataInfrastructures/{{cloud_exadata_infrastructure_id}}/dbServers")
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("error setting project: %s", err)
+	}
+
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/cloudExadataInfrastructures/{{cloud_exadata_infrastructure}}/dbServers")
 	if err != nil {
 		return fmt.Errorf("Error constructing id: %s", err)
 	}


### PR DESCRIPTION
Fixes nightly acceptance test failure for `TestAccOracleDatabaseDbServers_basic`.

### Root Cause & Fix

1. **Incorrect Template Variable in ID Construction**:
   `DataSourceOracleDatabaseDbServersRead` in `data_source_oracle_database_db_servers.go` constructed the resource ID using `projects/{{project}}/locations/{{location}}/cloudExadataInfrastructures/{{cloud_exadata_infrastructure_id}}/dbServers`.
   The schema field name is `cloud_exadata_infrastructure` (not `cloud_exadata_infrastructure_id`). This mismatch caused variable replacement to fail when setting the resource ID.

2. **Persist Project in ResourceData**:
   Added `d.Set("project", project)` so that the resolved project is properly stored in `schema.ResourceData`, ensuring `tpgresource.ReplaceVars` and subsequent state checks can access the project attribute.

```release-note:none
```