### PR TITLE
Support empty spec sub-blocks for GKE Hub Feature (workloadidentity /…

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -186,6 +186,7 @@ properties:
       - name: fleetobservability
         type: NestedObject
         description: Fleet Observability feature spec.
+        send_empty_value: true
         properties:
           - name: loggingConfig
             type: NestedObject
@@ -282,6 +283,7 @@ properties:
       - name: workloadidentity
         type: NestedObject
         description: Workload Identity feature spec.
+        send_empty_value: true
         properties:
           - name: scopeTenancyPool
             type: String


### PR DESCRIPTION
When users configure features that require empty sub-blocks (such as `spec { workloadidentity {} }` or `spec { fleetobservability {} }`), the generated expander previously dropped empty maps due to `!IsEmptyValue()` checks. This caused the GKE Hub API to reject the request with `400: MissingFieldError for field spec: should be set`.

This PR adds `send_empty_value: true` to the `workloadidentity` and `fleetobservability` `NestedObject` definitions under `spec` in `Feature.yaml` so that empty spec objects are preserved in the payload.

Closes https://github.com/hashicorp/terraform-provider-google/issues/29014

```release-note:bug
gkehub: fixed issue the prevented `workloadidentity` and `fleetobservability` fields being set to empty values in the `google_gke_hub_feature` resource
```