### PR TITLE
chronicle: add environment_allowed_for_all_users to google_chronicle_environment

### DIFF
--- a/mmv1/products/chronicle/Environment.yaml
+++ b/mmv1/products/chronicle/Environment.yaml
@@ -119,3 +119,8 @@ properties:
     required: true
     immutable: true
     description: Environment data retention in months.
+  - name: environmentAllowedForAllUsers
+    type: Boolean
+    immutable: true
+    description: |-
+      If set to true, automatically assigns the new environment to all existing users and API keys.

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_environment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_environment_basic.tf.tmpl
@@ -10,6 +10,7 @@ resource "google_chronicle_environment" "{{$.PrimaryResourceId}}" {
   aliases_json            = jsonencode([])
   data_access_scopes_json = jsonencode([])
   retention_duration = 3
+  environment_allowed_for_all_users = true
 
   deletion_protection  = false
 }

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_environment_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_environment_full.tf.tmpl
@@ -10,6 +10,7 @@ resource "google_chronicle_environment" "{{$.PrimaryResourceId}}" {
   aliases_json            = jsonencode([])
   data_access_scopes_json = jsonencode([])
   retention_duration = 3
+  environment_allowed_for_all_users = true
 
   deletion_protection  = false
 }


### PR DESCRIPTION
Adds missing field `environment_allowed_for_all_users` to `google_chronicle_environment`.

reference: b/552786302

```release-note:enhancement
chronicle: added `environment_allowed_for_all_users` field to `google_chronicle_environment`
```
