### PR TITLE
`teamcity`: use composite builds for reliable sweeping order

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/PERFORMING_TASKS_IN_TEAMCITY.md
+++ b/mmv1/third_party/terraform/.teamcity/PERFORMING_TASKS_IN_TEAMCITY.md
@@ -51,7 +51,7 @@ You can find the builds for nightly tests at:
 * [Google > Nightly Tests](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS?branch=refs%2Fheads%2Fnightly-test&mode=builds#all-projects)
 * [Google Beta > Nightly Tests](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS?branch=refs%2Fheads%2Fnightly-test&mode=builds#all-projects)
 
-These projects contain a build configuration per service package, plus a composite **All Nightly Tests** build that aggregates them. A cron on the Service Sweeper at 4am UTC starts the chain (all package tests → All Nightly Tests → Service Sweeper).
+These projects contain a build configuration per service package, plus a composite **All Nightly Tests** build that aggregates them. Package tests are still triggered at 4am UTC; the Service Sweeper runs five hours later and snapshot-depends on the composite.
 
 To view all the failed tests for a given commit:
 
@@ -125,7 +125,7 @@ In REPLAYING mode the build will download VCR cassettes from a GCS Bucket and ru
 
 ### Sweeping the Nightly Test Projects
 
-The Service Sweeper builds in [`Google > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS?mode=builds#all-projects) and [`Google Beta > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS#all-projects) run every night via CRON at 4am UTC. That cron is the entry point for the nightly chain: the sweeper snapshot-depends on the composite All Nightly Tests build, which snapshot-depends on every package test. Triggering the sweeper therefore queues all package tests first; the sweeper itself runs only after those tests finish. Package-test failures are recorded on the composite but do not skip the sweeper.
+The Service Sweeper builds in [`Google > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS?mode=builds#all-projects) and [`Google Beta > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS#all-projects) run every night via CRON, five hours after the package tests. They snapshot-depend on the composite All Nightly Tests build, which snapshot-depends on every package test, so the sweeper waits until that night's tests have finished. Package-test failures are recorded on the composite but do not skip the sweeper.
 
 ### Sweeping the VCR Project
 

--- a/mmv1/third_party/terraform/.teamcity/PERFORMING_TASKS_IN_TEAMCITY.md
+++ b/mmv1/third_party/terraform/.teamcity/PERFORMING_TASKS_IN_TEAMCITY.md
@@ -51,7 +51,7 @@ You can find the builds for nightly tests at:
 * [Google > Nightly Tests](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS?branch=refs%2Fheads%2Fnightly-test&mode=builds#all-projects)
 * [Google Beta > Nightly Tests](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS?branch=refs%2Fheads%2Fnightly-test&mode=builds#all-projects)
 
-These projects contain a build configuration per service package.
+These projects contain a build configuration per service package, plus a composite **All Nightly Tests** build that aggregates them. A cron on the Service Sweeper at 4am UTC starts the chain (all package tests → All Nightly Tests → Service Sweeper).
 
 To view all the failed tests for a given commit:
 
@@ -125,7 +125,7 @@ In REPLAYING mode the build will download VCR cassettes from a GCS Bucket and ru
 
 ### Sweeping the Nightly Test Projects
 
-The Service Sweeper builds in [`Google > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS?mode=builds#all-projects) and [`Google Beta > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS#all-projects) run every night via CRON. They are designed to not run until there are no builds testing any services in the GA or Beta nightly test GCP projects. No acceptance testing builds will start until the sweeper stops.
+The Service Sweeper builds in [`Google > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS?mode=builds#all-projects) and [`Google Beta > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS#all-projects) run every night via CRON at 4am UTC. That cron is the entry point for the nightly chain: the sweeper snapshot-depends on the composite All Nightly Tests build, which snapshot-depends on every package test. Triggering the sweeper therefore queues all package tests first; the sweeper itself runs only after those tests finish. Package-test failures are recorded on the composite but do not skip the sweeper.
 
 ### Sweeping the VCR Project
 
@@ -135,4 +135,4 @@ The Service Sweeper builds in [`Google > Upstream MM Testing`](https://hashicorp
 
 When testing the GA and Beta providers we can run tests in parallel because those tests use separate GCP projects. This creates a boundary between the two test suites and ensures they don't clash. However if an acceptance test provisions `google_project` resources in the process then there is no longer a clear GA/Beta boundary based on which host project is in use. This makes sweeping up these resources tough, as there's potential to disrupt any other running build.
 
-The `google_project` resource can be swept up safely if there are no other ongoing builds testing the GA/Beta Google providers. The `Project Sweeper` project contains a special build configuration for this sweeper that locks access to the GA/Beta/VCR GCP projects while it runs. This means the buid must wait for all other builds to stop before it starts, and while it is running no other Google-related builds can leave the queue and start running.
+The `google_project` resource can be swept up safely if there are no other ongoing builds testing the GA/Beta Google providers. The `Project Sweeper` project contains special build configurations for project and folder sweepers. They run via CRON at 12:00 UTC and snapshot-depend on both the GA and Beta All Nightly Tests composites, so they wait for (or reuse) that night's test chain before sweeping. They also lock access to the GA/Beta/VCR GCP projects while they run. This means the build must wait for all other builds to stop before it starts, and while it is running no other Google-related builds can leave the queue and start running.

--- a/mmv1/third_party/terraform/.teamcity/PERFORMING_TASKS_IN_TEAMCITY.md
+++ b/mmv1/third_party/terraform/.teamcity/PERFORMING_TASKS_IN_TEAMCITY.md
@@ -51,7 +51,7 @@ You can find the builds for nightly tests at:
 * [Google > Nightly Tests](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS?branch=refs%2Fheads%2Fnightly-test&mode=builds#all-projects)
 * [Google Beta > Nightly Tests](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS?branch=refs%2Fheads%2Fnightly-test&mode=builds#all-projects)
 
-These projects contain a build configuration per service package, plus a composite **All Nightly Tests** build that aggregates them. Package tests are still triggered at 4am UTC; the Service Sweeper runs five hours later and snapshot-depends on the composite.
+These projects contain a build configuration per service package, plus a composite **All Nightly Tests** build. The nightly cron triggers the composite at 4am UTC on `refs/heads/nightly-test`. Its snapshot dependencies schedule the package builds with a shared source snapshot; package builds no longer have individual nightly cron triggers. Each provider's Service Sweeper has a finish-build trigger watching its composite.
 
 To view all the failed tests for a given commit:
 
@@ -125,7 +125,11 @@ In REPLAYING mode the build will download VCR cassettes from a GCS Bucket and ru
 
 ### Sweeping the Nightly Test Projects
 
-The Service Sweeper builds in [`Google > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS?mode=builds#all-projects) and [`Google Beta > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS#all-projects) run every night via CRON, five hours after the package tests. They snapshot-depend on the composite All Nightly Tests build, which snapshot-depends on every package test, so the sweeper waits until that night's tests have finished. Package-test failures are recorded on the composite but do not skip the sweeper.
+The Service Sweeper builds in [`Google > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS?mode=builds#all-projects) and [`Google Beta > Nightly Tests`](https://hashicorp.teamcity.com/project/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS#all-projects) use finish-build triggers, not a separate cron schedule. Each watches its own **All Nightly Tests** composite on the configured nightly branch. The finish trigger does not require success (`successfulOnly = false`), and the snapshot dependency allows the sweeper to run despite dependency failures or cancellations. The composite records package failures and cancellations as build problems; the service sweeper is a downstream build, not part of the composite itself.
+
+Package builds retain per-service shared-resource locks. Each Service Sweeper locks all values of its provider's shared resource, preventing it from overlapping with package builds that acquire those locks, including ad hoc runs. GA and Beta service sweepers use separate provider locks.
+
+Finish triggers explicitly set their branch filters. TeamCity's `+:<default>` selects the VCS default branch (`main` for these VCS roots), not the nightly cron configuration's `refs/heads/nightly-test` branch. Trigger source IDs are resolved using the current DSL project context rather than a hardcoded production project prefix.
 
 ### Sweeping the VCR Project
 
@@ -135,4 +139,8 @@ The Service Sweeper builds in [`Google > Upstream MM Testing`](https://hashicorp
 
 When testing the GA and Beta providers we can run tests in parallel because those tests use separate GCP projects. This creates a boundary between the two test suites and ensures they don't clash. However if an acceptance test provisions `google_project` resources in the process then there is no longer a clear GA/Beta boundary based on which host project is in use. This makes sweeping up these resources tough, as there's potential to disrupt any other running build.
 
-The `google_project` resource can be swept up safely if there are no other ongoing builds testing the GA/Beta Google providers. The `Project Sweeper` project contains special build configurations for project and folder sweepers. They run via CRON at 12:00 UTC and snapshot-depend on both the GA and Beta All Nightly Tests composites, so they wait for (or reuse) that night's test chain before sweeping. They also lock access to the GA/Beta/VCR GCP projects while they run. This means the build must wait for all other builds to stop before it starts, and while it is running no other Google-related builds can leave the queue and start running.
+The **Global Sweepers** project contains separate **Project Sweeper** and **Folder Sweeper** builds. Both use a finish-build trigger watching the GA Service Sweeper on `refs/heads/nightly-test`, without requiring success. Neither has its own nightly cron trigger. Each has four explicit snapshot dependencies: the GA and Beta **All Nightly Tests** composites and the GA and Beta **Service Sweeper** builds. Dependency failures and cancellations do not prevent cleanup from running.
+
+Both global sweepers acquire all values of the GA, Beta, and VCR shared resources. This prevents them from running concurrently with builds that acquire those locks, or with each other. Branch filters select the events that trigger cleanup; they do not restrict which GCP resources cleanup can affect.
+
+Snapshot dependencies are not passive waits for existing runs. TeamCity can reuse a suitable build or request a new dependency build if no suitable one exists. Failure/cancellation actions do not control build reuse; the DSL's default reuse policy is successful builds only. When investigating apparent duplicates, inspect the waiting build's identity, **Triggered by** information, and dependency build IDs. A lock message naming the Beta Service Sweeper identifies the lock holder, not the waiting build, and is not by itself evidence of a duplicate Beta sweeper.

--- a/mmv1/third_party/terraform/.teamcity/USING_A_SINGLE_COMMIT_FOR_NIGHTLY_TESTS.md
+++ b/mmv1/third_party/terraform/.teamcity/USING_A_SINGLE_COMMIT_FOR_NIGHTLY_TESTS.md
@@ -2,7 +2,7 @@
 
 ## Background and problem
 
-Our nightly tests are implemented as a build per package in the provider. A cron schedule on the Service Sweeper at 4am UTC starts a build chain: every package test build, then the composite All Nightly Tests build, then the Service Sweeper. Snapshot dependencies make those package builds share one sources snapshot (the same git revision). When builds are triggered they enter the build queue and wait for an agent to be available to run the build. Overall the test suite takes approximately 8-10 hours to complete (excluding sweeper builds) and builds are leaving the queue at various times.
+Our nightly tests are implemented as a build per package in the provider. A cron schedule triggers builds from each build configuration at 4am UTC and we use locks to prevent builds conflicting with each other. The composite All Nightly Tests build snapshot-depends on every package test so they share one sources snapshot; the Service Sweeper snapshot-depends on that composite and is triggered five hours later. When builds are triggered they enter the build queue and wait for an agent to be available to run the build. Overall the test suite takes approximately 8-10 hours to complete (excluding sweeper builds) and builds are leaving the queue at various times.
 
 Builds in TeamCity use the latest commit from the branch they’re testing at the point that they leave the build queue and start to run. This can result in situations where the build queue contains multiple builds, early-running builds use the latest commit (A) on the main branch, a PR is merged and introduces a subsequent commit (B), and then builds that exit the queue later will run tests using commit B.
 
@@ -24,7 +24,7 @@ The solution we've implemented includes:
     * Renames the previous day's `nightly-test` branch to `UTC-nightly-test-YYYY-MM-DD`, where the date corresponds to when the base commit was made in UTC.
     * Creates a new `nightly-test` branch using the latest commit on the `main` branch
     * Sweeps up old `UTC-nightly-test-YYYY-MM-DD` branches [over 3 days old](https://github.com/hashicorp/terraform-provider-google/blob/5bce89216324fcf9165ef5fc8d1634e55465282b/.github/workflows/teamcity-nightly-workflow.yaml#L83)
-* [Updates to TeamCity](https://github.com/GoogleCloudPlatform/magic-modules/pull/10785) so that any builds triggered by the nightly cron at **4am UTC** check out the `nightly-test` branch. The Service Sweeper is the cron entry point; package tests are pulled in through snapshot dependencies and therefore use that same revision. 
+* [Updates to TeamCity](https://github.com/GoogleCloudPlatform/magic-modules/pull/10785) so that any builds triggered by the nightly cron at **4am UTC** check out the `nightly-test` branch. The Service Sweeper is triggered five hours later and snapshot-depends on the composite All Nightly Tests build, so it waits for that night's package tests. 
 
 <p align="center">
 <img src="./docs/images/clock-timings-of-branch-making-and-usage.png">

--- a/mmv1/third_party/terraform/.teamcity/USING_A_SINGLE_COMMIT_FOR_NIGHTLY_TESTS.md
+++ b/mmv1/third_party/terraform/.teamcity/USING_A_SINGLE_COMMIT_FOR_NIGHTLY_TESTS.md
@@ -2,7 +2,7 @@
 
 ## Background and problem
 
-Our nightly tests are implemented as a build per package in the provider. A cron schedule triggers builds from each build configuration at 4am UTC and we use locks to prevent builds conflicting with each other. When builds are triggered they enter the build queue and wait for an agent to be available to run the build. Overall the test suite takes approximately 8-10 hours to complete (excluding sweeper builds) and builds are leaving the queue at various times.
+Our nightly tests are implemented as a build per package in the provider. A cron schedule on the Service Sweeper at 4am UTC starts a build chain: every package test build, then the composite All Nightly Tests build, then the Service Sweeper. Snapshot dependencies make those package builds share one sources snapshot (the same git revision). When builds are triggered they enter the build queue and wait for an agent to be available to run the build. Overall the test suite takes approximately 8-10 hours to complete (excluding sweeper builds) and builds are leaving the queue at various times.
 
 Builds in TeamCity use the latest commit from the branch they’re testing at the point that they leave the build queue and start to run. This can result in situations where the build queue contains multiple builds, early-running builds use the latest commit (A) on the main branch, a PR is merged and introduces a subsequent commit (B), and then builds that exit the queue later will run tests using commit B.
 
@@ -24,7 +24,7 @@ The solution we've implemented includes:
     * Renames the previous day's `nightly-test` branch to `UTC-nightly-test-YYYY-MM-DD`, where the date corresponds to when the base commit was made in UTC.
     * Creates a new `nightly-test` branch using the latest commit on the `main` branch
     * Sweeps up old `UTC-nightly-test-YYYY-MM-DD` branches [over 3 days old](https://github.com/hashicorp/terraform-provider-google/blob/5bce89216324fcf9165ef5fc8d1634e55465282b/.github/workflows/teamcity-nightly-workflow.yaml#L83)
-* [Updates to TeamCity](https://github.com/GoogleCloudPlatform/magic-modules/pull/10785) so that any builds triggered by the nightly cron at **4am UTC** check out the `nightly-test` branch 
+* [Updates to TeamCity](https://github.com/GoogleCloudPlatform/magic-modules/pull/10785) so that any builds triggered by the nightly cron at **4am UTC** check out the `nightly-test` branch. The Service Sweeper is the cron entry point; package tests are pulled in through snapshot dependencies and therefore use that same revision. 
 
 <p align="center">
 <img src="./docs/images/clock-timings-of-branch-making-and-usage.png">

--- a/mmv1/third_party/terraform/.teamcity/USING_A_SINGLE_COMMIT_FOR_NIGHTLY_TESTS.md
+++ b/mmv1/third_party/terraform/.teamcity/USING_A_SINGLE_COMMIT_FOR_NIGHTLY_TESTS.md
@@ -2,9 +2,9 @@
 
 ## Background and problem
 
-Our nightly tests are implemented as a build per package in the provider. A cron schedule triggers builds from each build configuration at 4am UTC and we use locks to prevent builds conflicting with each other. The composite All Nightly Tests build snapshot-depends on every package test so they share one sources snapshot; the Service Sweeper snapshot-depends on that composite and is triggered five hours later. When builds are triggered they enter the build queue and wait for an agent to be available to run the build. Overall the test suite takes approximately 8-10 hours to complete (excluding sweeper builds) and builds are leaving the queue at various times.
+Our nightly tests are implemented as a build per package in the provider. Previously, a cron schedule triggered each package build independently at 4am UTC. Those builds entered the queue and waited for agents, starting at different times over the approximately 8-10 hour test suite (excluding sweepers). Shared-resource locks prevented conflicting builds but did not synchronize their source revisions.
 
-Builds in TeamCity use the latest commit from the branch they’re testing at the point that they leave the build queue and start to run. This can result in situations where the build queue contains multiple builds, early-running builds use the latest commit (A) on the main branch, a PR is merged and introduces a subsequent commit (B), and then builds that exit the queue later will run tests using commit B.
+Independent builds can resolve different source revisions as their branch changes. Early-running builds may use commit A on `main`, while later builds use commit B after another PR merges. The composite build chain described below instead synchronizes source revisions across its package dependencies.
 
 
 This is a problem as our release cut process assumes that all acceptance tests run on a given night are testing the same commit, and that commit is used to cut the release. If a night’s tests span multiple commits the Release Shepherd will need to analyze multiple builds and identify what commits were tested and determine whether tests pass equally for all those commits (and then decide on a single commit to use for the release cut!).
@@ -13,9 +13,7 @@ This is a problem as our release cut process assumes that all acceptance tests r
 
 To solve this problem we need to direct TeamCity to checkout a particular commit when running nightly tests.
 
-We cannot identify a commit to use for all tests and instruct TeamCity to checkout that specific commit directly from main. There is an open Feature Request tracked on JetBrains’ website for this feature: [Allow VCS root to checkout specified revision instead of the most current version.](https://youtrack.jetbrains.com/issue/TW-11400)
-
-Because of this limitation we need to label a commit with either a tag or a new branch and direct TeamCity to checkout the tag/branch, using them as an indirect way of checking out the commit we labeled.
+We retain the `nightly-test` branch to identify the nightly release candidate. Each provider's **All Nightly Tests** composite snapshot-depends on all its package builds, so they use a synchronized source snapshot even when agents start them at different times.
 
 The solution we've implemented includes:
 
@@ -24,7 +22,9 @@ The solution we've implemented includes:
     * Renames the previous day's `nightly-test` branch to `UTC-nightly-test-YYYY-MM-DD`, where the date corresponds to when the base commit was made in UTC.
     * Creates a new `nightly-test` branch using the latest commit on the `main` branch
     * Sweeps up old `UTC-nightly-test-YYYY-MM-DD` branches [over 3 days old](https://github.com/hashicorp/terraform-provider-google/blob/5bce89216324fcf9165ef5fc8d1634e55465282b/.github/workflows/teamcity-nightly-workflow.yaml#L83)
-* [Updates to TeamCity](https://github.com/GoogleCloudPlatform/magic-modules/pull/10785) so that any builds triggered by the nightly cron at **4am UTC** check out the `nightly-test` branch. The Service Sweeper is triggered five hours later and snapshot-depends on the composite All Nightly Tests build, so it waits for that night's package tests. 
+* The nightly cron at **4am UTC** triggers each provider's **All Nightly Tests** composite on `refs/heads/nightly-test`. Package builds are registered snapshot dependencies, not independently cron-triggered builds.
+* Each Service Sweeper uses a finish-build trigger watching its composite on the same branch, plus a snapshot dependency on that composite. It no longer has a fixed five-hour delay. Package build failures or cancellations are recorded on the composite, while the sweeper's dependency settings allow cleanup after those outcomes.
+* Global project and folder sweepers watch the GA Service Sweeper and snapshot-depend on both providers' composites and service sweepers. See [sweeper orchestration and build reuse](./PERFORMING_TASKS_IN_TEAMCITY.md#sweepers) for the trigger and locking behavior.
 
 <p align="center">
 <img src="./docs/images/clock-timings-of-branch-making-and-usage.png">

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_triggers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_triggers.kt
@@ -20,9 +20,7 @@ class NightlyTriggerConfiguration(
     val nightlyTestsEnabled: Boolean = true,
     var startHour: Int = DefaultStartHour,
     var daysOfWeek: String = DefaultDaysOfWeek,
-    val daysOfMonth: String = DefaultDaysOfMonth,
-    var startMinute: Int = 0,
-    val timezone: String = "SERVER"
+    val daysOfMonth: String = DefaultDaysOfMonth
 ){
     fun clone(): NightlyTriggerConfiguration{
         return NightlyTriggerConfiguration(
@@ -30,9 +28,7 @@ class NightlyTriggerConfiguration(
             this.nightlyTestsEnabled,
             this.startHour,
             this.daysOfWeek,
-            this.daysOfMonth,
-            this.startMinute,
-            this.timezone
+            this.daysOfMonth
         )
     }
 }
@@ -48,8 +44,7 @@ fun Triggers.runNightly(config: NightlyTriggerConfiguration) {
 
         schedulingPolicy = cron {
             hours = config.startHour.toString()
-            minutes = config.startMinute.toString()
-            timezone = config.timezone
+            timezone = "SERVER"
 
             dayOfWeek = config.daysOfWeek
             dayOfMonth = config.daysOfMonth

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_triggers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_triggers.kt
@@ -20,7 +20,9 @@ class NightlyTriggerConfiguration(
     val nightlyTestsEnabled: Boolean = true,
     var startHour: Int = DefaultStartHour,
     var daysOfWeek: String = DefaultDaysOfWeek,
-    val daysOfMonth: String = DefaultDaysOfMonth
+    val daysOfMonth: String = DefaultDaysOfMonth,
+    var startMinute: Int = 0,
+    val timezone: String = "SERVER"
 ){
     fun clone(): NightlyTriggerConfiguration{
         return NightlyTriggerConfiguration(
@@ -28,7 +30,9 @@ class NightlyTriggerConfiguration(
             this.nightlyTestsEnabled,
             this.startHour,
             this.daysOfWeek,
-            this.daysOfMonth
+            this.daysOfMonth,
+            this.startMinute,
+            this.timezone
         )
     }
 }
@@ -44,7 +48,8 @@ fun Triggers.runNightly(config: NightlyTriggerConfiguration) {
 
         schedulingPolicy = cron {
             hours = config.startHour.toString()
-            timezone = "SERVER"
+            minutes = config.startMinute.toString()
+            timezone = config.timezone
 
             dayOfWeek = config.daysOfWeek
             dayOfMonth = config.daysOfMonth

--- a/mmv1/third_party/terraform/.teamcity/components/constants.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/constants.kt
@@ -39,6 +39,7 @@ const val SharedResourceNameVcr = "ci-test-project-188019 Service Lock"
 
 // Build configuration names referenced in multiple places
 const val ServiceSweeperName = "Service Sweeper"
+const val AllNightlyTestsName = "All Nightly Tests"
 const val ServiceSweeperCronName = "$ServiceSweeperName - Cron"
 const val ServiceSweeperManualName = "$ServiceSweeperName - Manual"
 const val GlobalSweepersProjectName = "Global Sweepers"

--- a/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
@@ -8,11 +8,14 @@
 package projects
 
 import GlobalSweepersProjectName
+import NightlyTestsProjectId
 import SharedResourceNameBeta
 import SharedResourceNameGa
 import SharedResourceNameVcr
 import builds.*
 import generated.SweepersListGa
+import jetbrains.buildServer.configs.kotlin.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
 import replaceCharsId
 import vcs_roots.HashiCorpVCSRootGa
@@ -29,14 +32,41 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     // List of ALL shared resources; avoid clashing with any other running build
     val sharedResources: List<String> = listOf(SharedResourceNameGa, SharedResourceNameBeta, SharedResourceNameVcr)
 
+    // Compute IDs of the "All Tests" composite builds in GA and Beta nightly test projects
+    // These IDs must mirror how googleSubProjectGa/Beta and nightlyTests() compute their project IDs
+    val gaProjectId = replaceCharsId("GOOGLE")
+    val betaProjectId = replaceCharsId("GOOGLE_BETA")
+    val gaAllTestsId = AbsoluteId(replaceCharsId("${gaProjectId}_${NightlyTestsProjectId}_ALL_TESTS"))
+    val betaAllTestsId = AbsoluteId(replaceCharsId("${betaProjectId}_${NightlyTestsProjectId}_ALL_TESTS"))
+
     // Create build config for sweeping project resources
     // Uses the HashiCorpVCSRootGa VCS Root so that the latest sweepers in hashicorp/terraform-provider-google are used
     val serviceSweeperConfig = BuildConfigurationForGlobalSweeper("N/A", "Project Sweeper", "GoogleProject", SweepersListGa, sweeperId, HashiCorpVCSRootGa, sharedResources, gaConfig)
     serviceSweeperConfig.addTrigger(NightlyTriggerConfiguration(startHour=12))
+    serviceSweeperConfig.dependencies {
+        snapshot(gaAllTestsId) {
+            onDependencyFailure = FailureAction.IGNORE
+            onDependencyCancel = FailureAction.IGNORE
+        }
+        snapshot(betaAllTestsId) {
+            onDependencyFailure = FailureAction.IGNORE
+            onDependencyCancel = FailureAction.IGNORE
+        }
+    }
 
     // Create build config for sweeping folder resources
     val folderSweeperConfig = BuildConfigurationForGlobalSweeper("N/A", "Folder Sweeper", "GoogleFolder", SweepersListGa, sweeperId, HashiCorpVCSRootGa, sharedResources, gaConfig)
     folderSweeperConfig.addTrigger(NightlyTriggerConfiguration(startHour=12))
+    folderSweeperConfig.dependencies {
+        snapshot(gaAllTestsId) {
+            onDependencyFailure = FailureAction.IGNORE
+            onDependencyCancel = FailureAction.IGNORE
+        }
+        snapshot(betaAllTestsId) {
+            onDependencyFailure = FailureAction.IGNORE
+            onDependencyCancel = FailureAction.IGNORE
+        }
+    }
 
     return Project{
         id(sweeperId)

--- a/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
@@ -45,7 +45,7 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     val serviceSweeperConfig = BuildConfigurationForGlobalSweeper("N/A", "Project Sweeper", "GoogleProject", SweepersListGa, sweeperId, HashiCorpVCSRootGa, sharedResources, gaConfig)
     serviceSweeperConfig.triggers {
         finishBuildTrigger {
-            buildType = gaAllTestsId // Trigger project sweeper after GA Composite build (GA Service Tests + GA Sweeper)
+            buildType = gaAllTestsId.value // Trigger project sweeper after GA Composite build (GA Service Tests + GA Sweeper)
         }
     }
     serviceSweeperConfig.dependencies {
@@ -63,7 +63,7 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     val folderSweeperConfig = BuildConfigurationForGlobalSweeper("N/A", "Folder Sweeper", "GoogleFolder", SweepersListGa, sweeperId, HashiCorpVCSRootGa, sharedResources, gaConfig)
     folderSweeperConfig.triggers {
         finishBuildTrigger {
-            buildType = gaAllTestsId // Trigger folder sweeper after GA Composite build (GA Service Tests + GA Sweeper)
+            buildType = gaAllTestsId.value // Trigger folder sweeper after GA Composite build (GA Service Tests + GA Sweeper)
         }
     }
     folderSweeperConfig.dependencies {

--- a/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
@@ -15,6 +15,7 @@ import SharedResourceNameVcr
 import builds.*
 import generated.SweepersListGa
 import jetbrains.buildServer.configs.kotlin.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
@@ -37,10 +38,10 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     // These IDs must mirror how googleSubProjectGa/Beta and nightlyTests() compute their project IDs.
     val gaProjectId = replaceCharsId("GOOGLE")
     val betaProjectId = replaceCharsId("GOOGLE_BETA")
-    val gaAllTestsId = AbsoluteId(replaceCharsId("${gaProjectId}_${NightlyTestsProjectId}_ALL_TESTS"))
-    val betaAllTestsId = AbsoluteId(replaceCharsId("${betaProjectId}_${NightlyTestsProjectId}_ALL_TESTS"))
-    val gaServiceSweeperId = AbsoluteId(replaceCharsId("${gaProjectId}_${NightlyTestsProjectId}_Service_Sweeper"))
-    val betaServiceSweeperId = AbsoluteId(replaceCharsId("${betaProjectId}_${NightlyTestsProjectId}_Service_Sweeper"))
+    val gaAllTestsId = AbsoluteId("${DslContext.projectId}_${replaceCharsId("${gaProjectId}_${NightlyTestsProjectId}_ALL_TESTS")}")
+    val betaAllTestsId = AbsoluteId("${DslContext.projectId}_${replaceCharsId("${betaProjectId}_${NightlyTestsProjectId}_ALL_TESTS")}")
+    val gaServiceSweeperId = AbsoluteId("${DslContext.projectId}_${replaceCharsId("${gaProjectId}_${NightlyTestsProjectId}_Service_Sweeper")}")
+    val betaServiceSweeperId = AbsoluteId("${DslContext.projectId}_${replaceCharsId("${betaProjectId}_${NightlyTestsProjectId}_Service_Sweeper")}")
 
     // Create build config for sweeping project resources
     // Uses the HashiCorpVCSRootGa VCS Root so that the latest sweepers in hashicorp/terraform-provider-google are used

--- a/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
@@ -33,19 +33,21 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     // List of ALL shared resources; avoid clashing with any other running build
     val sharedResources: List<String> = listOf(SharedResourceNameGa, SharedResourceNameBeta, SharedResourceNameVcr)
 
-    // Compute IDs of the "All Tests" composite builds in GA and Beta nightly test projects
-    // These IDs must mirror how googleSubProjectGa/Beta and nightlyTests() compute their project IDs
+    // Compute IDs of the service sweepers in the GA and Beta nightly test projects.
+    // These IDs must mirror how googleSubProjectGa/Beta and nightlyTests() compute their project IDs.
     val gaProjectId = replaceCharsId("GOOGLE")
     val betaProjectId = replaceCharsId("GOOGLE_BETA")
     val gaAllTestsId = AbsoluteId(replaceCharsId("${gaProjectId}_${NightlyTestsProjectId}_ALL_TESTS"))
     val betaAllTestsId = AbsoluteId(replaceCharsId("${betaProjectId}_${NightlyTestsProjectId}_ALL_TESTS"))
+    val gaServiceSweeperId = AbsoluteId(replaceCharsId("${gaProjectId}_${NightlyTestsProjectId}_Service_Sweeper"))
+    val betaServiceSweeperId = AbsoluteId(replaceCharsId("${betaProjectId}_${NightlyTestsProjectId}_Service_Sweeper"))
 
     // Create build config for sweeping project resources
     // Uses the HashiCorpVCSRootGa VCS Root so that the latest sweepers in hashicorp/terraform-provider-google are used
     val serviceSweeperConfig = BuildConfigurationForGlobalSweeper("N/A", "Project Sweeper", "GoogleProject", SweepersListGa, sweeperId, HashiCorpVCSRootGa, sharedResources, gaConfig)
     serviceSweeperConfig.triggers {
         finishBuildTrigger {
-            buildType = gaAllTestsId.value // Trigger project sweeper after GA Composite build (GA Service Tests + GA Sweeper)
+            buildType = gaServiceSweeperId.value // Trigger project sweeper after the GA service sweeper
             successfulOnly = false
         }
     }
@@ -58,13 +60,21 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
             onDependencyFailure = FailureAction.IGNORE
             onDependencyCancel = FailureAction.IGNORE
         }
+        snapshot(gaServiceSweeperId) {
+            onDependencyFailure = FailureAction.IGNORE
+            onDependencyCancel = FailureAction.IGNORE
+        }
+        snapshot(betaServiceSweeperId) {
+            onDependencyFailure = FailureAction.IGNORE
+            onDependencyCancel = FailureAction.IGNORE
+        }
     }
 
     // Create build config for sweeping folder resources
     val folderSweeperConfig = BuildConfigurationForGlobalSweeper("N/A", "Folder Sweeper", "GoogleFolder", SweepersListGa, sweeperId, HashiCorpVCSRootGa, sharedResources, gaConfig)
     folderSweeperConfig.triggers {
         finishBuildTrigger {
-            buildType = gaAllTestsId.value // Trigger folder sweeper after GA Composite build (GA Service Tests + GA Sweeper)
+            buildType = gaServiceSweeperId.value // Trigger folder sweeper after the GA service sweeper
             successfulOnly = false
         }
     }
@@ -74,6 +84,14 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
             onDependencyCancel = FailureAction.IGNORE
         }
         snapshot(betaAllTestsId) {
+            onDependencyFailure = FailureAction.IGNORE
+            onDependencyCancel = FailureAction.IGNORE
+        }
+        snapshot(gaServiceSweeperId) {
+            onDependencyFailure = FailureAction.IGNORE
+            onDependencyCancel = FailureAction.IGNORE
+        }
+        snapshot(betaServiceSweeperId) {
             onDependencyFailure = FailureAction.IGNORE
             onDependencyCancel = FailureAction.IGNORE
         }

--- a/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
@@ -8,6 +8,7 @@
 package projects
 
 import GlobalSweepersProjectName
+import DefaultBranchName
 import NightlyTestsProjectId
 import SharedResourceNameBeta
 import SharedResourceNameGa
@@ -49,6 +50,7 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     serviceSweeperConfig.triggers {
         finishBuildTrigger {
             buildType = gaServiceSweeperId.value // Trigger project sweeper after the GA service sweeper
+            branchFilter = "+:$DefaultBranchName"
             successfulOnly = false
         }
     }
@@ -76,6 +78,7 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     folderSweeperConfig.triggers {
         finishBuildTrigger {
             buildType = gaServiceSweeperId.value // Trigger folder sweeper after the GA service sweeper
+            branchFilter = "+:$DefaultBranchName"
             successfulOnly = false
         }
     }

--- a/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
@@ -46,6 +46,7 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     serviceSweeperConfig.triggers {
         finishBuildTrigger {
             buildType = gaAllTestsId.value // Trigger project sweeper after GA Composite build (GA Service Tests + GA Sweeper)
+            successfulOnly = false
         }
     }
     serviceSweeperConfig.dependencies {
@@ -64,6 +65,7 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     folderSweeperConfig.triggers {
         finishBuildTrigger {
             buildType = gaAllTestsId.value // Trigger folder sweeper after GA Composite build (GA Service Tests + GA Sweeper)
+            successfulOnly = false
         }
     }
     folderSweeperConfig.dependencies {

--- a/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/global_sweepers_project.kt
@@ -17,6 +17,7 @@ import generated.SweepersListGa
 import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
 import replaceCharsId
 import vcs_roots.HashiCorpVCSRootGa
 
@@ -42,7 +43,11 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
     // Create build config for sweeping project resources
     // Uses the HashiCorpVCSRootGa VCS Root so that the latest sweepers in hashicorp/terraform-provider-google are used
     val serviceSweeperConfig = BuildConfigurationForGlobalSweeper("N/A", "Project Sweeper", "GoogleProject", SweepersListGa, sweeperId, HashiCorpVCSRootGa, sharedResources, gaConfig)
-    serviceSweeperConfig.addTrigger(NightlyTriggerConfiguration(startHour=12))
+    serviceSweeperConfig.triggers {
+        finishBuildTrigger {
+            buildType = gaAllTestsId // Trigger project sweeper after GA Composite build (GA Service Tests + GA Sweeper)
+        }
+    }
     serviceSweeperConfig.dependencies {
         snapshot(gaAllTestsId) {
             onDependencyFailure = FailureAction.IGNORE
@@ -56,7 +61,11 @@ fun globalSweepersSubProject(allConfig: AllContextParameters): Project {
 
     // Create build config for sweeping folder resources
     val folderSweeperConfig = BuildConfigurationForGlobalSweeper("N/A", "Folder Sweeper", "GoogleFolder", SweepersListGa, sweeperId, HashiCorpVCSRootGa, sharedResources, gaConfig)
-    folderSweeperConfig.addTrigger(NightlyTriggerConfiguration(startHour=12))
+    folderSweeperConfig.triggers {
+        finishBuildTrigger {
+            buildType = gaAllTestsId // Trigger folder sweeper after GA Composite build (GA Service Tests + GA Sweeper)
+        }
+    }
     folderSweeperConfig.dependencies {
         snapshot(gaAllTestsId) {
             onDependencyFailure = FailureAction.IGNORE

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -7,6 +7,7 @@
 
 package projects.reused
 
+import AllNightlyTestsName
 import NightlyTestsProjectId
 import ProviderNameBeta
 import ProviderNameGa
@@ -17,6 +18,9 @@ import SharedResourceNameGa
 import builds.*
 import generated.SweepersListBeta
 import generated.SweepersListGa
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.BuildTypeSettings
+import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
 import replaceCharsId
@@ -38,11 +42,28 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     }
 
     // Create build configs to run acceptance tests for each package defined in packages.kt and services.kt files
-    // and add cron trigger to them all
     val allPackages = getAllPackageInProviderVersion(providerName)
     val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, sharedResources, config)
-    packageBuildConfigs.forEach { buildConfiguration ->
-        buildConfiguration.addTrigger(cron)
+
+    // Create a composite build that runs all package tests
+    val compositeConfig = BuildType {
+        id(replaceCharsId("${projectId}_all_tests"))
+        name = AllNightlyTestsName
+        type = BuildTypeSettings.Type.COMPOSITE
+
+        vcs {
+            root(vcsRoot)
+            cleanCheckout = true
+        }
+
+        dependencies {
+            packageBuildConfigs.forEach { bc ->
+                snapshot(bc) {
+                    onDependencyFailure = FailureAction.ADD_PROBLEM
+                    onDependencyCancel = FailureAction.ADD_PROBLEM
+                }
+            }
+        }
     }
 
     // Create build config for sweeping the nightly test project
@@ -54,9 +75,17 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         else -> throw Exception("Provider name not supplied when generating a nightly test subproject")
     }
     val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, sweepersList, projectId, vcsRoot, sharedResources, config)
-    val sweeperCron = cron.clone()
-    sweeperCron.startHour += 5  // Ensure triggered after the package test builds are triggered
-    serviceSweeperConfig.addTrigger(sweeperCron)
+
+    // Add snapshot dependency on the composite config to run after tests finish
+    serviceSweeperConfig.dependencies {
+        snapshot(compositeConfig) {
+            onDependencyFailure = FailureAction.IGNORE
+            onDependencyCancel = FailureAction.IGNORE
+        }
+    }
+
+    // Trigger the sweeper, which will recursively trigger the composite build and all package tests
+    serviceSweeperConfig.addTrigger(cron)
 
     return Project {
         id(projectId)
@@ -67,6 +96,7 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         packageBuildConfigs.forEach { buildConfiguration ->
             buildType(buildConfiguration)
         }
+        buildType(compositeConfig)
         buildType(serviceSweeperConfig)
 
         params{

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -42,8 +42,12 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     }
 
     // Create build configs to run acceptance tests for each package defined in packages.kt and services.kt files
+    // and add cron trigger to them all
     val allPackages = getAllPackageInProviderVersion(providerName)
     val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, sharedResources, config)
+    packageBuildConfigs.forEach { buildConfiguration ->
+        buildConfiguration.addTrigger(cron)
+    }
 
     // Create a composite build that runs all package tests
     val compositeConfig = BuildType {
@@ -84,8 +88,9 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         }
     }
 
-    // Trigger the sweeper, which will recursively trigger the composite build and all package tests
-    serviceSweeperConfig.addTrigger(cron)
+    val sweeperCron = cron.clone()
+    sweeperCron.startHour += 5  // Ensure triggered after the package test builds are triggered
+    serviceSweeperConfig.addTrigger(sweeperCron)
 
     return Project {
         id(projectId)

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -25,9 +25,11 @@ import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
+import generated.ServicesListBeta
+import generated.ServicesListGa
 import replaceCharsId
 
-fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot, config: AccTestConfiguration, cron: NightlyTriggerConfiguration): Project {
+fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot, config: AccTestConfiguration, cron: NightlyTriggerConfiguration, servicesToTest: Array<String>? = null): Project {
 
     // Create unique ID for the dynamically-created project
     var projectId = "${parentProject}_${NightlyTestsProjectId}"
@@ -45,8 +47,8 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
 
     // Create build configs to run acceptance tests for each package defined in packages.kt and services.kt files
     val allPackages = getAllPackageInProviderVersion(providerName)
-    // Package builds are dependencies of the composite build and must not acquire shared-resource locks.
-    val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, listOf(), config)
+    // Package builds use per-service shared-resource locks to avoid clashes with ad hoc builds.
+    val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, sharedResources, config)
 
     // Create a composite build that runs all package tests
     val compositeId = replaceCharsId("${projectId}_all_tests")

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -25,11 +25,9 @@ import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
-import generated.ServicesListBeta
-import generated.ServicesListGa
 import replaceCharsId
 
-fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot, config: AccTestConfiguration, cron: NightlyTriggerConfiguration, servicesToTest: Array<String>? = null): Project {
+fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot, config: AccTestConfiguration, cron: NightlyTriggerConfiguration): Project {
 
     // Create unique ID for the dynamically-created project
     var projectId = "${parentProject}_${NightlyTestsProjectId}"

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -22,6 +22,7 @@ import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.BuildTypeSettings
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
 import replaceCharsId
 
@@ -47,8 +48,9 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, listOf(), config)
 
     // Create a composite build that runs all package tests
+    val compositeId = replaceCharsId("${projectId}_all_tests")
     val compositeConfig = BuildType {
-        id(replaceCharsId("${projectId}_all_tests"))
+        id(compositeId)
         name = AllNightlyTestsName
         type = BuildTypeSettings.Type.COMPOSITE
 
@@ -78,6 +80,11 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     }
     // We still allow locks in the service sweeper build configuration for adhoc triggers of services
     val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, sweepersList, projectId, vcsRoot, sharedResources, config)
+    serviceSweeperConfig.triggers {
+        finishBuildTrigger {
+            buildType = compositeId
+        }
+    }
 
     // Add snapshot dependency on the composite config to run after tests finish
     serviceSweeperConfig.dependencies {

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -20,6 +20,7 @@ import generated.SweepersListBeta
 import generated.SweepersListGa
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.BuildTypeSettings
+import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
@@ -82,7 +83,7 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, sweepersList, projectId, vcsRoot, sharedResources, config)
     serviceSweeperConfig.triggers {
         finishBuildTrigger {
-            buildType = compositeId
+            buildType = "${DslContext.projectId}_${compositeId}"
             successfulOnly = false
         }
     }

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -84,6 +84,7 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     serviceSweeperConfig.triggers {
         finishBuildTrigger {
             buildType = "${DslContext.projectId}_${compositeId}"
+            branchFilter = "+:${cron.branch}"
             successfulOnly = false
         }
     }

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -44,7 +44,8 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     // Create build configs to run acceptance tests for each package defined in packages.kt and services.kt files
     // and add cron trigger to them all
     val allPackages = getAllPackageInProviderVersion(providerName)
-    val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, sharedResources, config)
+    // Package builds are dependencies of the composite build and must not acquire shared-resource locks.
+    val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, listOf(), config)
 
     // Create a composite build that runs all package tests
     val compositeConfig = BuildType {

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -100,6 +100,7 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         description = "A project connected to the hashicorp/terraform-provider-${providerName} repository, where scheduled nightly tests run and users can trigger ad-hoc builds"
 
         buildType(compositeConfig)
+        packageBuildConfigs.forEach { buildType(it) }
         buildType(serviceSweeperConfig)
 
         params{

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -85,10 +85,6 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         }
     }
 
-    val sweeperCron = cron.clone()
-    sweeperCron.startHour += 5  // Ensure triggered after the package test builds are triggered
-    serviceSweeperConfig.addTrigger(sweeperCron)
-
     return Project {
         id(projectId)
         name = "Nightly Tests"

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -42,7 +42,6 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     }
 
     // Create build configs to run acceptance tests for each package defined in packages.kt and services.kt files
-    // and add cron trigger to them all
     val allPackages = getAllPackageInProviderVersion(providerName)
     // Package builds are dependencies of the composite build and must not acquire shared-resource locks.
     val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, listOf(), config)
@@ -67,6 +66,7 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
             }
         }
     }
+    compositeConfig.addTrigger(cron)
 
     // Create build config for sweeping the nightly test project
     var sweepersList: Map<String,Map<String,String>>

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -90,10 +90,6 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         name = "Nightly Tests"
         description = "A project connected to the hashicorp/terraform-provider-${providerName} repository, where scheduled nightly tests run and users can trigger ad-hoc builds"
 
-        // Register build configs in the project
-        packageBuildConfigs.forEach { buildConfiguration ->
-            buildType(buildConfiguration)
-        }
         buildType(compositeConfig)
         buildType(serviceSweeperConfig)
 

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -83,6 +83,7 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     serviceSweeperConfig.triggers {
         finishBuildTrigger {
             buildType = compositeId
+            successfulOnly = false
         }
     }
 

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -45,9 +45,6 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     // and add cron trigger to them all
     val allPackages = getAllPackageInProviderVersion(providerName)
     val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, sharedResources, config)
-    packageBuildConfigs.forEach { buildConfiguration ->
-        buildConfiguration.addTrigger(cron)
-    }
 
     // Create a composite build that runs all package tests
     val compositeConfig = BuildType {

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -76,6 +76,7 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         ProviderNameBetaDiffTest -> sweepersList = SweepersListBeta
         else -> throw Exception("Provider name not supplied when generating a nightly test subproject")
     }
+    // We still allow locks in the service sweeper build configuration for adhoc triggers of services
     val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, sweepersList, projectId, vcsRoot, sharedResources, config)
 
     // Add snapshot dependency on the composite config to run after tests finish

--- a/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
@@ -7,8 +7,10 @@
 
 package tests
 
+import AllNightlyTestsName
 import ServiceSweeperName
 import builds.UseTeamCityGoTest
+import jetbrains.buildServer.configs.kotlin.BuildTypeSettings
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -25,6 +27,9 @@ class BuildConfigurationFeatureTests {
 
         (gaProject.subProjects + betaProject.subProjects + globalSweepersProject.subProjects).forEach{p ->
             p.buildTypes.forEach{bt ->
+                if (bt.type == BuildTypeSettings.Type.COMPOSITE) {
+                    return@forEach
+                }
                 assertTrue("Build '${bt.id}' should fail on errors!", bt.failureConditions.errorMessage)
             }
         }
@@ -75,8 +80,8 @@ class BuildConfigurationFeatureTests {
                     break
                 }
             }
-            // service sweeper does not contain push artifacts to GCS step
-            if (!bt.name.startsWith(ServiceSweeperName)) {
+            // service sweeper and composite builds do not contain push artifacts to GCS step
+            if (!bt.name.startsWith(ServiceSweeperName) && bt.name != AllNightlyTestsName) {
                 assertTrue("Build configuration `${bt.name}` contains a build step that pushes artifacts to GCS", found)
             }
         }

--- a/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
@@ -7,14 +7,18 @@
 
 package tests
 
+import AllNightlyTestsName
+import ServiceSweeperName
+import jetbrains.buildServer.configs.kotlin.BuildTypeSettings
 import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import projects.googleCloudRootProject
 
 class NightlyTestProjectsTests {
     @Test
-    fun allBuildsShouldHaveTrigger() {
+    fun onlyServiceSweeperShouldHaveTrigger() {
         val root = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project
@@ -23,28 +27,57 @@ class NightlyTestProjectsTests {
         // Find Beta nightly test project
         var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
 
-        // Make assertions about builds in both nightly test projects
+        // Package tests and the composite are triggered via snapshot dependencies from the sweeper.
+        // Only the Service Sweeper should have a CRON trigger.
         (gaNightlyTestProject.buildTypes + betaNightlyTestProject.buildTypes).forEach{bt ->
-            assertTrue("Build configuration `${bt.name}` should contain at least one trigger", bt.triggers.items.isNotEmpty())
-             // Look for at least one CRON trigger
-            var found: Boolean = false
-            lateinit var schedulingTrigger: ScheduleTrigger
-            for (item in bt.triggers.items){
-                if (item.type == "schedulingTrigger") {
-                    schedulingTrigger = item as ScheduleTrigger
-                    found = true
-                    break
+            if (bt.name == ServiceSweeperName) {
+                assertTrue("Build configuration `${bt.name}` should contain at least one trigger", bt.triggers.items.isNotEmpty())
+                var found: Boolean = false
+                lateinit var schedulingTrigger: ScheduleTrigger
+                for (item in bt.triggers.items){
+                    if (item.type == "schedulingTrigger") {
+                        schedulingTrigger = item as ScheduleTrigger
+                        found = true
+                        break
+                    }
                 }
-            }
 
-            assertTrue("Build configuration `${bt.name}` should contain a CRON/'schedulingTrigger' trigger", found)
+                assertTrue("Build configuration `${bt.name}` should contain a CRON/'schedulingTrigger' trigger", found)
 
-            // Check that nightly test is being ran on the nightly-test branch
-            var isNightlyTestBranch: Boolean = false
-            if (schedulingTrigger.branchFilter == "+:refs/heads/nightly-test"){
-                isNightlyTestBranch = true
+                var isNightlyTestBranch: Boolean = false
+                if (schedulingTrigger.branchFilter == "+:refs/heads/nightly-test"){
+                    isNightlyTestBranch = true
+                }
+                assertTrue("Build configuration `${bt.name}` is using the nightly-test branch filter;", isNightlyTestBranch)
+            } else {
+                assertTrue("Build configuration `${bt.name}` should not have a trigger; it is started via snapshot dependency", bt.triggers.items.isEmpty())
             }
-            assertTrue("Build configuration `${bt.name}` is using the nightly-test branch filter;", isNightlyTestBranch)
+        }
+    }
+
+    @Test
+    fun nightlyTestsShouldHaveCompositeAllTestsBuild() {
+        val root = googleCloudRootProject(testContextParameters())
+
+        var gaNightlyTestProject = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
+        var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
+
+        listOf(gaNightlyTestProject, betaNightlyTestProject).forEach { project ->
+            val composite = getBuildFromProject(project, AllNightlyTestsName)
+            assertEquals("Build configuration `${composite.name}` should be a COMPOSITE build", BuildTypeSettings.Type.COMPOSITE, composite.type)
+
+            val packageBuilds = project.buildTypes.filter { bt ->
+                bt.name != ServiceSweeperName && bt.name != AllNightlyTestsName
+            }
+            assertTrue("Nightly test project `${project.name}` should have package test builds", packageBuilds.isNotEmpty())
+            assertEquals(
+                "Composite `${composite.name}` should snapshot-depend on every package test build",
+                packageBuilds.size,
+                composite.dependencies.items.size
+            )
+
+            val sweeper = getBuildFromProject(project, ServiceSweeperName)
+            assertEquals("Service sweeper should snapshot-depend on the composite All Nightly Tests build", 1, sweeper.dependencies.items.size)
         }
     }
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
@@ -18,7 +18,7 @@ import projects.googleCloudRootProject
 
 class NightlyTestProjectsTests {
     @Test
-    fun onlyServiceSweeperShouldHaveTrigger() {
+    fun allBuildsShouldHaveTrigger() {
         val root = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project
@@ -27,31 +27,34 @@ class NightlyTestProjectsTests {
         // Find Beta nightly test project
         var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
 
-        // Package tests and the composite are triggered via snapshot dependencies from the sweeper.
-        // Only the Service Sweeper should have a CRON trigger.
+        // Package tests and the Service Sweeper keep their upstream CRON triggers.
+        // The composite All Nightly Tests build is started via snapshot dependency only.
         (gaNightlyTestProject.buildTypes + betaNightlyTestProject.buildTypes).forEach{bt ->
-            if (bt.name == ServiceSweeperName) {
-                assertTrue("Build configuration `${bt.name}` should contain at least one trigger", bt.triggers.items.isNotEmpty())
-                var found: Boolean = false
-                lateinit var schedulingTrigger: ScheduleTrigger
-                for (item in bt.triggers.items){
-                    if (item.type == "schedulingTrigger") {
-                        schedulingTrigger = item as ScheduleTrigger
-                        found = true
-                        break
-                    }
-                }
-
-                assertTrue("Build configuration `${bt.name}` should contain a CRON/'schedulingTrigger' trigger", found)
-
-                var isNightlyTestBranch: Boolean = false
-                if (schedulingTrigger.branchFilter == "+:refs/heads/nightly-test"){
-                    isNightlyTestBranch = true
-                }
-                assertTrue("Build configuration `${bt.name}` is using the nightly-test branch filter;", isNightlyTestBranch)
-            } else {
+            if (bt.name == AllNightlyTestsName) {
                 assertTrue("Build configuration `${bt.name}` should not have a trigger; it is started via snapshot dependency", bt.triggers.items.isEmpty())
+                return@forEach
             }
+
+            assertTrue("Build configuration `${bt.name}` should contain at least one trigger", bt.triggers.items.isNotEmpty())
+             // Look for at least one CRON trigger
+            var found: Boolean = false
+            lateinit var schedulingTrigger: ScheduleTrigger
+            for (item in bt.triggers.items){
+                if (item.type == "schedulingTrigger") {
+                    schedulingTrigger = item as ScheduleTrigger
+                    found = true
+                    break
+                }
+            }
+
+            assertTrue("Build configuration `${bt.name}` should contain a CRON/'schedulingTrigger' trigger", found)
+
+            // Check that nightly test is being ran on the nightly-test branch
+            var isNightlyTestBranch: Boolean = false
+            if (schedulingTrigger.branchFilter == "+:refs/heads/nightly-test"){
+                isNightlyTestBranch = true
+            }
+            assertTrue("Build configuration `${bt.name}` is using the nightly-test branch filter;", isNightlyTestBranch)
         }
     }
 

--- a/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
@@ -10,7 +10,6 @@ package tests
 import AllNightlyTestsName
 import ServiceSweeperName
 import jetbrains.buildServer.configs.kotlin.BuildTypeSettings
-import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -27,34 +26,23 @@ class NightlyTestProjectsTests {
         // Find Beta nightly test project
         var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
 
-        // Package tests and the Service Sweeper keep their upstream CRON triggers.
-        // The composite All Nightly Tests build is started via snapshot dependency only.
+        // The composite starts on its nightly CRON trigger. Package builds have no
+        // individual nightly triggers, and the Service Sweeper follows the composite.
         (gaNightlyTestProject.buildTypes + betaNightlyTestProject.buildTypes).forEach{bt ->
             if (bt.name == AllNightlyTestsName) {
-                assertTrue("Build configuration `${bt.name}` should not have a trigger; it is started via snapshot dependency", bt.triggers.items.isEmpty())
+                assertTrue("Build configuration `${bt.name}` should have a trigger", bt.triggers.items.isNotEmpty())
                 return@forEach
             }
 
-            assertTrue("Build configuration `${bt.name}` should contain at least one trigger", bt.triggers.items.isNotEmpty())
-             // Look for at least one CRON trigger
-            var found: Boolean = false
-            lateinit var schedulingTrigger: ScheduleTrigger
-            for (item in bt.triggers.items){
-                if (item.type == "schedulingTrigger") {
-                    schedulingTrigger = item as ScheduleTrigger
-                    found = true
-                    break
-                }
+            if (bt.name == ServiceSweeperName) {
+                assertEquals("Build configuration `${bt.name}` should have one finish trigger", 1, bt.triggers.items.size)
+                return@forEach
             }
 
-            assertTrue("Build configuration `${bt.name}` should contain a CRON/'schedulingTrigger' trigger", found)
-
-            // Check that nightly test is being ran on the nightly-test branch
-            var isNightlyTestBranch: Boolean = false
-            if (schedulingTrigger.branchFilter == "+:refs/heads/nightly-test"){
-                isNightlyTestBranch = true
+            if (bt.name != AllNightlyTestsName) {
+                assertTrue("Package build configuration `${bt.name}` should not contain an individual nightly trigger", bt.triggers.items.isEmpty())
+                return@forEach
             }
-            assertTrue("Build configuration `${bt.name}` is using the nightly-test branch filter;", isNightlyTestBranch)
         }
     }
 
@@ -81,6 +69,7 @@ class NightlyTestProjectsTests {
 
             val sweeper = getBuildFromProject(project, ServiceSweeperName)
             assertEquals("Service sweeper should snapshot-depend on the composite All Nightly Tests build", 1, sweeper.dependencies.items.size)
+            assertEquals("Service sweeper should have one finish trigger from the composite", 1, sweeper.triggers.items.size)
         }
     }
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
@@ -8,16 +8,29 @@
 package tests
 
 import AllNightlyTestsName
+import DefaultBranchName
+import ProviderNameBeta
+import ProviderNameGa
 import ServiceSweeperName
+import SharedResourceNameBeta
+import SharedResourceNameGa
+import builds.NightlyTriggerConfiguration
+import builds.getGaAcceptanceTestConfig
 import jetbrains.buildServer.configs.kotlin.BuildTypeSettings
+import jetbrains.buildServer.configs.kotlin.FailureAction
+import jetbrains.buildServer.configs.kotlin.SharedResources
+import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import projects.googleCloudRootProject
+import projects.reused.getAllPackageInProviderVersion
+import projects.reused.nightlyTests
+import vcs_roots.HashiCorpVCSRootGa
 
 class NightlyTestProjectsTests {
     @Test
-    fun allBuildsShouldHaveTrigger() {
+    fun onlyCompositeShouldHaveNightlySchedule() {
         val root = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project
@@ -26,22 +39,20 @@ class NightlyTestProjectsTests {
         // Find Beta nightly test project
         var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
 
-        // The composite starts on its nightly CRON trigger. Package builds have no
-        // individual nightly triggers, and the Service Sweeper follows the composite.
-        (gaNightlyTestProject.buildTypes + betaNightlyTestProject.buildTypes).forEach{bt ->
-            if (bt.name == AllNightlyTestsName) {
-                assertTrue("Build configuration `${bt.name}` should have a trigger", bt.triggers.items.isNotEmpty())
-                return@forEach
-            }
+        listOf(gaNightlyTestProject, betaNightlyTestProject).forEach { project ->
+            val composite = getBuildFromProject(project, AllNightlyTestsName)
+            assertEquals("Composite should have one schedule trigger", 1, composite.triggers.items.size)
+            val trigger = composite.triggers.items.single()
+            assertTrue("Composite should use a schedule trigger", trigger is ScheduleTrigger)
+            trigger as ScheduleTrigger
+            assertTrue("Composite should use CRON scheduling", trigger.schedulingPolicy is ScheduleTrigger.SchedulingPolicy.Cron)
+            assertEquals("Composite should select the nightly branch", "+:$DefaultBranchName", trigger.branchFilter)
+            assertEquals("Nightly runs should not require pending changes", false, trigger.withPendingChangesOnly)
 
-            if (bt.name == ServiceSweeperName) {
-                assertEquals("Build configuration `${bt.name}` should have one finish trigger", 1, bt.triggers.items.size)
-                return@forEach
-            }
-
-            if (bt.name != AllNightlyTestsName) {
-                assertTrue("Package build configuration `${bt.name}` should not contain an individual nightly trigger", bt.triggers.items.isEmpty())
-                return@forEach
+            val sweeper = getBuildFromProject(project, ServiceSweeperName)
+            assertFinishTrigger(sweeper, composite, DefaultBranchName)
+            project.buildTypes.filter { it != composite && it != sweeper }.forEach { build ->
+                assertTrue("Package build `${build.name}` should have no independent trigger", build.triggers.items.isEmpty())
             }
         }
     }
@@ -61,15 +72,47 @@ class NightlyTestProjectsTests {
                 bt.name != ServiceSweeperName && bt.name != AllNightlyTestsName
             }
             assertTrue("Nightly test project `${project.name}` should have package test builds", packageBuilds.isNotEmpty())
-            assertEquals(
-                "Composite `${composite.name}` should snapshot-depend on every package test build",
-                packageBuilds.size,
-                composite.dependencies.items.size
-            )
+            assertSnapshotDependencies(composite, packageBuilds, FailureAction.ADD_PROBLEM)
 
             val sweeper = getBuildFromProject(project, ServiceSweeperName)
-            assertEquals("Service sweeper should snapshot-depend on the composite All Nightly Tests build", 1, sweeper.dependencies.items.size)
-            assertEquals("Service sweeper should have one finish trigger from the composite", 1, sweeper.triggers.items.size)
+            assertSnapshotDependencies(sweeper, listOf(composite), FailureAction.IGNORE)
+        }
+    }
+
+    @Test
+    fun serviceSweeperShouldFollowCustomNightlyBranch() {
+        val config = getGaAcceptanceTestConfig(testContextParameters())
+        val cron = NightlyTriggerConfiguration(
+            branch = "refs/heads/experimental-nightly",
+            nightlyTestsEnabled = false,
+            startHour = 7
+        )
+        val project = nightlyTests("EXPERIMENTAL", ProviderNameGa, HashiCorpVCSRootGa, config, cron)
+        val composite = getBuildFromProject(project, AllNightlyTestsName)
+        val schedule = composite.triggers.items.single() as ScheduleTrigger
+        assertEquals(false, schedule.enabled)
+        assertEquals("+:${cron.branch}", schedule.branchFilter)
+        assertEquals("7", (schedule.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron).hours)
+        assertFinishTrigger(getBuildFromProject(project, ServiceSweeperName), composite, cron.branch)
+    }
+
+    @Test
+    fun nightlyPackagesAndSweepersShouldRetainProviderLocks() {
+        val root = googleCloudRootProject(testContextParameters())
+        listOf(
+            Triple(gaProjectName, ProviderNameGa, SharedResourceNameGa),
+            Triple(betaProjectName, ProviderNameBeta, SharedResourceNameBeta)
+        ).forEach { (name, provider, resource) ->
+            val project = getNestedProjectFromRoot(root, name, nightlyTestsProjectName)
+            val composite = getBuildFromProject(project, AllNightlyTestsName)
+            val sweeper = getBuildFromProject(project, ServiceSweeperName)
+            assertTrue("Composite should not hold locks needed by package builds", composite.features.items.filterIsInstance<SharedResources>().isEmpty())
+            assertSharedResourceLocks(sweeper, SharedResources { lockAllValues(resource) })
+            project.buildTypes.filter { it != composite && it != sweeper }.forEach { build ->
+                val path = build.params.findRawParam("PACKAGE_PATH")!!.value
+                val packageName = getAllPackageInProviderVersion(provider).entries.single { it.value.getValue("path") == path }.key
+                assertSharedResourceLocks(build, SharedResources { lockSpecificValue(resource, packageName) })
+            }
         }
     }
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -157,7 +157,7 @@ class SweeperTests {
         assertEquals("Project sweeper should snapshot-depend on GA and Beta All Nightly Tests", 2, projectSweeper.dependencies.items.size)
         assertEquals("Folder sweeper should snapshot-depend on GA and Beta All Nightly Tests", 2, folderSweeper.dependencies.items.size)
 
-        // Cron hours match upstream: nightly chain at DefaultStartHour (4 UTC), global sweepers at 12 UTC
+        // Cron hours match upstream: service sweeper at DefaultStartHour+5 (9 UTC), global sweepers at 12 UTC
         val stGa = sweeperGa.triggers.items[0] as ScheduleTrigger
         val cronGa = stGa.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
         val stBeta = sweeperBeta.triggers.items[0] as ScheduleTrigger
@@ -167,8 +167,8 @@ class SweeperTests {
         val stFolder = folderSweeper.triggers.items[0] as ScheduleTrigger
         val cronFolder = stFolder.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
 
-        assertEquals("GA nightly Service Sweeper should trigger at ${DefaultStartHour}00 UTC", DefaultStartHour, cronGa.hours.toString().toInt())
-        assertEquals("Beta nightly Service Sweeper should trigger at ${DefaultStartHour}00 UTC", DefaultStartHour, cronBeta.hours.toString().toInt())
+        assertEquals("GA nightly Service Sweeper should trigger 5 hours after package tests", DefaultStartHour + 5, cronGa.hours.toString().toInt())
+        assertEquals("Beta nightly Service Sweeper should trigger 5 hours after package tests", DefaultStartHour + 5, cronBeta.hours.toString().toInt())
         assertEquals("Project sweeper should trigger at 12:00 UTC", 12, cronProject.hours.toString().toInt())
         assertEquals("Folder sweeper should trigger at 12:00 UTC", 12, cronFolder.hours.toString().toInt())
     }

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -7,7 +7,7 @@
 
 package tests
 
-import GlobalSweepersProjectName
+import DefaultStartHour
 import ServiceSweeperCronName
 import ServiceSweeperManualName
 import ServiceSweeperName
@@ -131,7 +131,7 @@ class SweeperTests {
     }
 
     @Test
-    fun globalSweepersRunAfterServiceSweepers() {
+    fun globalSweepersDependOnAllNightlyTests() {
         val root = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project's service sweeper
@@ -146,29 +146,30 @@ class SweeperTests {
         val globalSweepersProject = getSubProject(root, globalSweepersProjectName)
         val projectSweeper: BuildType = getBuildFromProject(globalSweepersProject, "Project Sweeper")
         val folderSweeper: BuildType = getBuildFromProject(globalSweepersProject, "Folder Sweeper")
-        
+
         // Check only one schedule trigger is on the builds in question
         assertTrue(sweeperGa.triggers.items.size == 1)
         assertTrue(sweeperBeta.triggers.items.size == 1)
         assertTrue(projectSweeper.triggers.items.size == 1)
         assertTrue(folderSweeper.triggers.items.size == 1)
 
-        // Assert that the hour value that sweeper builds are triggered at is less than the hour value that project/folder sweeper builds are triggered at
+        // Global sweepers wait for GA and Beta "All Nightly Tests" composites via snapshot dependencies
+        assertEquals("Project sweeper should snapshot-depend on GA and Beta All Nightly Tests", 2, projectSweeper.dependencies.items.size)
+        assertEquals("Folder sweeper should snapshot-depend on GA and Beta All Nightly Tests", 2, folderSweeper.dependencies.items.size)
+
+        // Cron hours match upstream: nightly chain at DefaultStartHour (4 UTC), global sweepers at 12 UTC
         val stGa = sweeperGa.triggers.items[0] as ScheduleTrigger
         val cronGa = stGa.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
         val stBeta = sweeperBeta.triggers.items[0] as ScheduleTrigger
         val cronBeta = stBeta.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
-        
         val stProject = projectSweeper.triggers.items[0] as ScheduleTrigger
         val cronProject = stProject.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
-        
         val stFolder = folderSweeper.triggers.items[0] as ScheduleTrigger
         val cronFolder = stFolder.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
-        
-        assertTrue("Service sweeper for the GA Nightly Test project should be triggered at an earlier hour than the project sweeper", cronGa.hours.toString().toInt() < cronProject.hours.toString().toInt())
-        assertTrue("Service sweeper for the Beta Nightly Test project should be triggered at an earlier hour than the project sweeper", cronBeta.hours.toString().toInt() < cronProject.hours.toString().toInt())
-        
-        assertTrue("Service sweeper for the GA Nightly Test project should be triggered at an earlier hour than the folder sweeper", cronGa.hours.toString().toInt() < cronFolder.hours.toString().toInt())
-        assertTrue("Service sweeper for the Beta Nightly Test project should be triggered at an earlier hour than the folder sweeper", cronBeta.hours.toString().toInt() < cronFolder.hours.toString().toInt())
+
+        assertEquals("GA nightly Service Sweeper should trigger at ${DefaultStartHour}00 UTC", DefaultStartHour, cronGa.hours.toString().toInt())
+        assertEquals("Beta nightly Service Sweeper should trigger at ${DefaultStartHour}00 UTC", DefaultStartHour, cronBeta.hours.toString().toInt())
+        assertEquals("Project sweeper should trigger at 12:00 UTC", 12, cronProject.hours.toString().toInt())
+        assertEquals("Folder sweeper should trigger at 12:00 UTC", 12, cronFolder.hours.toString().toInt())
     }
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -7,13 +7,11 @@
 
 package tests
 
-import DefaultStartHour
 import ServiceSweeperCronName
 import ServiceSweeperManualName
 import ServiceSweeperName
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.Project
-import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -147,29 +145,14 @@ class SweeperTests {
         val projectSweeper: BuildType = getBuildFromProject(globalSweepersProject, "Project Sweeper")
         val folderSweeper: BuildType = getBuildFromProject(globalSweepersProject, "Folder Sweeper")
 
-        // Check only one schedule trigger is on the builds in question
+        // Each nightly service sweeper follows its composite, while global sweepers
+        // follow the GA service sweeper after both GA and Beta sweepers complete.
         assertTrue(sweeperGa.triggers.items.size == 1)
         assertTrue(sweeperBeta.triggers.items.size == 1)
         assertTrue(projectSweeper.triggers.items.size == 1)
         assertTrue(folderSweeper.triggers.items.size == 1)
 
-        // Global sweepers wait for GA and Beta "All Nightly Tests" composites via snapshot dependencies
-        assertEquals("Project sweeper should snapshot-depend on GA and Beta All Nightly Tests", 2, projectSweeper.dependencies.items.size)
-        assertEquals("Folder sweeper should snapshot-depend on GA and Beta All Nightly Tests", 2, folderSweeper.dependencies.items.size)
-
-        // Cron hours match upstream: service sweeper at DefaultStartHour+5 (9 UTC), global sweepers at 12 UTC
-        val stGa = sweeperGa.triggers.items[0] as ScheduleTrigger
-        val cronGa = stGa.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
-        val stBeta = sweeperBeta.triggers.items[0] as ScheduleTrigger
-        val cronBeta = stBeta.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
-        val stProject = projectSweeper.triggers.items[0] as ScheduleTrigger
-        val cronProject = stProject.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
-        val stFolder = folderSweeper.triggers.items[0] as ScheduleTrigger
-        val cronFolder = stFolder.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
-
-        assertEquals("GA nightly Service Sweeper should trigger 5 hours after package tests", DefaultStartHour + 5, cronGa.hours.toString().toInt())
-        assertEquals("Beta nightly Service Sweeper should trigger 5 hours after package tests", DefaultStartHour + 5, cronBeta.hours.toString().toInt())
-        assertEquals("Project sweeper should trigger at 12:00 UTC", 12, cronProject.hours.toString().toInt())
-        assertEquals("Folder sweeper should trigger at 12:00 UTC", 12, cronFolder.hours.toString().toInt())
+        assertEquals("Project sweeper should snapshot-depend on GA and Beta composites and service sweepers", 4, projectSweeper.dependencies.items.size)
+        assertEquals("Folder sweeper should snapshot-depend on GA and Beta composites and service sweepers", 4, folderSweeper.dependencies.items.size)
     }
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -7,11 +7,17 @@
 
 package tests
 
+import AllNightlyTestsName
+import DefaultBranchName
 import ServiceSweeperCronName
 import ServiceSweeperManualName
 import ServiceSweeperName
+import SharedResourceNameBeta
+import SharedResourceNameGa
+import SharedResourceNameVcr
 import jetbrains.buildServer.configs.kotlin.BuildType
-import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.FailureAction
+import jetbrains.buildServer.configs.kotlin.SharedResources
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -130,29 +136,28 @@ class SweeperTests {
 
     @Test
     fun globalSweepersDependOnAllNightlyTests() {
-        val root = googleCloudRootProject(testContextParameters())
+        listOf("TeamCityTests", "Experimental_NightlyTests").forEach { projectId ->
+            val root = googleCloudRootProject(testContextParameters(projectId))
+            val gaNightly = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
+            val betaNightly = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
+            val gaComposite = getBuildFromProject(gaNightly, AllNightlyTestsName)
+            val betaComposite = getBuildFromProject(betaNightly, AllNightlyTestsName)
+            val sweeperGa = getBuildFromProject(gaNightly, ServiceSweeperName)
+            val sweeperBeta = getBuildFromProject(betaNightly, ServiceSweeperName)
+            assertFinishTrigger(sweeperGa, gaComposite, DefaultBranchName)
+            assertFinishTrigger(sweeperBeta, betaComposite, DefaultBranchName)
 
-        // Find GA nightly test project's service sweeper
-        val gaNightlyTests: Project = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
-        val sweeperGa: BuildType = getBuildFromProject(gaNightlyTests, ServiceSweeperName)
-
-        // Find Beta nightly test project's service sweeper
-        val betaNightlyTests : Project = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
-        val sweeperBeta: BuildType = getBuildFromProject(betaNightlyTests, ServiceSweeperName)
-
-        // Find Global sweepers project's builds
-        val globalSweepersProject = getSubProject(root, globalSweepersProjectName)
-        val projectSweeper: BuildType = getBuildFromProject(globalSweepersProject, "Project Sweeper")
-        val folderSweeper: BuildType = getBuildFromProject(globalSweepersProject, "Folder Sweeper")
-
-        // Each nightly service sweeper follows its composite, while global sweepers
-        // follow the GA service sweeper after both GA and Beta sweepers complete.
-        assertTrue(sweeperGa.triggers.items.size == 1)
-        assertTrue(sweeperBeta.triggers.items.size == 1)
-        assertTrue(projectSweeper.triggers.items.size == 1)
-        assertTrue(folderSweeper.triggers.items.size == 1)
-
-        assertEquals("Project sweeper should snapshot-depend on GA and Beta composites and service sweepers", 4, projectSweeper.dependencies.items.size)
-        assertEquals("Folder sweeper should snapshot-depend on GA and Beta composites and service sweepers", 4, folderSweeper.dependencies.items.size)
+            val globalSweepers = getSubProject(root, globalSweepersProjectName)
+            listOf("Project Sweeper", "Folder Sweeper").forEach { name ->
+                val sweeper = getBuildFromProject(globalSweepers, name)
+                assertFinishTrigger(sweeper, sweeperGa, DefaultBranchName)
+                assertSnapshotDependencies(sweeper, listOf(gaComposite, betaComposite, sweeperGa, sweeperBeta), FailureAction.IGNORE)
+                assertSharedResourceLocks(sweeper, SharedResources {
+                    lockAllValues(SharedResourceNameGa)
+                    lockAllValues(SharedResourceNameBeta)
+                    lockAllValues(SharedResourceNameVcr)
+                })
+            }
+        }
     }
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/test_utils.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/test_utils.kt
@@ -8,8 +8,15 @@
 package tests
 
 import builds.AllContextParameters
+import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.DslContext
+import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.SharedResources
+import jetbrains.buildServer.configs.kotlin.triggers.FinishBuildTrigger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 
 const val gaProjectName = "Google"
@@ -19,7 +26,8 @@ const val weeklyDiffTestsProjectName = "Weekly Diff Tests"
 const val mmUpstreamProjectName = "Upstream MM Testing"
 const val globalSweepersProjectName = "Global Sweepers"
 
-fun testContextParameters(): AllContextParameters {
+fun testContextParameters(projectId: String = "TeamCityTests"): AllContextParameters {
+    DslContext.projectId = AbsoluteId(projectId)
     return AllContextParameters(
         "credsGa",
         "credsBeta",
@@ -87,4 +95,40 @@ fun getBuildFromProject(parentProject: Project, buildName: String): BuildType {
         fail("Could not find the '$buildName' build in project ${parentProject.name}")
     }
     return buildType!!
+}
+
+fun assertFinishTrigger(build: BuildType, source: BuildType, branch: String) {
+    assertEquals("${build.name} should have exactly one trigger", 1, build.triggers.items.size)
+    val trigger = build.triggers.items.single()
+    assertTrue("${build.name} should use a finish-build trigger", trigger is FinishBuildTrigger)
+    trigger as FinishBuildTrigger
+    assertEquals("${build.name} should watch the source build's resolved ID", source.id!!.value, trigger.buildType)
+    assertEquals("${build.name} should watch the configured branch", "+:$branch", trigger.branchFilter)
+    assertEquals("${build.name} should not require a successful source build", false, trigger.successfulOnly)
+}
+
+fun assertSnapshotDependencies(build: BuildType, sources: List<BuildType>, failureAction: FailureAction) {
+    val dependencies = build.dependencies.items
+    assertEquals("${build.name} should have exactly the expected dependencies", sources.size, dependencies.size)
+    assertEquals(
+        "${build.name} should depend on the registered source builds",
+        sources.map { it.id!!.value }.toSet(),
+        dependencies.map { it.buildTypeId.id!!.value }.toSet()
+    )
+    dependencies.forEach { dependency ->
+        val snapshot = requireNotNull(dependency.snapshot) { "${build.name} should use snapshot dependencies" }
+        assertEquals("${build.name} should preserve dependency failure handling", failureAction, snapshot.onDependencyFailure)
+        assertEquals("${build.name} should preserve dependency cancellation handling", failureAction, snapshot.onDependencyCancel)
+        assertTrue("${build.name} should synchronize source revisions", snapshot.synchronizeRevisions)
+    }
+}
+
+fun assertSharedResourceLocks(build: BuildType, expected: SharedResources) {
+    val features = build.features.items.filterIsInstance<SharedResources>()
+    assertEquals("${build.name} should have one shared-resource feature", 1, features.size)
+    assertEquals(
+        "${build.name} should acquire the expected locks",
+        expected.params.single { it.name == "locks-param" }.value,
+        features.single().params.single { it.name == "locks-param" }.value
+    )
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Validation of composite build chain, they can be found [here](https://github.com/hashicorp/terraform-provider-google/compare/main...BBBmau:terraform-provider-google:identity_playground)

Here's the output that i get when running it with 3 services

# How it appears for Service Sweeper with the dependencies set
<img width="1944" height="1274" alt="image" src="https://github.com/user-attachments/assets/52e75e82-38e8-4837-9bdb-a1bc2110fa03" />
<img width="1810" height="629" alt="image" src="https://github.com/user-attachments/assets/bb21d007-1ee2-4545-a33a-40a4551f4fb8" />

# How it appears for All Nightly Tests
<img width="1820" height="591" alt="image" src="https://github.com/user-attachments/assets/8872028d-dd8e-4772-949d-421c9b2aca38" />




**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
