### PR TITLE
compute: add `rsa_encryption_wo` and `raw_key_wo` fields to `google_compute_disk` and `google_compute_region_disk` resources

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -78,6 +78,20 @@ samples:
       - name: 'disk_basic'
         resource_id_vars:
           disk_name: 'test-disk'
+  - name: 'disk_basic_wo'
+    primary_resource_id: 'default'
+    tgc_skip_test: write-only fields are not generated for TGC
+    steps:
+      - name: 'disk_basic_wo'
+        resource_id_vars:
+          disk_name: 'test-disk'
+  - name: 'disk_rsa_encrypted_key_wo'
+    primary_resource_id: 'default'
+    tgc_skip_test: write-only fields are not generated for TGC
+    steps:
+      - name: 'disk_rsa_encrypted_key_wo'
+        resource_id_vars:
+          disk_name: 'test-disk'
   - name: 'disk_async'
     primary_resource_id: 'secondary'
     steps:
@@ -206,6 +220,7 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
+        write_only: true
         is_missing_in_cai: true
       - name: 'rsaEncryptedKey'
         type: String
@@ -214,6 +229,7 @@ properties:
           customer-supplied encryption key to either encrypt or decrypt
           this resource. You can provide either the rawKey or the rsaEncryptedKey.
         sensitive: true
+        write_only: true
         is_missing_in_cai: true
       - name: 'sha256'
         type: String

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -88,6 +88,15 @@ samples:
           region_disk_name: 'my-region-disk'
           disk_name: 'my-disk'
           snapshot_name: 'my-snapshot'
+  - name: 'region_disk_rsa_encrypted_key_wo'
+    primary_resource_id: 'regiondisk'
+    tgc_skip_test: write-only fields are not generated for TGC
+    steps:
+      - name: 'region_disk_rsa_encrypted_key_wo'
+        resource_id_vars:
+          region_disk_name: 'my-region-disk'
+          disk_name: 'my-disk'
+          snapshot_name: 'my-snapshot'
   - name: 'region_disk_async'
     primary_resource_id: 'primary'
     steps:
@@ -180,6 +189,7 @@ properties:
           customer-supplied encryption key to either encrypt or decrypt
           this resource. You can provide either the rawKey or the rsaEncryptedKey.
         sensitive: true
+        write_only: true
         is_missing_in_cai: true
       - name: 'sha256'
         type: String

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -79,6 +79,15 @@ samples:
           region_disk_name: 'my-region-disk'
           disk_name: 'my-disk'
           snapshot_name: 'my-snapshot'
+  - name: 'region_disk_disk_encryption_key_wo'
+    primary_resource_id: 'regiondisk'
+    tgc_skip_test: write-only fields are not generated for TGC
+    steps:
+      - name: 'region_disk_disk_encryption_key_wo'
+        resource_id_vars:
+          region_disk_name: 'my-region-disk'
+          disk_name: 'my-disk'
+          snapshot_name: 'my-snapshot'
   - name: 'region_disk_async'
     primary_resource_id: 'primary'
     steps:
@@ -162,6 +171,7 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
+        write_only: true
         is_missing_in_cai: true
       - name: 'rsaEncryptedKey'
         type: String

--- a/mmv1/templates/terraform/samples/services/compute/disk_basic_wo.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/disk_basic_wo.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_compute_disk" "default" {
+  name  = "{{index $.ResourceIdVars "disk_name"}}"
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+  image = "debian-11-bullseye-v20220719"
+  labels = {
+    environment = "dev"
+  }
+  physical_block_size_bytes = 4096
+  disk_encryption_key {
+    raw_key_wo         = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
+    raw_key_wo_version = 1
+  }
+}

