### PR TITLE
performance capture ga changes post release

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -123,7 +123,6 @@ var (
 		"settings.0.insights_config.0.enhanced_query_insights_enabled",
 	}
 
-{{- if ne $.TargetVersionName "ga" }}
     performanceCaptureConfigKeys = []string{
 		"settings.0.performance_capture_config.0.enabled",
 		"settings.0.performance_capture_config.0.probing_interval_seconds",
@@ -140,7 +139,6 @@ var (
 		"settings.0.performance_capture_config.0.transaction_kill_type",
 		"settings.0.performance_capture_config.0.transaction_kill_excluded_user_hosts",
 	}
-{{- end }}
 
 	sqlServerAuditConfigurationKeys = []string{
 		"settings.0.sql_server_audit_config.0.bucket",
@@ -939,7 +937,6 @@ API (for read pools, effective_availability_type may differ from availability_ty
 							},
 							Description: `Configuration of Query Insights.`,
 						},
-{{- if ne $.TargetVersionName "ga" }}
 						"performance_capture_config": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -994,42 +991,42 @@ API (for read pools, effective_availability_type may differ from availability_ty
 										Optional:     true,
 										Computed:     true,
 										AtLeastOneOf: performanceCaptureConfigKeys,
-										Description:  `The minimum percentage of CPU utilization that triggers the performance capture. Valid range is 10 to 99. 0 disables the check.`,
+										Description:  `The minimum percentage of CPU utilization that triggers the performance capture.`,
 									},
 									"memory_usage_threshold_percent": {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										Computed:     true,
 										AtLeastOneOf: performanceCaptureConfigKeys,
-										Description:  `The minimum percentage of memory usage that triggers the performance capture. Valid range is 10 to 99. 0 disables the check.`,
+										Description:  `The minimum percentage of memory usage that triggers the performance capture.`,
 									},
 									"history_list_length_threshold_count": {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										Computed:     true,
 										AtLeastOneOf: performanceCaptureConfigKeys,
-										Description:  `The minimum number of undo log entries in the history list length that triggers the performance capture. Valid range is 10000 to 10000000. 0 disables the check.`,
+										Description:  `The minimum number of undo log entries in the history list length that triggers the performance capture.`,
 									},
 									"semaphore_wait_threshold_count": {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										Computed:     true,
 										AtLeastOneOf: performanceCaptureConfigKeys,
-										Description:  `The minimum number of semaphore waits that triggers the performance capture. Valid range is 10 to 10000. 0 disables the check.`,
+										Description:  `The minimum number of semaphore waits that triggers the performance capture.`,
 									},
 									"transaction_lock_wait_threshold_count": {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										Computed:     true,
 										AtLeastOneOf: performanceCaptureConfigKeys,
-										Description:  `The minimum number of transactions in lock wait state that triggers the performance capture. Valid range is 10 to 10000. 0 disables the check.`,
+										Description:  `The minimum number of transactions in lock wait state that triggers the performance capture.`,
 									},
 									"transaction_kill_threshold_seconds": {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										Computed:     true,
 										AtLeastOneOf: performanceCaptureConfigKeys,
-										Description:  `The amount of time in seconds that a transaction needs to have been open before the watcher starts terminating it. Valid range is 60 to 604800. 0 disables termination.`,
+										Description:  `The amount of time in seconds that a transaction needs to have been open before the watcher starts terminating it.`,
 									},
 									"transaction_kill_type": {
 										Type:         schema.TypeString,
@@ -1050,7 +1047,6 @@ API (for read pools, effective_availability_type may differ from availability_ty
 							},
 							Description: `Configuration of Performance Capture.`,
 						},
-{{- end }}
 						"entraid_config": {
 							Type:        schema.TypeList,
 							Optional:    true,
@@ -2111,9 +2107,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		InsightsConfig:                expandInsightsConfig(_settings["insights_config"].([]interface{})),
 		PasswordValidationPolicy:      expandPasswordValidationPolicy(_settings["password_validation_policy"].([]interface{})),
 		ConnectionPoolConfig:          expandConnectionPoolConfig(_settings["connection_pool_config"].(*schema.Set).List()),
-{{- if ne $.TargetVersionName "ga" }}
 		PerformanceCaptureConfig:      expandPerformanceCaptureConfig(_settings["performance_capture_config"].([]interface{})),
-{{- end }}
 		ReadPoolAutoScaleConfig:       expandReadPoolAutoScaleConfig(_settings["read_pool_auto_scale_config"].([]interface{})),
 	}
 
@@ -2500,7 +2494,6 @@ func expandInsightsConfig(configured []interface{}) *sqladmin.InsightsConfig {
 	}
 }
 
