### PR TITLE
gcloud sql: add encryption_confidential_mode to google_sql_database_instance

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -1276,6 +1276,13 @@ API (for read pools, effective_availability_type may differ from availability_ty
 				Computed: true,
 				ForceNew: true,
 			},
+			"encryption_confidential_mode": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Enables Confidential Mode on Hyperdisk storage for enhanced security. Only supported on Zonal C4A PG and MySQL instances.`,
+			},
 			"root_password": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1899,9 +1906,16 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if k, ok := d.GetOk("encryption_key_name"); ok {
-		instance.DiskEncryptionConfiguration = &sqladmin.DiskEncryptionConfiguration{
-			KmsKeyName: k.(string),
+		if instance.DiskEncryptionConfiguration == nil {
+			instance.DiskEncryptionConfiguration = &sqladmin.DiskEncryptionConfiguration{}
 		}
+		instance.DiskEncryptionConfiguration.KmsKeyName = k.(string)
+	}
+	if v, ok := d.GetOk("encryption_confidential_mode"); ok {
+		if instance.DiskEncryptionConfiguration == nil {
+			instance.DiskEncryptionConfiguration = &sqladmin.DiskEncryptionConfiguration{}
+		}
+		instance.DiskEncryptionConfiguration.ConfidentialMode = v.(bool)
 	}
 
 	var patchData *sqladmin.DatabaseInstance
@@ -2649,8 +2663,13 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 		log.Printf("[WARN] Failed to set SQL Database Instance Settings")
 	}
 	if instance.DiskEncryptionConfiguration != nil {
-		if err := d.Set("encryption_key_name", instance.DiskEncryptionConfiguration.KmsKeyName); err != nil {
-			return fmt.Errorf("Error setting encryption_key_name: %s", err)
+		if instance.DiskEncryptionConfiguration.KmsKeyName != "" {
+			if err := d.Set("encryption_key_name", instance.DiskEncryptionConfiguration.KmsKeyName); err != nil {
+				return fmt.Errorf("Error setting encryption_key_name: %s", err)
+			}
+		}
+		if err := d.Set("encryption_confidential_mode", instance.DiskEncryptionConfiguration.ConfidentialMode); err != nil {
+			return fmt.Errorf("Error setting encryption_confidential_mode: %s", err)
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
@@ -24,6 +24,8 @@ fields:
   - api_field: 'dnsNames.name'
   - api_field: 'diskEncryptionConfiguration.kmsKeyName'
     field: 'encryption_key_name'
+  - api_field: 'diskEncryptionConfiguration.confidentialMode'
+    field: 'encryption_confidential_mode'
   - field: 'final_backup_description'
   - api_field: 'ipAddresses.ipAddress'
     field: 'first_ip_address'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -2938,6 +2938,36 @@ func TestAccSqlDatabaseInstance_encryptionKey(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_confidentialHyperdisk(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_id":    envvar.GetTestProjectFromEnv(),
+		"key_name":      "tf-test-key-" + acctest.RandString(t, 10),
+		"instance_name": "tf-test-sql-" + acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Nprintf(
+					testGoogleSqlDatabaseInstance_confidentialHyperdisk, context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_sql_database_instance.master", "encryption_confidential_mode", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.master",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
 func TestAccSqlDatabaseInstance_encryptionKey_replicaInDifferentRegion(t *testing.T) {
 	t.Parallel()
 
@@ -8948,6 +8978,47 @@ func testGoogleSqlDatabaseInstance_insights_enhanced_postgres17(instanceName str
 `, instanceName, enhanced)
 }
 
+var testGoogleSqlDatabaseInstance_confidentialHyperdisk = `
+data "google_project" "project" {
+  project_id = "%{project_id}"
+}
+resource "google_kms_key_ring" "keyring" {
+  name     = "%{key_name}"
+  location = "us-west4"
+}
+
+resource "google_kms_crypto_key" "key" {
+  name     = "%{key_name}"
+  key_ring = google_kms_key_ring.keyring.id
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
+  crypto_key_id = google_kms_crypto_key.key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloud-sql.iam.gserviceaccount.com"
+}
+
+resource "google_sql_database_instance" "master" {
+  name                = "%{instance_name}-master"
+  database_version    = "POSTGRES_15"
+  region              = "us-west4"
+  deletion_protection = false
+  encryption_key_name = google_kms_crypto_key.key.id
+  encryption_confidential_mode = true
+
+  settings {
+    tier = "db-c4a-highmem-8"
+    edition = "ENTERPRISE_PLUS"
+    availability_type = "ZONAL"
+    disk_type         = "HYPERDISK_BALANCED"
+    location_preference {
+      zone = "us-west4-a"
+    }
+  }
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key]
+}
+`
 var testGoogleSqlDatabaseInstance_encryptionKey = `
 data "google_project" "project" {
   project_id = "%{project_id}"

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -396,6 +396,9 @@ includes an up-to-date reference of supported versions.
     That service account needs the `Cloud KMS > Cloud KMS CryptoKey Encrypter/Decrypter` role on your
     key - please see [this step](https://cloud.google.com/sql/docs/mysql/configure-cmek#grantkey).
 
+* `encryption_confidential_mode` - (Optional)
+    Enables Confidential Mode on Hyperdisk storage for enhanced security. Only supported on C4A instances.
+
 * `deletion_protection` - (Optional) Whether Terraform will be prevented from destroying the instance.
     When the field is set to true or unset in Terraform state, a `terraform apply`
     or `terraform destroy` that would delete the instance will fail.


### PR DESCRIPTION
Cloud SQL supports Confidential Mode for Hyperdisk Balanced storage volumes (confidentialMode on DiskEncryptionConfiguration) for enhanced security on C4A machine instances.

This adds the encryption_confidential_mode boolean attribute to google_sql_database_instance, mapping to
diskEncryptionConfiguration.confidentialMode in the Cloud SQL v1beta4 API.

```release-note:enhancement
sql: added `encryption_confidential_mode` to `google_sql_database_instance`
```

The CI failure is because ConfidentialMode is not yet in the published google.golang.org/api client. The field is already live in the public Discovery doc at https://sqladmin.googleapis.com/$discovery/rest?version=v1beta4, and we are waiting on the next google-api-go-client release to bump the dependency.

### Tests
Ran `TestAccSqlDatabaseInstance_confidentialHyperdisk`:

```text
=== RUN   TestAccSqlDatabaseInstance_confidentialHyperdisk
=== PAUSE TestAccSqlDatabaseInstance_confidentialHyperdisk
=== CONT  TestAccSqlDatabaseInstance_confidentialHyperdisk
--- PASS: TestAccSqlDatabaseInstance_confidentialHyperdisk (369.66s)
PASS
ok   github.com/hashicorp/terraform-provider-google-beta/google-beta/services/sql 369.840s