### PR TITLE
chronicle_rule_deployment: split archived=true update into two sequential PATCHes

### DIFF
--- a/mmv1/templates/terraform/pre_update/chronicle_rule_deployment.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/chronicle_rule_deployment.go.tmpl
@@ -31,3 +31,77 @@ if hasRunFrequencyUpdate && !hasScheduleCustomizationsUpdate {
         obj["scheduleCustomizations"] = scProp
     }
 }
+
+// removeRunFrequencyFromUpdateMask removes 'runFrequency' from the updateMask in a URL.
+removeRunFrequencyFromUpdateMask := func(url string) string {
+    url = strings.ReplaceAll(url, "%2CrunFrequency", "")
+    url = strings.ReplaceAll(url, "runFrequency%2C", "")
+    url = strings.ReplaceAll(url, "runFrequency", "")
+    url = strings.ReplaceAll(url, "%2C%2C", "%2C")
+    url = strings.TrimSuffix(url, "%2C")
+    return url
+}
+
+// Remove "runFrequency" from updateMask if run_frequency not configured by user
+if _, ok := d.GetOk("run_frequency"); !ok {
+    url = removeRunFrequencyFromUpdateMask(url)
+}
+
+// If archived is being set to true, the API does not allow it to be included
+// in an update_mask alongside any other fields. Split into two sequential PATCHes:
+// 1) all non-archived fields first, 2) archived alone (handled by main update).
+if d.HasChange("archived") {
+    if v, ok := d.GetOk("archived"); ok && v.(bool) {
+        // Build a mask and obj without archived for the first PATCH
+        maskWithoutArchived := slices.DeleteFunc(slices.Clone(updateMask), func(s string) bool {
+            return s == "archived"
+        })
+        objWithoutArchived := make(map[string]interface{})
+        for k, v := range obj {
+            if k != "archived" {
+                objWithoutArchived[k] = v
+            }
+        }
+
+        if len(maskWithoutArchived) > 0 {
+            firstUrl, err := transport_tpg.AddQueryParams(
+                strings.Split(url, "?")[0],
+                map[string]string{"updateMask": strings.Join(maskWithoutArchived, ",")},
+            )
+            if err != nil {
+                return err
+            }
+            _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+                Config:    config,
+                Method:    "PATCH",
+                Project:   billingProject,
+                RawURL:    firstUrl,
+                UserAgent: userAgent,
+                Body:      objWithoutArchived,
+                Timeout:   d.Timeout(schema.TimeoutUpdate),
+                Headers:   headers,
+            })
+            if err != nil {
+                return fmt.Errorf("Error updating RuleDeployment (pre-archive step) %q: %s", d.Id(), err)
+            }
+        }
+
+        // Narrow updateMask and obj to archived only for the main generated PATCH
+        updateMask = []string{"archived"}
+        for k := range obj {
+            if k != "archived" {
+                delete(obj, k)
+            }
+        }
+
+        // Rebuild url with archived-only mask
+        url, err = transport_tpg.AddQueryParams(
+            strings.Split(url, "?")[0],
+            map[string]string{"updateMask": "archived"},
+        )
+        if err != nil {
+            return err
+        }
+    }
+}
+


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28897

The Chronicle API rejects a `UpdateRuleDeployment` request if `archived=true` is included in the `update_mask` alongside any other fields. This caused Terraform to return a `400` error when a user attempted to archive a rule deployment in a single apply (e.g. setting `enabled=false`, `alerting=false`, and `archived=true` simultaneously), requiring a manual two-step apply as a workaround.

### Details
* Adds logic to `pre_update` hook that detects when `archived` is changing to `true` alongside other fields
* Fires a first PATCH with all non-`archived` fields using a clean `updateMask` slice (via `slices.DeleteFunc`) and a freshly constructed URL via `AddQueryParams`
* Narrows `obj` and `updateMask` to `archived` only, letting the main generated PATCH send the second `archived`-only request
* Avoids fragile URL string replacement by operating directly on the `updateMask` slice before `AddQueryParams` is called

### Tests
`TestAccChronicleRuleDeployment_archived`

### Release Note Template for Downstream PRs (will be copied)
` ` `release-note:bug
`google_chronicle_rule_deployment`: fixed an error when setting `archived = true` alongside other field changes in a single apply by splitting the update into two sequential API calls
` ` `