### PR TITLE
appengine: promote vpc_access to GA and update  descriptions

### DIFF
--- a/mmv1/products/appengine/StandardAppVersion.yaml
+++ b/mmv1/products/appengine/StandardAppVersion.yaml
@@ -86,7 +86,6 @@ samples:
         ignore_read_extra:
           - delete_service_on_destroy
   - name: app_engine_standard_app_version_vpc_access
-    min_version: beta
     primary_resource_id: gae-std-app-ver-vpc-access
     steps:
       - name: app_engine_standard_app_version_vpc_access
@@ -354,7 +353,6 @@ properties:
           The egress setting for the connector, controlling what traffic is diverted through it.
   - name: vpcAccess
     type: NestedObject
-    min_version: beta
     description: |
       Direct VPC Access settings for standard apps.
     conflicts:
@@ -364,11 +362,11 @@ properties:
         api_name: vpcEgress
         type: String
         description: |
-          The egress setting for the VPC Access, controlling what traffic is diverted through it.
+          The traffic egress setting for the VPC network interface, controlling what traffic is diverted through it.
       - name: networkInterfaces
         type: Array
         description: |
-          List of network interfaces for the VPC Access. Currently only a single network interface is supported.
+          The Direct VPC configuration. Currently only a single network interface is supported.
         item_type:
           type: NestedObject
           properties:
@@ -376,19 +374,19 @@ properties:
               type: String
               diff_suppress_func: tpgresource.CompareSelfLinkOrResourceName
               description: |
-                The name of the VPC network to which the version connects (e.g. `projects/my-project/global/networks/default`).
+                The VPC network that the App Engine resource will be able to send traffic to. At least one of `network` or `subnetwork` must be specified. If `network` is not specified, it will be looked up from the subnetwork. Example: `{VPC_NETWORK}` or `projects/{HOST_PROJECT_ID}/global/networks/{VPC_NETWORK}`.
             - name: subnetwork
               api_name: subnet
               type: String
               diff_suppress_func: tpgresource.CompareSelfLinkOrResourceName
               description: |
-                The name of the subnetwork to which the version connects (e.g. `projects/my-project/regions/us-central1/subnetworks/default`).
+                The VPC subnetwork that the App Engine resource will get IPs from. At least one of `network` or `subnetwork` must be specified. If `subnetwork` is not specified, the subnetwork with the same name as the network will be used. Example: `{SUBNET_NAME}` or `projects/{HOST_PROJECT_ID}/regions/{REGION}/subnetworks/{SUBNET_NAME}`.
             - name: tags
               type: Array
               item_type:
                 type: String
               description: |
-                Network tags applied to this App Engine version.
+                The network tags that will be applied to this App Engine resource.
   - name: inboundServices
     type: Array
     description: |

--- a/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version_vpc_access.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version_vpc_access.tf.tmpl
@@ -1,31 +1,31 @@
 resource "google_service_account" "service_account" {
-  provider     = google-beta
+  provider     = google
   account_id   = "{{index $.ResourceIdVars "sa_email"}}"
   display_name = "Test Service Account for GAE"
 }
 
 resource "google_project_iam_member" "gae_api" {
-  provider = google-beta
+  provider = google
   project  = google_service_account.service_account.project
   role     = "roles/compute.networkUser"
   member   = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 resource "google_project_iam_member" "storage_viewer" {
-  provider = google-beta
+  provider = google
   project  = google_service_account.service_account.project
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 resource "google_compute_network" "custom" {
-  provider                = google-beta
+  provider                = google
   name                    = "custom-net-{{index $.ResourceIdVars "service_id"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "custom" {
-  provider      = google-beta
+  provider      = google
   name          = "custom-sub-{{index $.ResourceIdVars "service_id"}}"
   ip_cidr_range = "10.0.0.0/24"
   region        = "us-central1"
@@ -33,28 +33,28 @@ resource "google_compute_subnetwork" "custom" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  provider                    = google-beta
+  provider                    = google
   name                        = "{{index $.ResourceIdVars "bucket_name"}}"
   location                    = "US"
   uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "requirements" {
-  provider = google-beta
+  provider = google
   name     = "requirements.txt"
   bucket   = google_storage_bucket.bucket.name
   source   = "./test-fixtures/hello-world-flask/requirements.txt"
 }
 
 resource "google_storage_bucket_object" "main" {
-  provider = google-beta
+  provider = google
   name     = "main.py"
   bucket   = google_storage_bucket.bucket.name
   source   = "./test-fixtures/hello-world-flask/main.py"
 }
 
 resource "google_app_engine_standard_app_version" "{{$.PrimaryResourceId}}" {
-  provider     = google-beta
+  provider     = google
   version_id   = "v1"
   service      = "{{index $.ResourceIdVars "service_id"}}"
   runtime      = "python310"


### PR DESCRIPTION
## Description

Promote App Engine Standard App Version VPC Access feature from beta to GA and align field descriptions with the authoritative proto definitions.

## Changes
- VPC Access is now fully supported in GA, removing the beta restriction
- Improve user documentation and reduce ambiguity around field requirements

## Testing
- Sample configuration updated to use GA provider

```release-note:enhancement
appengine: `google_app_engine_standard_app_version` - The `vpc_access` block is now generally available (GA) and no longer requires the beta provider. This allows you to configure Direct VPC Access for standard App Engine applications using the standard `google` provider.
```