-{{- if ne $.TargetVersionName "ga" }}
 func expandPerformanceCaptureConfig(configured []interface{}) *sqladmin.PerformanceCaptureConfig {
 	if len(configured) == 0 || configured[0] == nil {
 		return nil
@@ -2525,7 +2518,6 @@ func expandPerformanceCaptureConfig(configured []interface{}) *sqladmin.Performa
 		ForceSendFields:              []string{"Enabled"},
 	}
 }
-{{- end }}
 
 func expandPasswordValidationPolicy(configured []interface{}) *sqladmin.PasswordValidationPolicy {
 	if len(configured) == 0 || configured[0] == nil {
@@ -3441,11 +3433,9 @@ func flattenSettings(settings *sqladmin.Settings, iType string, d *schema.Resour
 		data["insights_config"] = flattenInsightsConfig(settings.InsightsConfig)
 	}
 
-{{- if ne $.TargetVersionName "ga" }}
 	if settings.PerformanceCaptureConfig != nil {
 		data["performance_capture_config"] = flattenPerformanceCaptureConfig(settings.PerformanceCaptureConfig)
 	}
-{{- end }}
 
 	if settings.ReadPoolAutoScaleConfig != nil {
 		data["read_pool_auto_scale_config"] = flattenReadPoolAutoScaleConfig(settings.ReadPoolAutoScaleConfig)
@@ -3868,7 +3858,6 @@ func flattenInsightsConfig(insightsConfig *sqladmin.InsightsConfig) interface{} 
 	return []map[string]interface{}{data}
 }
 
-{{- if ne $.TargetVersionName "ga" }}
 func flattenPerformanceCaptureConfig(performanceCaptureConfig *sqladmin.PerformanceCaptureConfig) interface{} {
 	data := map[string]interface{}{
 		"enabled":                         performanceCaptureConfig.Enabled,
@@ -3889,7 +3878,6 @@ func flattenPerformanceCaptureConfig(performanceCaptureConfig *sqladmin.Performa
 
 	return []map[string]interface{}{data}
 }
-{{- end }}
 
 func flattenTargetMetrics(targetMetrics []*sqladmin.TargetMetric) []interface{} {
 	if len(targetMetrics) == 0 { // Handles nil or empty slice

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
@@ -154,7 +154,6 @@ fields:
   - api_field: 'settings.insightsConfig.recordApplicationTags'
   - api_field: 'settings.insightsConfig.recordClientAddress'
   - api_field: 'settings.insightsConfig.enhancedQueryInsightsEnabled'
-{{- if ne $.TargetVersionName "ga" }}
   - api_field: 'settings.performanceCaptureConfig.enabled'
   - api_field: 'settings.performanceCaptureConfig.probeThreshold'
   - api_field: 'settings.performanceCaptureConfig.probingIntervalSeconds'
@@ -169,7 +168,6 @@ fields:
   - api_field: 'settings.performanceCaptureConfig.transactionKillThresholdSeconds'
   - api_field: 'settings.performanceCaptureConfig.transactionKillType'
   - api_field: 'settings.performanceCaptureConfig.transactionKillExcludedUserHosts'
-{{- end }}
   - api_field: 'settings.entraidConfig.applicationId'
   - api_field: 'settings.entraidConfig.tenantId'
   - api_field: 'settings.ipConfiguration.allocatedIpRange'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -2837,7 +2837,6 @@ func TestAccSqlDatabaseInstance_insights(t *testing.T) {
 	})
 }
 
-{{- if ne $.TargetVersionName "ga" }}
 func TestAccSqlDatabaseInstance_performanceCaptureConfig(t *testing.T) {
 	t.Parallel()
 
@@ -2876,7 +2875,6 @@ func TestAccSqlDatabaseInstance_performanceCaptureConfig(t *testing.T) {
 		},
 	})
 }
-{{- end }}
 
 func TestAccSqlDatabaseInstance_insights_enhanced_postgres17(t *testing.T) {
 	t.Parallel()
@@ -8853,7 +8851,6 @@ resource "google_sql_database_instance" "instance" {
 }
 `
 
-{{- if ne $.TargetVersionName "ga" }}
 var testGoogleSqlDatabaseInstance_performanceCaptureConfig = `
 resource "google_sql_database_instance" "instance" {
   name                = "tf-test-%d"
@@ -8923,7 +8920,6 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `
-{{- end }}
 
 func testGoogleSqlDatabaseInstance_insights_enhanced_postgres17(instanceName string, enhanced bool) string {
 	return fmt.Sprintf(`resource "google_sql_database_instance" "instance" {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -713,35 +713,35 @@ The optional `settings.password_validation_policy` subblock for instances declar
 
 * `enable_password_policy` - Enables or disable the password validation policy.
 
-The optional `settings.performance_capture_config` (Beta) subblock for instances declares Performance Capture configuration. It contains:
+The optional `settings.performance_capture_config` subblock for instances declares Performance Capture configuration. It contains:
 
-* `enabled` - (Beta) True if the Performance Capture feature is enabled.
+* `enabled` - True if the Performance Capture feature is enabled.
 
-* `probing_interval_seconds` - (Beta) The time interval in seconds between any two probes.
+* `probing_interval_seconds` - The time interval in seconds between any two probes.
 
-* `probe_threshold` - (Beta) The minimum number of consecutive readings above threshold that triggers instance state capture.
+* `probe_threshold` - The minimum number of consecutive readings above threshold that triggers instance state capture.
 
-* `running_threads_threshold` - (Beta) The minimum number of server threads running to trigger the capture on primary.
+* `running_threads_threshold` - The minimum number of server threads running to trigger the capture on primary.
 
-* `seconds_behind_source_threshold` - (Beta) The minimum number of seconds replica must be lagging behind primary to trigger capture on replica.
+* `seconds_behind_source_threshold` - The minimum number of seconds replica must be lagging behind primary to trigger capture on replica.
 
-* `transaction_duration_threshold` - (Beta) The amount of time in seconds that a transaction needs to have been open before the watcher starts recording it.
+* `transaction_duration_threshold` - The amount of time in seconds that a transaction needs to have been open before the watcher starts recording it.
 
-* `cpu_utilization_threshold_percent` - (Beta) The minimum percentage of CPU utilization that triggers the performance capture. Valid range is 10 to 99. `0` disables the check.
+* `cpu_utilization_threshold_percent` - The minimum percentage of CPU utilization that triggers the performance capture.
 
-* `memory_usage_threshold_percent` - (Beta) The minimum percentage of memory usage that triggers the performance capture. Valid range is 10 to 99. `0` disables the check.
+* `memory_usage_threshold_percent` - The minimum percentage of memory usage that triggers the performance capture.
 
-* `history_list_length_threshold_count` - (Beta) The minimum number of undo log entries in the history list length that triggers the performance capture. Valid range is 10000 to 10000000. `0` disables the check.
+* `history_list_length_threshold_count` - The minimum number of undo log entries in the history list length that triggers the performance capture.
 
-* `semaphore_wait_threshold_count` - (Beta) The minimum number of semaphore waits that triggers the performance capture. Valid range is 10 to 10000. `0` disables the check.
+* `semaphore_wait_threshold_count` - The minimum number of semaphore waits that triggers the performance capture.
 
-* `transaction_lock_wait_threshold_count` - (Beta) The minimum number of transactions in lock wait state that triggers the performance capture. Valid range is 10 to 10000. `0` disables the check.
+* `transaction_lock_wait_threshold_count` - The minimum number of transactions in lock wait state that triggers the performance capture.
 
-* `transaction_kill_threshold_seconds` - (Beta) The amount of time in seconds that a transaction needs to have been open before the watcher starts terminating it. Valid range is 60 to 604800. `0` disables termination.
+* `transaction_kill_threshold_seconds` - The amount of time in seconds that a transaction needs to have been open before the watcher starts terminating it.
 
-* `transaction_kill_type` - (Beta) Determines which transactions are allowed to be terminated when they exceed `transaction_kill_threshold_seconds`. Possible values are: `TRANSACTION_KILL_TYPE_UNSPECIFIED`, `READ_ONLY_TRANSACTIONS`, `ALL_TRANSACTIONS`.
+* `transaction_kill_type` - Determines which transactions are allowed to be terminated when they exceed `transaction_kill_threshold_seconds`. Possible values are: `TRANSACTION_KILL_TYPE_UNSPECIFIED`, `READ_ONLY_TRANSACTIONS`, `ALL_TRANSACTIONS`.
 
-* `transaction_kill_excluded_user_hosts` - (Beta) A list of users to exclude from transaction termination. Entries can be in the format `user@host` or just `user`.
+* `transaction_kill_excluded_user_hosts` - A list of users to exclude from transaction termination. Entries can be in the format `user@host` or just `user`.
 
 The optional `replica_configuration` block must have `master_instance_name` set
 to work, cannot be updated and supports:


### PR DESCRIPTION
Making performance Capture fields GA post release
Flag definitions are modified as we avoid mentioning range values at multiple location due to
- PC range checks are at central place, which could be changed in future.
- Change in range would require downstream doc/flag info changes
- Aligns with other PC flags without value constraint checks and hence doesn't require range info

testing: b/474020862#comment16
Public doc: https://docs.cloud.google.com/sql/docs/mysql/performance-capture

```release-note:enhancement
sql: promoted performance capture fields to GA in `google_sql_database_instance` resource
```
