### PR TITLE
config: set default_from_api for Deployment artifactsGcsBucket

### DIFF
--- a/mmv1/products/config/Deployment.yaml
+++ b/mmv1/products/config/Deployment.yaml
@@ -120,6 +120,7 @@ properties:
   - name: artifactsGcsBucket
     type: String
     description: Location for Cloud Build logs and artifacts.
+    default_from_api: true
   - name: workerPool
     type: String
     description: Custom Cloud Build worker pool resource name.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28249
Fixes b/537025655

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement 
Config: set default_from_api for Deployment artifactsGcsBucket to true. 
```
