### PR TITLE
`compute`: fix permadiff regression when iap is omitted

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -918,6 +918,7 @@ properties:
     description: |
       Settings for enabling Cloud Identity Aware Proxy.
       If OAuth client is not set, the Google-managed OAuth client is used.
+    diff_suppress_func: 'suppressIapDiffWhenUnset'
     send_empty_value: true
     properties:
       - name: 'enabled'

--- a/mmv1/templates/terraform/constants/backend_service.go.tmpl
+++ b/mmv1/templates/terraform/constants/backend_service.go.tmpl
@@ -19,6 +19,15 @@ func suppressWhenDisabled(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
+// Suppress API-returned IAP values when the iap block is omitted from configuration.
+func suppressIapDiffWhenUnset(_ string, _, _ string, d *schema.ResourceData) bool {
+	iap := d.GetRawConfig().GetAttr("iap")
+	if iap.IsNull() {
+		return true
+	}
+	return iap.IsKnown() && iap.LengthInt() == 0
+}
+
 // Whether the backend is a global or regional NEG
 func isNegBackend(backend map[string]interface{}) bool {
 	backendGroup, ok := backend["group"]


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes an IAP perpetual diff when iap is omitted from google_compute_backend_service configuration while retaining support for write-only OAuth fields.

API-returned IAP values are now preserved when the block is omitted, while explicitly configured IAP changes remain diffable.

Fixes hashicorp/terraform-provider-google#29069.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

# Local Testing from changes introduced in this PR

## 7.46.0 terraform apply when iap is omitted from tf config 
```hcl
󰀵 mau  ~/󰲋 /iap_write_only_diff_fix   11:58   tfdev  
Initializing the backend...
Initializing provider plugins...
- Finding latest version of hashicorp/google...
- Installing hashicorp/google v9.9.9...
- Installed hashicorp/google v9.9.9 (unauthenticated)
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

╷
│ Warning: Incomplete lock file information for providers
│ 
│ Due to your customized provider installation methods, Terraform was forced to calculate lock file
│ checksums locally for the following providers:
│   - hashicorp/google
│ 
│ The current .terraform.lock.hcl file only includes checksums for darwin_arm64, so Terraform running on
│ another platform will fail to install these providers.
│ 
│ To calculate additional checksums for another platform, run:
│   terraform providers lock -platform=linux_amd64
│ (where linux_amd64 is the platform to generate)
╵
Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

󰀵 mau  ~/󰲋 /iap_write_only_diff_fix   11:58   terraform apply -var="project_id=hc-terraform-testing"

google_compute_global_network_endpoint_group.iap_permadiff: Refreshing state... [id=projects/hc-terraform-testing/global/networkEndpointGroups/iap-permadiff-repro-neg]
google_compute_global_network_endpoint.iap_permadiff: Refreshing state... [id=hc-terraform-testing/iap-permadiff-repro-neg//example.com/443]
google_compute_backend_service.iap_permadiff: Refreshing state... [id=projects/hc-terraform-testing/global/backendServices/iap-permadiff-repro]

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # google_compute_backend_service.iap_permadiff will be updated in-place
  ~ resource "google_compute_backend_service" "iap_permadiff" {
        id                                            = "projects/hc-terraform-testing/global/backendServices/iap-permadiff-repro"
        name                                          = "iap-permadiff-repro"
        # (26 unchanged attributes hidden)

      - iap {
          - enabled                         = false -> null
          - oauth2_client_id_wo             = (write-only attribute) -> null
          - oauth2_client_secret_sha256     = (sensitive value) -> null
          - oauth2_client_secret_wo         = (write-only attribute) -> null
            # (4 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: no

Apply cancelled.
```
## After applying diff in local terraform provider binary
```hcl
󰀵 mau  ~/󰲋 /iap_write_only_diff_fix   11:58   tfclean

󰀵 mau  ~/󰲋 /iap_write_only_diff_fix   11:59   tfdev  
Initializing the backend...
Initializing provider plugins...
- Finding latest version of hashicorp/google...
- Installing hashicorp/google v9.9.9...
- Installed hashicorp/google v9.9.9 (unauthenticated)
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

╷
│ Warning: Incomplete lock file information for providers
│ 
│ Due to your customized provider installation methods, Terraform was forced to calculate lock file
│ checksums locally for the following providers:
│   - hashicorp/google
│ 
│ The current .terraform.lock.hcl file only includes checksums for darwin_arm64, so Terraform running on
│ another platform will fail to install these providers.
│ 
│ To calculate additional checksums for another platform, run:
│   terraform providers lock -platform=linux_amd64
│ (where linux_amd64 is the platform to generate)
╵
Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

󰀵 mau  ~/󰲋 /iap_write_only_diff_fix   11:59   terraform apply -var="project_id=hc-terraform-testing"

google_compute_global_network_endpoint_group.iap_permadiff: Refreshing state... [id=projects/hc-terraform-testing/global/networkEndpointGroups/iap-permadiff-repro-neg]
google_compute_global_network_endpoint.iap_permadiff: Refreshing state... [id=hc-terraform-testing/iap-permadiff-repro-neg//example.com/443]
google_compute_backend_service.iap_permadiff: Refreshing state... [id=projects/hc-terraform-testing/global/backendServices/iap-permadiff-repro]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no
changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

```


```release-note:bug
compute: fix permadiff regression when iap is omitted
```