--- a/mmv1/templates/terraform/samples/services/compute/disk_rsa_encrypted_key_wo.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/disk_rsa_encrypted_key_wo.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_compute_disk" "default" {
+  name  = "{{index $.ResourceIdVars "disk_name"}}"
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+  image = "debian-11-bullseye-v20220719"
+  disk_encryption_key {
+    rsa_encrypted_key_wo         = "fB6BS8tJGhGVDZDjGt1pwUo2wyNbkzNxgH1avfOtiwB9X6oPG94gWgenygitnsYJyKjdOJ7DyXLmxwQOSmnCYCUBWdKCSssyLV5907HL2mb5TfqmgHk5JcArI/t6QADZWiuGtR+XVXqiLa5B9usxFT2BTmbHvSKfkpJ7McCNc/3U0PQR8euFRZ9i75o/w+pLHFMJ05IX3JB0zHbXMV173PjObiV3ItSJm2j3mp5XKabRGSA5rmfMnHIAMz6stGhcuom6+bMri2u/axmPsdxmC6MeWkCkCmPjaKsVz1+uQUNCJkAnzesluhoD+R6VjFDm4WI7yYabu4MOOAOTaQXdEg=="
+    rsa_encrypted_key_wo_version = 1
+  }
+}

--- a/mmv1/templates/terraform/samples/services/compute/region_disk_disk_encryption_key_wo.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_disk_disk_encryption_key_wo.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_compute_region_disk" "regiondisk" {
+  name                      = "{{index $.ResourceIdVars "region_disk_name"}}"
+  snapshot                  = google_compute_snapshot.snapdisk.id
+  type                      = "pd-ssd"
+  region                    = "us-central1"
+  physical_block_size_bytes = 4096
+  disk_encryption_key {
+    raw_key_wo         = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
+    raw_key_wo_version = 1
+  }
+
+  replica_zones = ["us-central1-a", "us-central1-f"]
+}
+
+resource "google_compute_disk" "disk" {
+  name  = "{{index $.ResourceIdVars "disk_name"}}"
+  image = "debian-cloud/debian-11"
+  size  = 50
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "snapdisk" {
+  name        = "{{index $.ResourceIdVars "snapshot_name"}}"
+  source_disk = google_compute_disk.disk.name
+  zone        = "us-central1-a"
+}

--- a/mmv1/templates/terraform/samples/services/compute/region_disk_rsa_encrypted_key_wo.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_disk_rsa_encrypted_key_wo.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_compute_region_disk" "regiondisk" {
+  name                      = "{{index $.ResourceIdVars "region_disk_name"}}"
+  snapshot                  = google_compute_snapshot.snapdisk.id
+  type                      = "pd-ssd"
+  region                    = "us-central1"
+  physical_block_size_bytes = 4096
+  disk_encryption_key {
+    rsa_encrypted_key_wo         = "fB6BS8tJGhGVDZDjGt1pwUo2wyNbkzNxgH1avfOtiwB9X6oPG94gWgenygitnsYJyKjdOJ7DyXLmxwQOSmnCYCUBWdKCSssyLV5907HL2mb5TfqmgHk5JcArI/t6QADZWiuGtR+XVXqiLa5B9usxFT2BTmbHvSKfkpJ7McCNc/3U0PQR8euFRZ9i75o/w+pLHFMJ05IX3JB0zHbXMV173PjObiV3ItSJm2j3mp5XKabRGSA5rmfMnHIAMz6stGhcuom6+bMri2u/axmPsdxmC6MeWkCkCmPjaKsVz1+uQUNCJkAnzesluhoD+R6VjFDm4WI7yYabu4MOOAOTaQXdEg=="
+    rsa_encrypted_key_wo_version = 1
+  }
+
+  replica_zones = ["us-central1-a", "us-central1-f"]
+}
+
+resource "google_compute_disk" "disk" {
+  name  = "{{index $.ResourceIdVars "disk_name"}}"
+  image = "debian-cloud/debian-11"
+  size  = 50
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "snapdisk" {
+  name        = "{{index $.ResourceIdVars "snapshot_name"}}"
+  source_disk = google_compute_disk.disk.name
+  zone        = "us-central1-a"
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: add `rsa_encryption_wo` and `raw_key_wo` fields to `google_compute_disk` resource
```

```release-note:enhancement
compute: add `rsa_encryption_wo` and `raw_key_wo` fields to `google_compute_region_disk` resource
```
