### PR TITLE
networkservices: add google_network_services_gateway data source

### DIFF
--- a/mmv1/products/networkservices/Gateway.yaml
+++ b/mmv1/products/networkservices/Gateway.yaml
@@ -29,6 +29,8 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/gateways/{{name}}
+datasource_experimental:
+  generate: true
 timeouts:
   insert_minutes: 30
   update_minutes: 30


### PR DESCRIPTION
networkservices: added google_network_services_gateway data source

Adds a Get-style handwritten data source that wraps `projects.locations.gateways.get` and reuses the existing resource schema and read. This lets users look up existing OPEN_MESH and Secure Web Proxy gateways without importing them into a managed resource.

The change ships to both `google` and `google-beta` via Magic Modules generation.

```release-note:new-datasource
`google_network_services_gateway`
```
