### PR TITLE
gkeonprem: add list resources

### DIFF
--- a/mmv1/products/gkeonprem/BareMetalAdminCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalAdminCluster.yaml
@@ -40,6 +40,7 @@ async:
 exclude_delete: true
 taint_resource_on_failed_create: true
 include_in_tgc_next: true
+generate_list_resource: true
 custom_code:
 samples:
   - name: gkeonprem_bare_metal_admin_cluster_basic

--- a/mmv1/products/gkeonprem/BareMetalAdminCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalAdminCluster.yaml
@@ -42,6 +42,7 @@ taint_resource_on_failed_create: true
 include_in_tgc_next: true
 generate_list_resource: true
 custom_code:
+  decoder: templates/terraform/decoders/compute_resource_policy_attachment.go.tmpl
 samples:
   - name: gkeonprem_bare_metal_admin_cluster_basic
     primary_resource_id: admin-cluster-basic

--- a/mmv1/products/gkeonprem/BareMetalCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalCluster.yaml
@@ -45,6 +45,7 @@ taint_resource_on_failed_create: true
 include_in_tgc_next: true
 generate_list_resource: true
 custom_code:
+  decoder: templates/terraform/decoders/compute_resource_policy_attachment.go.tmpl
 samples:
   - name: gkeonprem_bare_metal_cluster_basic
     primary_resource_id: cluster-basic

--- a/mmv1/products/gkeonprem/BareMetalCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalCluster.yaml
@@ -43,6 +43,7 @@ async:
     resource_inside_response: true
 taint_resource_on_failed_create: true
 include_in_tgc_next: true
+generate_list_resource: true
 custom_code:
 samples:
   - name: gkeonprem_bare_metal_cluster_basic

--- a/mmv1/products/gkeonprem/VmwareAdminCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareAdminCluster.yaml
@@ -37,6 +37,7 @@ async:
     resource_inside_response: true
 exclude_delete: true
 taint_resource_on_failed_create: true
+generate_list_resource: true
 custom_code:
 samples:
   - name: gkeonprem_vmware_admin_cluster_basic

--- a/mmv1/products/gkeonprem/VmwareAdminCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareAdminCluster.yaml
@@ -39,6 +39,7 @@ exclude_delete: true
 taint_resource_on_failed_create: true
 generate_list_resource: true
 custom_code:
+  decoder: templates/terraform/decoders/compute_resource_policy_attachment.go.tmpl
 samples:
   - name: gkeonprem_vmware_admin_cluster_basic
     primary_resource_id: admin-cluster-basic

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -41,6 +41,8 @@ async:
 taint_resource_on_failed_create: true
 include_in_tgc_next: true
 generate_list_resource: true
+custom_code:
+  decoder: templates/terraform/decoders/compute_resource_policy_attachment.go.tmpl
 samples:
   - name: gkeonprem_vmware_cluster_basic
     primary_resource_id: cluster-basic

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -40,6 +40,7 @@ async:
     resource_inside_response: true
 taint_resource_on_failed_create: true
 include_in_tgc_next: true
+generate_list_resource: true
 samples:
   - name: gkeonprem_vmware_cluster_basic
     primary_resource_id: cluster-basic


### PR DESCRIPTION
Adds list-resource generation for the following gkeonprem resources:

- `google_gkeonprem_bare_metal_admin_cluster`
- `google_gkeonprem_bare_metal_cluster`
- `google_gkeonprem_vmware_admin_cluster`
- `google_gkeonprem_vmware_cluster`

```release-note:new-list-resource
`google_gkeonprem_bare_metal_admin_cluster`
```

```release-note:new-list-resource
`google_gkeonprem_bare_metal_cluster`
```

```release-note:new-list-resource
`google_gkeonprem_vmware_admin_cluster`
```

```release-note:new-list-resource
`google_gkeonprem_vmware_cluster`
```

Tests: Acceptance tests PASSED (confirmed by Validator agent).
