### PR TITLE
biglakeiceberg: set default partition field-ids

### DIFF
--- a/mmv1/templates/terraform/encoders/biglake_iceberg_table_create.go.tmpl
+++ b/mmv1/templates/terraform/encoders/biglake_iceberg_table_create.go.tmpl
@@ -8,4 +8,18 @@
 			wo["order-id"] = 1
 		}
 	}
+
+	// Iceberg PartitionSpec fields require a field-id (conventionally starting at 1000).
+	// Since field_id is output-only in the schema, inject defaults if omitted.
+	if ps, ok := obj["partition-spec"].(map[string]interface{}); ok {
+		if fields, ok := ps["fields"].([]interface{}); ok {
+			for i, field := range fields {
+				if f, ok := field.(map[string]interface{}); ok {
+					if _, hasId := f["field-id"]; !hasId {
+						f["field-id"] = 1000 + i
+					}
+				}
+			}
+		}
+	}
 	return obj, nil


### PR DESCRIPTION
The BigLake Iceberg REST Catalog API requires `field-id` for fields in `partition-spec` during `CreateTable` requests. However, `field_id` is defined as `output: true` in the Magic Modules schema, so Terraform omits it when constructing the create payload, leading to an API 400 error (`field-id missing for partition field ...`).

This change updates the table create encoder (`biglake_iceberg_table_create.go.tmpl`) to automatically inject sequential default `field-id` values (starting at 1000, per Apache Iceberg convention) if not already present. This mirrors how `order-id = 1` is already injected for `write-order`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/29136

```release-note:bug
biglakeiceberg: fixed an issue where creating a partitioned `google_biglake_iceberg_table` failed due to missing `field-id`
```
