### PR TITLE
tests: update debian-11 compute images and families to debian-13

### DIFF
--- a/mmv1/templates/terraform/constants/disk.tmpl
+++ b/mmv1/templates/terraform/constants/disk.tmpl
@@ -159,7 +159,7 @@ func diskImageEquals(oldImageName, newImageName string) bool {
 
 func diskImageFamilyEquals(imageName, familyName string) bool {
 	// Handles the case when the image name includes the family name
-	// e.g. image name: debian-11-bullseye-v20220719, family name: debian-11
+	// e.g. image name: debian-13-trixie-v20260827, family name: debian-13
 
 	// First condition is to check if image contains arm64 because of case like:
 	// image name: opensuse-leap-15-4-v20220713-arm64, family name: opensuse-leap (should not be evaluated during handling of amd64 cases)

--- a/mmv1/templates/terraform/examples/flask_google_cloud_quickstart.tf.tmpl
+++ b/mmv1/templates/terraform/examples/flask_google_cloud_quickstart.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_compute_instance" "{{$.PrimaryResourceId}}" {
   }
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/examples/instance_custom_hostname.tf.tmpl
+++ b/mmv1/templates/terraform/examples/instance_custom_hostname.tf.tmpl
@@ -8,7 +8,7 @@ resource "google_compute_instance" "{{$.PrimaryResourceId}}" {
   hostname = "hashicorptest.com"
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {

--- a/mmv1/templates/terraform/examples/instance_virtual_display_enabled.tf.tmpl
+++ b/mmv1/templates/terraform/examples/instance_virtual_display_enabled.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_compute_instance" "{{$.PrimaryResourceId}}" {
   enable_display = true
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {

--- a/mmv1/templates/terraform/examples/router_peer_router_appliance.tf.tmpl
+++ b/mmv1/templates/terraform/examples/router_peer_router_appliance.tf.tmpl
@@ -39,7 +39,7 @@ resource "google_compute_instance" "instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/examples/spot_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/spot_instance_basic.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_compute_instance" "{{$.PrimaryResourceId}}" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   scheduling {

--- a/mmv1/templates/terraform/samples/services/backupdr/backup_dr_bpa.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/backupdr/backup_dr_bpa.tf.tmpl
@@ -9,7 +9,7 @@ resource "google_compute_instance" "myinstance" {
   zone         = "us-central1-a"
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
       labels = {
         my_label = "value"
       }

--- a/mmv1/templates/terraform/samples/services/compute/autoscaler_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/autoscaler_basic.tf.tmpl
@@ -57,6 +57,6 @@ resource "google_compute_instance_group_manager" "foobar" {
 }
 
 data "google_compute_image" "debian_9" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }

--- a/mmv1/templates/terraform/samples/services/compute/autoscaler_single_instance.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/autoscaler_single_instance.tf.tmpl
@@ -69,7 +69,7 @@ resource "google_compute_instance_group_manager" "default" {
 data "google_compute_image" "debian_9" {
   provider = {{index $.ResourceIdVars "provider_name"}}
 
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_dynamic_backends.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_dynamic_backends.tf.tmpl
@@ -13,7 +13,7 @@ locals {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_in_flight.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_in_flight.tf.tmpl
@@ -18,7 +18,7 @@ resource "google_compute_instance_template" "default" {
   machine_type          = "e2-micro"
 
   disk {
-    source_image = "debian-cloud/debian-11"
+    source_image = "debian-cloud/debian-13"
     auto_delete  = true
     boot         = true
   }

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_signed_url_key.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_signed_url_key.tf.tmpl
@@ -45,7 +45,7 @@ resource "google_compute_instance_template" "webserver" {
   }
 
   disk {
-    source_image = "debian-cloud/debian-11"
+    source_image = "debian-cloud/debian-13"
     auto_delete  = true
     boot         = true
   }

--- a/mmv1/templates/terraform/samples/services/compute/compute_machine_image_kms.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_machine_image_kms.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_compute_instance" "vm" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/samples/services/compute/compute_packet_mirroring_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_packet_mirroring_full.tf.tmpl
@@ -4,7 +4,7 @@ resource "google_compute_instance" "mirror" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/samples/services/compute/compute_resource_policy_attachment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_resource_policy_attachment_basic.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_compute_instance" "instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/samples/services/compute/disk_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/disk_basic.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_compute_disk" "default" {
   name  = "{{index $.ResourceIdVars "disk_name"}}"
   type  = "pd-ssd"
   zone  = "us-central1-a"
-  image = "debian-11-bullseye-v20220719"
+  image = "debian-13-trixie-v20260827"
   labels = {
     environment = "dev"
   }

--- a/mmv1/templates/terraform/samples/services/compute/disk_resource_policy_attachment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/disk_resource_policy_attachment_basic.tf.tmpl
@@ -26,6 +26,6 @@ resource "google_compute_resource_policy" "policy" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }

--- a/mmv1/templates/terraform/samples/services/compute/external_http_lb_mig_backend.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/external_http_lb_mig_backend.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_compute_instance_template" "default" {
     boot         = true
     device_name  = "persistent-disk-0"
     mode         = "READ_WRITE"
-    source_image = "projects/debian-cloud/global/images/family/debian-11"
+    source_image = "projects/debian-cloud/global/images/family/debian-13"
     type         = "PERSISTENT"
   }
   labels = {

--- a/mmv1/templates/terraform/samples/services/compute/forwarding_rule_http_lb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/forwarding_rule_http_lb.tf.tmpl
@@ -51,7 +51,7 @@ resource "google_compute_region_backend_service" "default" {
 
 data "google_compute_image" "debian_image" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/forwarding_rule_regional_http_xlb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/forwarding_rule_regional_http_xlb.tf.tmpl
@@ -51,7 +51,7 @@ resource "google_compute_region_backend_service" "default" {
 
 data "google_compute_image" "debian_image" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/global_forwarding_rule_internal.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/global_forwarding_rule_internal.tf.tmpl
@@ -63,7 +63,7 @@ resource "google_compute_backend_service" "default" {
 
 data "google_compute_image" "debian_image" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/instance_basic.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_compute_instance" "{{$.PrimaryResourceId}}" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/samples/services/compute/instance_group_membership.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/instance_group_membership.tf.tmpl
@@ -8,7 +8,7 @@ resource "google_compute_instance" "default-instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/samples/services/compute/instance_template_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/instance_template_basic.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_compute_instance_template" "{{$.PrimaryResourceId}}" {
   machine_type = "e2-medium"
 
   disk {
-    source_image = "debian-cloud/debian-11"
+    source_image = "debian-cloud/debian-13"
   }
 
   network_interface {

--- a/mmv1/templates/terraform/samples/services/compute/instance_with_ip.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/instance_with_ip.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_compute_address" "{{$.PrimaryResourceId}}" {
 }
 
 data "google_compute_image" "debian_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/machine_image_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/machine_image_basic.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_compute_instance" "vm" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/samples/services/compute/machine_image_resource_manager_tags.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/machine_image_resource_manager_tags.tf.tmpl
@@ -21,7 +21,7 @@ resource "google_compute_instance" "vm" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/samples/services/compute/network_attachment_instance_usage.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/network_attachment_instance_usage.tf.tmpl
@@ -31,7 +31,7 @@ resource "google_compute_instance" "default" {
 
     boot_disk {
         initialize_params {
-            image = "debian-cloud/debian-11"
+            image = "debian-cloud/debian-13"
         }
     }
 

--- a/mmv1/templates/terraform/samples/services/compute/network_endpoint.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/network_endpoint.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_compute_network_endpoint" "{{$.PrimaryResourceId}}" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/network_endpoints.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/network_endpoints.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_compute_network_endpoints" "{{$.PrimaryResourceId}}" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/region_autoscaler_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_autoscaler_basic.tf.tmpl
@@ -20,7 +20,7 @@ resource "google_compute_instance_template" "foobar" {
   machine_type = "e2-standard-4"
 
   disk {
-    source_image = "debian-cloud/debian-11"
+    source_image = "debian-cloud/debian-13"
     disk_size_gb = 250
   }
 
@@ -65,6 +65,6 @@ resource "google_compute_region_instance_group_manager" "foobar" {
 }
 
 data "google_compute_image" "debian_9" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }

--- a/mmv1/templates/terraform/samples/services/compute/region_backend_service_balancing_mode.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_backend_service_balancing_mode.tf.tmpl
@@ -16,7 +16,7 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 data "google_compute_image" "debian_image" {
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/region_disk_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_disk_basic.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_compute_region_disk" "regiondisk" {
 
 resource "google_compute_disk" "disk" {
   name  = "{{index $.ResourceIdVars "disk_name"}}"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   size  = 50
   type  = "pd-ssd"
   zone  = "us-central1-a"

--- a/mmv1/templates/terraform/samples/services/compute/region_disk_resource_policy_attachment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_disk_resource_policy_attachment_basic.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_compute_region_disk_resource_policy_attachment" "{{$.PrimaryRes
 
 resource "google_compute_disk" "disk" {
   name  = "{{index $.ResourceIdVars "base_disk_name"}}"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   size  = 50
   type  = "pd-ssd"
   zone  = "us-central1-a"
@@ -41,6 +41,6 @@ resource "google_compute_resource_policy" "policy" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }

--- a/mmv1/templates/terraform/samples/services/compute/region_network_endpoint_portmap.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_network_endpoint_portmap.tf.tmpl
@@ -33,7 +33,7 @@ resource "google_compute_region_network_endpoint" "{{$.PrimaryResourceId}}" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
   provider           = google-beta
 }

--- a/mmv1/templates/terraform/samples/services/compute/reservation_sharing_policy.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/reservation_sharing_policy.tf.tmpl
@@ -1,5 +1,5 @@
 data "google_compute_image" "my_image" {
-  family = "debian-11"
+  family = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/reservation_source_instance_template.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/reservation_source_instance_template.tf.tmpl
@@ -1,5 +1,5 @@
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/security_policy_rule_with_body_exclude.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/security_policy_rule_with_body_exclude.tf.tmpl
@@ -40,7 +40,7 @@ resource "google_compute_instance_template" "default" {
   machine_type = "e2-micro"
 
   disk {
-    source_image = "projects/debian-cloud/global/images/family/debian-11"
+    source_image = "projects/debian-cloud/global/images/family/debian-13"
     auto_delete  = true
     boot         = true
   }

--- a/mmv1/templates/terraform/samples/services/compute/snapshot_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/snapshot_basic.tf.tmpl
@@ -9,7 +9,7 @@ resource "google_compute_snapshot" "{{$.PrimaryResourceId}}" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/snapshot_basic_2.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/snapshot_basic_2.tf.tmpl
@@ -12,7 +12,7 @@ resource "google_compute_snapshot" "{{$.PrimaryResourceId}}" {
 
 data "google_compute_image" "debian" {
   provider = google-beta
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/snapshot_basic_source_instant_snapshot.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/snapshot_basic_source_instant_snapshot.tf.tmpl
@@ -16,7 +16,7 @@ resource "google_compute_instant_snapshot" "instant_snapshot" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/snapshot_chainname.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/snapshot_chainname.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_compute_snapshot" "{{$.PrimaryResourceId}}" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/stateful_igm.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/stateful_igm.tf.tmpl
@@ -1,5 +1,5 @@
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -42,7 +42,7 @@ resource "google_compute_disk" "default" {
   name  = "{{index $.ResourceIdVars "disk_name"}}"
   type  = "pd-ssd"
   zone  = google_compute_instance_group_manager.igm.zone
-  image = "debian-11-bullseye-v20220719"
+  image = "debian-13-trixie-v20260827"
   physical_block_size_bytes = 4096
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/stateful_rigm.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/stateful_rigm.tf.tmpl
@@ -1,5 +1,5 @@
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -48,7 +48,7 @@ resource "google_compute_disk" "default" {
   name  = "{{index $.ResourceIdVars "disk_name"}}"
   type  = "pd-ssd"
   zone  = "us-central1-a"
-  image = "debian-11-bullseye-v20220719"
+  image = "debian-13-trixie-v20260827"
   physical_block_size_bytes = 4096
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/target_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/target_instance_basic.tf.tmpl
@@ -4,7 +4,7 @@ resource "google_compute_target_instance" "{{$.PrimaryResourceId}}" {
 }
 
 data "google_compute_image" "vmimage" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/compute/target_instance_with_security_policy.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/target_instance_with_security_policy.tf.tmpl
@@ -18,7 +18,7 @@ resource "google_compute_subnetwork" "default" {
 
 data "google_compute_image" "vmimage" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/dns/dns_managed_zone_quickstart.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dns/dns_managed_zone_quickstart.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/samples/services/kms/kms_secret_ciphertext_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/kms/kms_secret_ciphertext_basic.tf.tmpl
@@ -25,7 +25,7 @@ resource "google_compute_instance" "instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/templates/terraform/samples/services/networkmanagement/network_management_connectivity_test_instances.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkmanagement/network_management_connectivity_test_instances.tf.tmpl
@@ -53,6 +53,6 @@ resource "google_compute_network" "vpc" {
 }
 
 data "google_compute_image" "debian_9" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }

--- a/mmv1/templates/terraform/samples/services/networkservices/network_services_lb_route_extension_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkservices/network_services_lb_route_extension_basic.tf.tmpl
@@ -238,7 +238,7 @@ resource "google_compute_instance" "vm_test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 }

--- a/mmv1/templates/terraform/samples/services/networkservices/network_services_lb_route_extension_observability.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkservices/network_services_lb_route_extension_observability.tf.tmpl
@@ -232,7 +232,7 @@ resource "google_compute_instance" "vm_test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 }

--- a/mmv1/templates/terraform/samples/services/networkservices/network_services_lb_traffic_extension_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkservices/network_services_lb_traffic_extension_basic.tf.tmpl
@@ -228,7 +228,7 @@ resource "google_compute_instance" "vm_test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 }

--- a/mmv1/templates/terraform/samples/services/osconfig/os_config_guest_policies_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/osconfig/os_config_guest_policies_basic.tf.tmpl
@@ -1,6 +1,6 @@
 data "google_compute_image" "my_image" {
   provider = google-beta
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/osconfig/os_config_patch_deployment_instance.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/osconfig/os_config_patch_deployment_instance.tf.tmpl
@@ -1,5 +1,5 @@
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/templates/terraform/samples/services/tpuv2/tpu_v2_vm_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/tpuv2/tpu_v2_vm_full.tf.tmpl
@@ -91,7 +91,7 @@ resource "google_compute_disk" "disk" {
   provider = google-beta
 
   name  = "{{index $.ResourceIdVars "disk_name"}}"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   size  = 10
   type  = "pd-ssd"
   zone  = "us-central1-c"

--- a/mmv1/third_party/terraform/functions/region_from_zone_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_test.go
@@ -52,7 +52,7 @@ resource "google_compute_disk" "default" {
 	name  = "%{resource_name}"
 	type  = "pd-ssd"
 	zone  = "%{resource_location}"
-	image = "debian-11-bullseye-v20220719"
+	image = "debian-13-trixie-v20260827"
 	labels = {
 	  environment = "dev"
 	}

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_backup_plan_association_test.go
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_backup_plan_association_test.go
@@ -52,7 +52,7 @@ resource "google_compute_instance" "default" {
   tags = ["foo", "bar"]
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
       labels = {
         my_label = "value"
       }
@@ -238,7 +238,7 @@ resource "google_compute_instance" "default" {
   tags         = ["foo", "bar"]
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {

--- a/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_backup_plan_association_test.go
+++ b/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_backup_plan_association_test.go
@@ -67,7 +67,7 @@ resource "google_compute_instance" "default" {
   tags = ["foo", "bar"]
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
       labels = {
         my_label = "value"
       }
@@ -155,7 +155,7 @@ resource "google_compute_instance" "default" {
   tags = ["foo", "bar"]
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
       labels = {
         my_label = "value"
       }

--- a/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_backup_plan_test.go
+++ b/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_backup_plan_test.go
@@ -59,7 +59,7 @@ resource "google_compute_instance" "default" {
   tags = ["foo", "bar"]
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
       labels = {
         my_label = "value"
       }
@@ -141,7 +141,7 @@ resource "google_compute_instance" "default" {
   tags = ["foo", "bar"]
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
       labels = {
         my_label = "value"
       }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_image_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_image_test.go
@@ -98,7 +98,7 @@ func testAccDataSourceCheckPublicImage() resource.TestCheckFunc {
 
 		ds_attr := ds.Primary.Attributes
 		attrs_to_test := map[string]string{
-			"family": "debian-11",
+			"family": "debian-13",
 		}
 
 		for attr, expect_value := range attrs_to_test {
@@ -112,7 +112,7 @@ func testAccDataSourceCheckPublicImage() resource.TestCheckFunc {
 			}
 		}
 
-		selfLink := "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-11-bullseye-v20220719"
+		selfLink := "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-13-trixie-v20260827"
 
 		if !tpgresource.CompareSelfLinkOrResourceName("", ds_attr["self_link"], selfLink, nil) && ds_attr["self_link"] != selfLink {
 			return fmt.Errorf("self link does not match: %s vs %s", ds_attr["self_link"], selfLink)
@@ -125,7 +125,7 @@ func testAccDataSourceCheckPublicImage() resource.TestCheckFunc {
 var testAccDataSourcePublicImageConfig = `
 data "google_compute_image" "debian" {
   project = "debian-cloud"
-  name    = "debian-11-bullseye-v20220719"
+  name    = "debian-13-trixie-v20260827"
 }
 `
 

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_images_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_images_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceComputeImages_basic(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"image":         "debian-cloud/debian-11",
+		"image":         "debian-cloud/debian-13",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_group_manager_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_group_manager_test.go
@@ -96,7 +96,7 @@ func testAccDataSourceGoogleComputeInstanceGroupManager_basic1(context map[strin
     }
 
     data "google_compute_image" "my_image" {
-        family  = "debian-11"
+        family  = "debian-13"
         project = "debian-cloud"
     }
 
@@ -173,7 +173,7 @@ func testAccDataSourceGoogleComputeInstanceGroupManager_basic2(context map[strin
     }
 
     data "google_compute_image" "my_image" {
-        family  = "debian-11"
+        family  = "debian-13"
         project = "debian-cloud"
     }
 

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_group_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_group_test.go
@@ -201,7 +201,7 @@ func testAccCheckDataSourceGoogleComputeInstanceGroup(dataSourceName string) res
 func testAccCheckDataSourceGoogleComputeInstanceGroupConfig(instanceName, igName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -244,7 +244,7 @@ data "google_compute_instance_group" "test" {
 func testAccCheckDataSourceGoogleComputeInstanceGroupConfigWithNamedPort(instanceName, igName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -297,7 +297,7 @@ data "google_compute_instance_group" "test" {
 func testAccCheckDataSourceGoogleComputeInstanceGroup_fromIGM(igmName, secondIgmName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager_test.go
@@ -96,7 +96,7 @@ func testAccDataSourceGoogleComputeRegionInstanceGroupManager_usingSelfLink(cont
     }
 
     data "google_compute_image" "my_image" {
-        family  = "debian-11"
+        family  = "debian-13"
         project = "debian-cloud"
     }
 
@@ -173,7 +173,7 @@ func testAccDataSourceGoogleComputeRegionInstanceGroupManager_usingNameAndRegion
     }
 
     data "google_compute_image" "my_image" {
-        family  = "debian-11"
+        family  = "debian-13"
         project = "debian-cloud"
     }
 

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_test.go
@@ -37,7 +37,7 @@ resource "google_compute_target_pool" "foo" {
 
 data "google_compute_image" "debian" {
   project = "debian-cloud"
-  name    = "debian-11-bullseye-v20220719"
+  name    = "debian-13-trixie-v20260827"
 }
 
 resource "google_compute_instance_template" "foo" {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_snapshot_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_snapshot_test.go
@@ -75,7 +75,7 @@ func TestAccSnapshotDatasource_filterMostRecent(t *testing.T) {
 func testAccSnapshot_name(project, suffix string) string {
 	return acctest.Nprintf(`
 	data "google_compute_image" "tf-test-image" {
-		family  = "debian-11"
+		family  = "debian-13"
 		project = "debian-cloud"
 	}
 	resource "google_compute_disk" "tf-test-disk" {
@@ -107,7 +107,7 @@ func testAccSnapshot_name(project, suffix string) string {
 func testAccSnapshot_filter(project, suffix string) string {
 	return acctest.Nprintf(`
 	data "google_compute_image" "tf-test-image" {
-		family  = "debian-11"
+		family  = "debian-13"
 		project = "debian-cloud"
 	}
 	resource "google_compute_disk" "tf-test-disk" {
@@ -158,7 +158,7 @@ func testAccSnapshot_filter(project, suffix string) string {
 func testAccSnapshot_filter_mostRecent(project, suffix string) string {
 	return acctest.Nprintf(`
 	data "google_compute_image" "tf-test-image" {
-		family  = "debian-11"
+		family  = "debian-13"
 		project = "debian-cloud"
 	}
 	resource "google_compute_disk" "tf-test-disk" {

--- a/mmv1/third_party/terraform/services/compute/iam_compute_instance_test.go
+++ b/mmv1/third_party/terraform/services/compute/iam_compute_instance_test.go
@@ -65,7 +65,7 @@ func testAccComputeInstanceIamPolicy_basic(zone, instanceName, roleId string) st
 
     boot_disk {
       initialize_params {
-        image = "debian-cloud/debian-11"
+        image = "debian-cloud/debian-13"
       }
     }
 

--- a/mmv1/third_party/terraform/services/compute/list_google_compute_instance_test.go
+++ b/mmv1/third_party/terraform/services/compute/list_google_compute_instance_test.go
@@ -61,7 +61,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk_test.go
@@ -245,7 +245,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -275,7 +275,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -306,7 +306,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -419,7 +419,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_autoscaler_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_autoscaler_test.go.tmpl
@@ -171,7 +171,7 @@ func TestAccComputeAutoscaler_scaleInControlFixed(t *testing.T) {
 func testAccComputeAutoscaler_scaffolding(itName, tpName, igmName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -1654,7 +1654,7 @@ func testAccComputeBackendService_withBackend(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1711,7 +1711,7 @@ func testAccComputeBackendService_withBackendAndMaxUtilization(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1769,7 +1769,7 @@ func testAccComputeBackendService_withBackendAndIAP(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2099,7 +2099,7 @@ func testAccComputeBackendService_withMaxConnections(
 	serviceName, igName, itName, checkName string, maxConnections int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2156,7 +2156,7 @@ func testAccComputeBackendService_withMaxConnectionsPerInstance(
 	serviceName, igName, itName, checkName string, maxConnectionsPerInstance int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2229,7 +2229,7 @@ resource "google_compute_backend_service" "lipsum" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2388,7 +2388,7 @@ resource "google_compute_backend_service" "lipsum" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2537,7 +2537,7 @@ resource "google_compute_url_map" "default" {
 }
 
 data "google_compute_image" "debian_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3043,7 +3043,7 @@ resource "google_compute_health_check" "health_check" {
 func testAccComputeBackendService_withBackendAndPreference(suffix, loadBalancingScheme, preference string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3315,7 +3315,7 @@ func testAccComputeBackendService_withMaxInFlightRequests(
 	serviceName, igName, itName, checkName string, maxInFlightRequests int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3375,7 +3375,7 @@ func testAccComputeBackendService_withMaxInFlightRequestsPerInstance(
 	serviceName, igName, itName, checkName string, maxInFlightRequestsPerInstance int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3467,7 +3467,7 @@ resource "google_compute_backend_service" "lipsum" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3529,7 +3529,7 @@ resource "google_compute_health_check" "default" {
 func testAccComputeBackendService_withTrafficDuration(serviceName, igName, itName, checkName, duration string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_bulk_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_bulk_per_instance_config_test.go
@@ -184,7 +184,7 @@ resource "google_compute_bulk_per_instance_config" "default" {
 func testAccComputeBulkPerInstanceConfig_igm(context map[string]any) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_resource_policy_attachment_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_resource_policy_attachment_test.go
@@ -44,7 +44,7 @@ func TestAccComputeDiskResourcePolicyAttachment_update(t *testing.T) {
 func testAccComputeDiskResourcePolicyAttachment_basic(diskName, policyName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -84,7 +84,7 @@ resource "google_compute_disk_resource_policy_attachment" "foobar" {
 func testAccComputeDiskResourcePolicyAttachment_update(diskName, policyName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
@@ -206,8 +206,8 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			ExpectDiffSuppress: true,
 		},
 		"matching image debian arm64 self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-11-bullseye-arm64-v20220719",
-			New:                "debian-11-arm64",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-13-trixie-arm64-v20260827",
+			New:                "debian-13-arm64",
 			ExpectDiffSuppress: true,
 		},
 		"different architecture image opensuse arm64 self_link": {
@@ -231,8 +231,8 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			ExpectDiffSuppress: false,
 		},
 		"different architecture image debian arm64 self_link": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-11-bullseye-arm64-v20220719",
-			New:                "debian-11",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-13-trixie-arm64-v20260827",
+			New:                "debian-13",
 			ExpectDiffSuppress: false,
 		},
 		"different architecture image opensuse arm64 family": {
@@ -256,8 +256,8 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			ExpectDiffSuppress: false,
 		},
 		"different architecture image debian arm64 family": {
-			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-11-bullseye-v20220719",
-			New:                "debian-11-arm64",
+			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-13-trixie-v20260827",
+			New:                "debian-13-arm64",
 			ExpectDiffSuppress: false,
 		},
 		// amd images
@@ -1311,7 +1311,7 @@ func TestAccComputeDisk_VSSWindows(t *testing.T) {
 func testAccComputeDisk_basic(diskName string, diskType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1331,7 +1331,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_updated(diskName string, diskType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1352,7 +1352,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_fromSnapshot(projectName, firstDiskName, snapshotName, diskName, ref_selector string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1385,7 +1385,7 @@ resource "google_compute_disk" "seconddisk" {
 func testAccComputeDisk_encryption(diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1405,7 +1405,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_encryptionKMS(diskName, kmsKey string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1426,7 +1426,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_deleteDetach(instanceName, diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1463,7 +1463,7 @@ resource "google_compute_instance" "bar" {
 func testAccComputeDisk_deleteDetachIGM(diskName, mgrName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1577,7 +1577,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_resourcePolicies(diskName, policyName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1610,7 +1610,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_updateResourcePolicies(diskName, policyName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1643,7 +1643,7 @@ resource "google_compute_disk" "foobar" {
 func testAccComputeDisk_multiWriter(instance string, diskName string, enableMultiwriter bool) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1687,7 +1687,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeDisk_diskClone(diskName, refSelector string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		family  = "debian-11"
+		family  = "debian-13"
 		project = "debian-cloud"
 	}
 
@@ -1741,7 +1741,7 @@ func TestAccComputeDisk_encryptionWithRSAEncryptedKey(t *testing.T) {
 func testAccComputeDisk_encryptionWithRSAEncryptedKey(diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1924,7 +1924,7 @@ provider "google" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1949,7 +1949,7 @@ provider "google" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
@@ -842,7 +842,7 @@ resource "google_compute_url_map" "default" {
 }
 
 data "google_compute_image" "debian_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -961,7 +961,7 @@ resource "google_compute_url_map" "default" {
 }
 
 data "google_compute_image" "debian_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_image_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_image_test.go
@@ -417,7 +417,7 @@ func testAccCheckComputeImageResolution(t *testing.T, n string) resource.TestChe
 		family := rs.Primary.Attributes["family"]
 		link := rs.Primary.Attributes["self_link"]
 
-		url := fmt.Sprintf("%sprojects/%s/global/images/family/%s", transport_tpg.BaseUrl(tpgcompute.Product, config), "debian-cloud", "debian-11")
+		url := fmt.Sprintf("%sprojects/%s/global/images/family/%s", transport_tpg.BaseUrl(tpgcompute.Product, config), "debian-cloud", "debian-13")
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "GET",
@@ -595,7 +595,7 @@ func testAccCheckComputeImageHasSourceType(image *map[string]interface{}) resour
 func testAccComputeImage_resolving(name, family string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -644,7 +644,7 @@ resource "google_compute_image" "foobar" {
 func testAccComputeImage_license(name string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -663,7 +663,7 @@ resource "google_compute_image" "foobar" {
     my-label    = "my-label-value"
   }
   licenses = [
-    "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-11-bullseye",
+    "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-13-trixie",
   ]
 }
 `, name, name)
@@ -701,7 +701,7 @@ resource "google_compute_image" "foobar" {
 func testAccComputeImage_basedondisk(diskName, imageName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -721,7 +721,7 @@ resource "google_compute_image" "foobar" {
 func testAccComputeImage_shieldedInstance_InitialState(imageName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -753,7 +753,7 @@ resource "google_compute_image" "foobar" {
 func testAccComputeImage_shieldedInstance_UpdatedState(imageName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -781,7 +781,7 @@ resource "google_compute_image" "foobar" {
 func testAccComputeImage_sourceImage(imageName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -795,7 +795,7 @@ resource "google_compute_image" "foobar" {
 func testAccComputeImage_sourceSnapshot(diskName, snapshotName, imageName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -823,7 +823,7 @@ resource "google_compute_image" "foobar" {
 func testAccComputeImage_sourceDiskEncryptionKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -896,7 +896,7 @@ data "google_compute_default_service_account" "default" {
 func testAccComputeImage_sourceImageEncryptionKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -969,7 +969,7 @@ data "google_compute_default_service_account" "default" {
 func testAccComputeImage_sourceSnapshotEncryptionKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1101,7 +1101,7 @@ resource "google_kms_crypto_key_iam_member" "crypto_key" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_test.go.tmpl
@@ -1331,7 +1331,7 @@ resource "google_compute_instance_from_machine_image" "foobar" {
 func testAccComputeInstanceFromMachineImage_withSourceMachineImageEncryptionKey(instanceName, machineImageName, bootDiskID, serviceAccountEmail, keyRingSuffix, keyNameSuffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1470,7 +1470,7 @@ func TestAccComputeInstanceFromMachineImage_IgmpQuery_v2(t *testing.T) {
 func testAccComputeInstanceFromMachineImage_igmpQuery_v2(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -1527,7 +1527,7 @@ resource "google_compute_instance_from_machine_image" "foobar" {
 func testAccComputeInstanceFromMachineImage_workloadIdentity(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
@@ -712,7 +712,7 @@ func TestAccComputeInstanceFromTemplate_VSSWindows(t *testing.T) {
 func testAccComputeInstanceFromTemplate_basic(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -795,7 +795,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_maxRunDuration_onInstanceStopAction(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -896,7 +896,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_localSsdRecoveryTimeout(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -982,7 +982,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplateWithOverride_localSsdRecoveryTimeout(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1073,7 +1073,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_partnerMetadata(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1159,7 +1159,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplateWithOverride_partnerMetadata(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1255,7 +1255,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromRegionTemplate_basic(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1340,7 +1340,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_regionalDisk(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1407,7 +1407,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_self_link_unique(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1489,7 +1489,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_overrideBootDisk(templateDisk, overrideDisk, template, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1554,7 +1554,7 @@ resource "google_compute_instance_from_template" "inst" {
 func testAccComputeInstanceFromTemplate_overrideAttachedDisk(templateDisk, overrideDisk, template, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1592,7 +1592,7 @@ resource "google_compute_instance_template" "template" {
   }
 
   disk {
-    source_image = "debian-cloud/debian-11"
+    source_image = "debian-cloud/debian-13"
     auto_delete  = true
     boot         = false
   }
@@ -1619,7 +1619,7 @@ resource "google_compute_instance_from_template" "inst" {
 func testAccComputeInstanceFromTemplate_overrideScratchDisk(templateDisk, overrideDisk, template, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1696,7 +1696,7 @@ resource "google_compute_instance_from_template" "inst" {
 func testAccComputeInstanceFromTemplate_overrideScheduling(templateDisk, template, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1747,7 +1747,7 @@ resource "google_compute_instance_from_template" "inst" {
 func testAccComputeInstanceFromTemplate_schedulingPreemptionNoticeDuration(template, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1843,7 +1843,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_terminationTime(templateDisk, template, termination_time, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1898,7 +1898,7 @@ resource "google_compute_instance_from_template" "inst" {
 func testAccComputeInstanceFromTemplate_overrideMetadataDotStartupScript(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2302,7 +2302,7 @@ func TestAccComputeInstanceFromTemplate_IgmpQuery_v2(t *testing.T) {
 func testAccComputeInstanceFromTemplateWithOverride_interface(instance, template string) string {
   return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2382,7 +2382,7 @@ resource "google_compute_resource_policy" "test-snapshot-policy2" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2434,7 +2434,7 @@ resource "google_compute_resource_policy" "test-snapshot-policy2" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2486,7 +2486,7 @@ resource "google_compute_resource_policy" "test-snapshot-policy2" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2514,7 +2514,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_DiskForceAttach_zonal(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2581,7 +2581,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_DiskForceAttach(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2657,7 +2657,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_igmpQuery_v2(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -2774,7 +2774,7 @@ resource "google_compute_instance_from_template" "foobar" {
 func testAccComputeInstanceFromTemplate_workloadIdentity(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
@@ -648,7 +648,7 @@ func testAccCheckInstanceGroupManagerDestroyProducer(t *testing.T) func(s *terra
 func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -714,7 +714,7 @@ resource "google_compute_instance_group_manager" "igm-no-tp" {
 func testAccInstanceGroupManager_self_link_unique(template, target, igm1, igm2 string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -780,7 +780,7 @@ resource "google_compute_instance_group_manager" "igm-no-tp" {
 func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -823,7 +823,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
 func testAccInstanceGroupManager_update(template, target, description, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -893,7 +893,7 @@ resource "google_compute_instance_group_manager" "igm-update" {
 func testAccInstanceGroupManager_update2(template1, target1, target2, template2, description, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1003,7 +1003,7 @@ resource "google_compute_instance_group_manager" "igm-update" {
 func testAccInstanceGroupManager_update3(template1, target1, target2, template2, description2, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1089,7 +1089,7 @@ resource "google_compute_instance_group_manager" "igm-update" {
 func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1140,7 +1140,7 @@ resource "google_compute_instance_group_manager" "igm-update" {
 func testAccInstanceGroupManager_rollingUpdatePolicy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1195,7 +1195,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 func testAccInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1247,7 +1247,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 func testAccInstanceGroupManager_rollingUpdatePolicy3(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1298,7 +1298,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 func testAccInstanceGroupManager_rollingUpdatePolicy4(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1346,7 +1346,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 func testAccInstanceGroupManager_rollingUpdatePolicy5(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1395,7 +1395,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1452,7 +1452,7 @@ resource "google_compute_instance_group_manager" "igm-basic-2" {
 func testAccInstanceGroupManager_autoHealingPolicies(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1510,7 +1510,7 @@ resource "google_compute_http_health_check" "zero" {
 func testAccInstanceGroupManager_autoHealingPoliciesRemoved(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1564,7 +1564,7 @@ resource "google_compute_http_health_check" "zero" {
 func testAccInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1632,7 +1632,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
 func testAccInstanceGroupManager_stateful(network, template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1722,7 +1722,7 @@ resource "google_compute_http_health_check" "zero" {
 func testAccInstanceGroupManager_statefulUpdated(network, template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1816,7 +1816,7 @@ resource "google_compute_http_health_check" "zero" {
 func testAccInstanceGroupManager_statefulRemoved(network, template, target, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1885,7 +1885,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
 func testAccInstanceGroupManager_stoppedSuspendedTargetSize(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1932,7 +1932,7 @@ resource "google_compute_instance_group_manager" "sr-igm" {
 func testAccInstanceGroupManager_stoppedSuspendedTargetSizeUpdate(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1977,7 +1977,7 @@ resource "google_compute_instance_group_manager" "sr-igm" {
 func testAccInstanceGroupManager_waitForStatus(template, target, igm, perInstanceConfig string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2039,7 +2039,7 @@ resource "google_compute_per_instance_config" "per-instance" {
 func testAccInstanceGroupManager_waitForStatusUpdated(template, target, igm, perInstanceConfig string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2121,7 +2121,7 @@ resource "google_compute_per_instance_config" "per-instance" {
 func testAccInstanceGroupManager_withTargetSize(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2171,7 +2171,7 @@ resource "google_compute_instance_group_manager" "igm-workload-policy" {
 func testAccInstanceGroupManager_resourcePoliciesWorkloadPolicyUpdateError(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2228,7 +2228,7 @@ resource "google_compute_instance_group_manager" "igm-workload-policy" {
 func testAccInstanceGroupManager_resourcePoliciesWorkloadPolicyUpdate(suffix, workloadPolicy string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2299,7 +2299,7 @@ resource "google_compute_instance_group_manager" "igm-workload-policy" {
 func testAccInstanceGroupManager_resourcePoliciesWorkloadPolicyUpdate2(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2377,7 +2377,7 @@ func TestAccInstanceGroupManager_targetSizePolicy(t *testing.T) {
 func testAccInstanceGroupManager_targetSizePolicy(template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2439,7 +2439,7 @@ resource "google_compute_instance_group_manager" "igm-tsp" {
 func testAccInstanceGroupManager_resourceManagerTags(template_name, tag_name, igm_name, project_id string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_membership_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_membership_test.go.tmpl
@@ -126,7 +126,7 @@ func testAccComputeInstanceGroupMembership_noInstanceGroupMembership(context map
 
       boot_disk {
         initialize_params {
-          image = "debian-cloud/debian-11"
+          image = "debian-cloud/debian-13"
         }
       }
 
@@ -141,7 +141,7 @@ func testAccComputeInstanceGroupMembership_noInstanceGroupMembership(context map
 
       boot_disk {
         initialize_params {
-          image = "debian-cloud/debian-11"
+          image = "debian-cloud/debian-13"
         }
       }
 
@@ -156,7 +156,7 @@ func testAccComputeInstanceGroupMembership_noInstanceGroupMembership(context map
 
       boot_disk {
         initialize_params {
-          image = "debian-cloud/debian-11"
+          image = "debian-cloud/debian-13"
         }
       }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_test.go
@@ -385,7 +385,7 @@ func testAccComputeInstanceGroup_hasCorrectNetwork(t *testing.T, nInstanceGroup 
 func testAccComputeInstanceGroup_basic(zone, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -440,7 +440,7 @@ resource "google_compute_instance_group" "empty" {
 func testAccComputeInstanceGroup_rename(instance, instanceGroup, backend, health string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -503,7 +503,7 @@ resource "google_compute_https_health_check" "healthcheck" {
 func testAccComputeInstanceGroup_update(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -546,7 +546,7 @@ resource "google_compute_instance_group" "update" {
 func testAccComputeInstanceGroup_update2(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -589,7 +589,7 @@ resource "google_compute_instance_group" "update" {
 func testAccComputeInstanceGroup_outOfOrderInstances(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -647,7 +647,7 @@ resource "google_compute_instance_group" "group" {
 func testAccComputeInstanceGroup_network(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_migrate_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_migrate_test.go
@@ -96,7 +96,7 @@ func TestAccComputeInstanceMigrateState(t *testing.T) {
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 		},
@@ -176,7 +176,7 @@ func TestAccComputeInstanceMigrateState_bootDisk(t *testing.T) {
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 		},
@@ -252,7 +252,7 @@ func TestAccComputeInstanceMigrateState_v4FixBootDisk(t *testing.T) {
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 		},
@@ -322,7 +322,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 	diskName := fmt.Sprintf("tf-test-instance-test-%s", acctest.RandString(t, 10))
 	disk := map[string]interface{}{
 		"name":        diskName,
-		"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+		"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 		"zone":        zone,
 	}
 	url := fmt.Sprintf("%sprojects/%s/zones/%s/disks", transport_tpg.BaseUrl(tpgcompute.Product, config), config.Project, zone)
@@ -351,7 +351,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 			map[string]interface{}{
@@ -419,7 +419,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 	diskName := fmt.Sprintf("tf-test-instance-test-%s", acctest.RandString(t, 10))
 	disk := map[string]interface{}{
 		"name":        diskName,
-		"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+		"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 		"zone":        zone,
 	}
 	url := fmt.Sprintf("%sprojects/%s/zones/%s/disks", transport_tpg.BaseUrl(tpgcompute.Product, config), config.Project, zone)
@@ -448,7 +448,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 			map[string]interface{}{
@@ -519,13 +519,13 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 			map[string]interface{}{
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 				"diskEncryptionKey": map[string]interface{}{
 					"rawKey": "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
@@ -560,7 +560,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 	attributes := map[string]string{
 		"boot_disk.#":                       "1",
 		"disk.#":                            "1",
-		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-11",
+		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-13",
 		"disk.0.disk_encryption_key_raw":    "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
 		"disk.0.disk_encryption_key_sha256": "esTuF7d4eatX4cnc4JsiEiaI+Rff78JgPhA/v1zxX9E=",
 		"zone":                              zone,
@@ -596,13 +596,13 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 			map[string]interface{}{
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 				"diskEncryptionKey": map[string]interface{}{
 					"rawKey": "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
@@ -637,7 +637,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 	attributes := map[string]string{
 		"boot_disk.#":                       "1",
 		"disk.#":                            "1",
-		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-11",
+		"disk.0.image":                      "projects/debian-cloud/global/images/family/debian-13",
 		"disk.0.disk_encryption_key_raw":    "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
 		"disk.0.disk_encryption_key_sha256": "esTuF7d4eatX4cnc4JsiEiaI+Rff78JgPhA/v1zxX9E=",
 		"zone":                              zone,
@@ -672,19 +672,19 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 			map[string]interface{}{
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 			map[string]interface{}{
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/debian-11-bullseye-v20220719",
+					"sourceImage": "projects/debian-cloud/global/images/debian-13-trixie-v20260827",
 				},
 			},
 		},
@@ -716,9 +716,9 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 	attributes := map[string]string{
 		"boot_disk.#":        "1",
 		"disk.#":             "2",
-		"disk.0.image":       "projects/debian-cloud/global/images/debian-11-bullseye-v20220719",
+		"disk.0.image":       "projects/debian-cloud/global/images/debian-13-trixie-v20260827",
 		"disk.0.auto_delete": "true",
-		"disk.1.image":       "global/images/family/debian-11",
+		"disk.1.image":       "global/images/family/debian-13",
 		"disk.1.auto_delete": "true",
 		"zone":               zone,
 	}
@@ -753,19 +753,19 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 			map[string]interface{}{
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 			map[string]interface{}{
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/debian-11-bullseye-v20220719",
+					"sourceImage": "projects/debian-cloud/global/images/debian-13-trixie-v20260827",
 				},
 			},
 		},
@@ -797,9 +797,9 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 	attributes := map[string]string{
 		"boot_disk.#":        "1",
 		"disk.#":             "2",
-		"disk.0.image":       "projects/debian-cloud/global/images/debian-11-bullseye-v20220719",
+		"disk.0.image":       "projects/debian-cloud/global/images/debian-13-trixie-v20260827",
 		"disk.0.auto_delete": "true",
-		"disk.1.image":       "global/images/family/debian-11",
+		"disk.1.image":       "global/images/family/debian-13",
 		"disk.1.auto_delete": "true",
 		"zone":               zone,
 	}
@@ -834,7 +834,7 @@ func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 			map[string]interface{}{
@@ -908,7 +908,7 @@ func TestAccComputeInstanceMigrateState_v4FixScratchDisk(t *testing.T) {
 				"boot":       true,
 				"autoDelete": true,
 				"initializeParams": map[string]interface{}{
-					"sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+					"sourceImage": "projects/debian-cloud/global/images/family/debian-13",
 				},
 			},
 			map[string]interface{}{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -2286,7 +2286,7 @@ func TestAccComputeInstanceTemplate_dynamicNic(t *testing.T) {
 func testAccComputeInstanceTemplate_dynamicNic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2402,7 +2402,7 @@ resource "google_compute_storage_pool" "example" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3128,7 +3128,7 @@ func testAccCheckComputeInstanceTemplateNotRecreated(instanceTemplate *map[strin
 func testAccComputeInstanceTemplate_basic(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3177,7 +3177,7 @@ provider "google" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3228,7 +3228,7 @@ provider "google" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3336,7 +3336,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_metadataGceContainerDeclaration(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3380,7 +3380,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_preemptible(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3420,7 +3420,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_maintenance_interval(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3465,7 +3465,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_hostErrorTimeoutSeconds(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3511,7 +3511,7 @@ resource "google_compute_address" "foo" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3545,7 +3545,7 @@ resource "google_compute_address" "foo" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3594,7 +3594,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_networkTier(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3619,7 +3619,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_networkIP(suffix, networkIP string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3647,7 +3647,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_networkIPAddress(suffix, ipAddress string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3675,7 +3675,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_disks(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3721,7 +3721,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_disksInvalid(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3886,7 +3886,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_regionDisks(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3929,7 +3929,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_diskIops(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3958,7 +3958,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_diskIopsThroughput(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3989,7 +3989,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_subnet_auto(network, suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4035,7 +4035,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4120,7 +4120,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4152,7 +4152,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_startup_script(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4183,7 +4183,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_primaryAliasIpRange(i string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4230,7 +4230,7 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4269,7 +4269,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_guestAccelerator(i string, count uint8) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4304,7 +4304,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_minCpuPlatform(i string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4336,7 +4336,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_encryptionKMS(suffix, kmsLink, keyRingName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4382,7 +4382,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_sourceSnapshotEncryptionKey_RawKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4435,7 +4435,7 @@ resource "google_compute_instance_template" "template" {
 func testAccComputeInstanceTemplate_sourceSnapshotEncryptionKey_RsaKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4489,7 +4489,7 @@ resource "google_compute_instance_template" "template" {
 func testAccComputeInstanceTemplate_sourceImageEncryptionKey_RawKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4532,7 +4532,7 @@ resource "google_compute_instance_template" "template" {
 func testAccComputeInstanceTemplate_sourceImageEncryptionKey_RsaKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4575,7 +4575,7 @@ resource "google_compute_instance_template" "template" {
 func testAccComputeInstanceTemplate_soleTenantInstanceTemplate(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4625,7 +4625,7 @@ resource "google_compute_resource_policy" "foo" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4668,7 +4668,7 @@ resource "google_compute_resource_policy" "foo" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4703,7 +4703,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate_nonSpecificReservation(templateName, consumeReservationType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4732,7 +4732,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate_specificReservation(templateName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5128,7 +5128,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_imageResourceTest(diskName string, imageName string, imageDescription string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -5161,7 +5161,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_diskResourcePolicies(suffix string, policyName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 resource "google_compute_instance_template" "foobar" {
@@ -5245,7 +5245,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_queueCount(instanceTemplateName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -5272,7 +5272,7 @@ data "google_compute_default_service_account" "default" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5349,7 +5349,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_flexStart(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5402,7 +5402,7 @@ resource "google_compute_instance_template" "foobar" {
   tags           = ["foo", "bar"]
 
   disk {
-    source_image = "debian-cloud/debian-11"
+    source_image = "debian-cloud/debian-13"
     auto_delete  = true
     boot         = true
   }
@@ -5441,7 +5441,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_provisioningModelEmptyString(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5471,7 +5471,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_spot(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5512,7 +5512,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_spot_maxRunDuration(suffix string, instanceTerminationAction string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5558,7 +5558,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_maxRunDuration_onInstanceStopAction(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5606,7 +5606,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_onInstanceStopAction_terminationTime(suffix string, terminationTime string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5646,7 +5646,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_localSsdRecoveryTimeout(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5689,7 +5689,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_partnerMetadata(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5753,7 +5753,7 @@ resource "google_kms_crypto_key_iam_member" "crypto_key" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5828,7 +5828,7 @@ resource "google_kms_crypto_key_iam_member" "crypto_key" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5885,7 +5885,7 @@ resource "google_tags_tag_value" "value" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5918,7 +5918,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_network_attachment(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5953,7 +5953,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_gracefulShutdown(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -6001,7 +6001,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_schedulingSkipGuestOSShutdown(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -6043,7 +6043,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_schedulingPreemptionNoticeDuration(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -6090,7 +6090,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_keyRevocationActionType(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -6117,7 +6117,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_GuestOsFeatures(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -6144,7 +6144,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_workloadIdentity(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -6214,7 +6214,7 @@ resource "google_compute_instance_template" "foobar" {
   machine_type = "e2-medium"
 
   disk {
-    source_image = "debian-cloud/debian-11"
+    source_image = "debian-cloud/debian-13"
     auto_delete  = true
     boot         = true
   }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -5703,7 +5703,7 @@ func TestAccComputeInstance_guestOsFeatures(t *testing.T) {
 	var instance map[string]interface{}
 	context_1 := map[string]interface{}{
 		"instance_name":     fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
-		"guest_os_features": `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF"]`,
+		"guest_os_features": `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "SEV_LIVE_MIGRATABLE_V2", "IDPF"]`,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -5717,7 +5717,10 @@ func TestAccComputeInstance_guestOsFeatures(t *testing.T) {
 					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.0", "UEFI_COMPATIBLE"),
 					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.1", "VIRTIO_SCSI_MULTIQUEUE"),
 					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.2", "GVNIC"),
-					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.3", "IDPF"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.3", "SEV_CAPABLE"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.4", "SEV_SNP_CAPABLE"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.5", "SEV_LIVE_MIGRATABLE_V2"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.6", "IDPF"),
 				),
 			},
 		},
@@ -9998,16 +10001,25 @@ resource "google_compute_image" "foobar" {
   name              = "%s"
   source_disk       = google_compute_disk.foobar.self_link
   guest_os_features {
-    type = "GVNIC"
+    type = "UEFI_COMPATIBLE"
   }
   guest_os_features {
     type = "VIRTIO_SCSI_MULTIQUEUE"
   }
   guest_os_features {
-    type = "UEFI_COMPATIBLE"
+    type = "GVNIC"
   }
   guest_os_features {
     type = "SEV_CAPABLE"
+  }
+  guest_os_features {
+    type = "SEV_SNP_CAPABLE"
+  }
+  guest_os_features {
+    type = "SEV_LIVE_MIGRATABLE_V2"
+  }
+  guest_os_features {
+    type = "IDPF"
   }
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -5347,7 +5347,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithoutAccessConfig(t *testi
 func testAccComputeInstance_GracefulShutdownUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 resource "google_compute_instance" "foobar" {
@@ -5383,7 +5383,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_schedulingSkipGuestOSShutdown(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5412,7 +5412,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_schedulingSkipGuestOSShutdownUpdated(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5441,7 +5441,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_preemptionNoticeDuration(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family    = "debian-11"
+  family    = "debian-13"
   project   = "debian-cloud"
 }
 
@@ -5862,7 +5862,7 @@ resource "google_compute_instance" "foobar" {
 
 	boot_disk {
 		initialize_params {
-			image = "debian-cloud/debian-11"
+			image = "debian-cloud/debian-13"
 		}
 	}
 
@@ -7020,7 +7020,7 @@ func testAccCheckComputeInstanceNicAccessConfigHasNoSecurityPolicy(instance *map
 func testAccComputeInstance_basic(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7060,7 +7060,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic2(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7090,7 +7090,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic3(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7121,7 +7121,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic4(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7151,7 +7151,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic5(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7181,7 +7181,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_metadataGceContainerDeclaration(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7213,7 +7213,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_machineType(instance string, machineType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7239,7 +7239,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_description(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7265,7 +7265,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_descriptionUpdate(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7303,7 +7303,7 @@ resource "google_tags_tag_value" "value" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7361,7 +7361,7 @@ resource "google_tags_tag_value" "value_new" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7396,7 +7396,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_diskResourcePoliciesOnePolicy(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7446,7 +7446,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_diskResourcePoliciesOnePolicyUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7496,7 +7496,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_diskResourcePoliciesTwoPolicies(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7546,7 +7546,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_diskResourcePoliciesAttachment(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7601,7 +7601,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic_deletionProtectionFalse(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7628,7 +7628,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_basic_deletionProtectionTrue(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7657,7 +7657,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_forceNewAndChangeMetadata(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7690,7 +7690,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_update(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7728,7 +7728,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_ip(ip, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7765,7 +7765,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_ipv6(ip, instance, record string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -7844,7 +7844,7 @@ resource "google_compute_instance" "test" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -7860,7 +7860,7 @@ resource "google_compute_instance" "test" {
 func testAccComputeInstance_internalIpv6(ip, instance string) string {
 	return fmt.Sprintf(`
   data "google_compute_image" "my_image" {
-    family  = "debian-11"
+    family  = "debian-13"
     project = "debian-cloud"
   }
 
@@ -7941,7 +7941,7 @@ resource "google_compute_instance" "foobar" {
   boot_disk {
     auto_delete = false
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {
@@ -7969,7 +7969,7 @@ resource "google_compute_address" "ipv6-address" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8018,7 +8018,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_PTRRecord(record, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8051,7 +8051,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_networkTier(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8084,7 +8084,7 @@ func testAccComputeInstance_disks_encryption(bootEncryptionKey string, diskNameT
 	sort.Strings(diskNames)
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8184,7 +8184,7 @@ func testAccComputeInstance_disks_encryption_restart(bootEncryptionKey string, d
 	}
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8238,7 +8238,7 @@ func testAccComputeInstance_disks_encryption_restartUpdate(bootEncryptionKey str
 	}
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8293,7 +8293,7 @@ func testAccComputeInstance_disks_kms(bootEncryptionKey string, diskNameToEncryp
 	sort.Strings(diskNames)
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8386,7 +8386,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_instanceSchedule(instance, schedule string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8425,7 +8425,7 @@ resource "google_compute_resource_policy" "instance_schedule" {
 func testAccComputeInstance_addResourcePolicy(instance, schedule string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8466,7 +8466,7 @@ resource "google_compute_resource_policy" "instance_schedule" {
 func testAccComputeInstance_updateResourcePolicy(instance, schedule1, schedule2 string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8521,7 +8521,7 @@ resource "google_compute_resource_policy" "instance_schedule2" {
 func testAccComputeInstance_removeResourcePolicy(instance, schedule1, schedule2 string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8576,7 +8576,7 @@ resource "google_compute_resource_policy" "instance_schedule2" {
 func testAccComputeInstance_bootDiskUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8605,7 +8605,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8641,7 +8641,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk_sourceUrl(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8677,7 +8677,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk_modeRo(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8714,7 +8714,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_addAttachedDisk(disk, disk2, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8761,7 +8761,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_detachDisk(disk, disk2, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8804,7 +8804,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_updateAttachedDiskEncryptionKey(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8844,7 +8844,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk_forceAttach(disk, instance string, force_attach bool) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8895,7 +8895,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_attachedDisk_forceAttach_zonal(disk, instance string, force_attach bool) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8944,7 +8944,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_source(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -8973,7 +8973,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_sourceUrl(disk, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9002,7 +9002,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_type(instance string, diskType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9028,7 +9028,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_mode(instance string, diskMode string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9056,7 +9056,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_forceAttach_zonal(disk, instance string, force_attach bool) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9086,7 +9086,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_bootDisk_forceAttach(instance string, force_attach bool) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9112,7 +9112,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_with375GbScratchDisk(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9155,7 +9155,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_with18TbScratchDisk(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9209,7 +9209,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_serviceAccount(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9242,7 +9242,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_noServiceAccount(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9273,7 +9273,7 @@ func testAccComputeInstance_serviceAccountEmail_0scopes(instance string) string 
 data "google_project" "project" {}
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9306,7 +9306,7 @@ data "google_compute_default_service_account" "default" {
 func testAccComputeInstance_serviceAccount_update0(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9332,7 +9332,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_serviceAccount_update01(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9365,7 +9365,7 @@ data "google_compute_default_service_account" "default" {
 func testAccComputeInstance_serviceAccount_update02(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9399,7 +9399,7 @@ data "google_compute_default_service_account" "default" {
 func testAccComputeInstance_serviceAccount_update3(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9434,7 +9434,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_serviceAccount_update4(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 resource "google_compute_instance" "foobar" {
@@ -9462,7 +9462,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_scheduling(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9491,7 +9491,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_schedulingUpdated(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9521,7 +9521,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_TerminationTime(instance string, terminationTime string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9555,7 +9555,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_TerminationTimeDeleted(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9708,7 +9708,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_subnet_auto(suffix, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9741,7 +9741,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_subnet_custom(suffix, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9781,7 +9781,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_subnet_xpn(org, billingId, projectName, instance, suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9866,7 +9866,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_networkIPAuto(suffix, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9904,7 +9904,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_network_ip_custom(suffix, instance, ipAddress string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9943,7 +9943,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_private_image_family(disk, family, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -9984,7 +9984,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_networkPerformanceConfig(disk string, image string, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10039,7 +10039,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_multiNic(instance, network, subnetwork string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10121,7 +10121,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_guestAccelerator(instance string, count uint8) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10156,7 +10156,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_minCpuPlatform(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10184,7 +10184,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_minCpuPlatform_remove(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10212,7 +10212,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_primaryAliasIpRange(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10241,7 +10241,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_secondaryAliasIpRange(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10296,7 +10296,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_aliasIpv6Range_noAlias(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10341,7 +10341,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_aliasIpv6Range(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10392,7 +10392,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_secondaryAliasIpRangeUpdate(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10439,7 +10439,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_secondaryAliasIpRangeTwoAliasIps(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10491,7 +10491,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_secondaryAliasIpRangeUpdateWithCommonAddress(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10543,7 +10543,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_secondaryAliasIpRangeUpdateWithCommonAddressDifferentRanges(network, subnet, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10595,7 +10595,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_hostname(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10623,7 +10623,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_stopInstanceToUpdate(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10660,7 +10660,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_stopInstanceToUpdate2(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10696,7 +10696,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_stopInstanceToUpdate3(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10723,7 +10723,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_withoutNodeAffinities(instance, nodeTemplate, nodeGroup string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10770,7 +10770,7 @@ resource "google_compute_node_group" "nodes" {
 func testAccComputeInstance_soleTenantNodeAffinities(instance, nodeTemplate, nodeGroup string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10839,7 +10839,7 @@ resource "google_compute_node_group" "nodes" {
 func testAccComputeInstance_soleTenantNodeAffinitiesUpdated(instance, nodeTemplate, nodeGroup string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10908,7 +10908,7 @@ resource "google_compute_node_group" "nodes" {
 func testAccComputeInstance_soleTenantNodeAffinitiesReduced(instance, nodeTemplate, nodeGroup string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10971,7 +10971,7 @@ resource "google_compute_node_group" "nodes" {
 func testAccComputeInstance_reservationAffinity_nonSpecificReservationConfig(instanceName, reservationType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -10999,7 +10999,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_reservationAffinity_specificReservationConfig(instanceName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -11325,7 +11325,7 @@ provider "google" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -11361,7 +11361,7 @@ provider "google" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -11527,7 +11527,7 @@ func testAccComputeInstance_machineType_desiredStatus_allowStoppingForUpdate(
 
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -11561,7 +11561,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_desiredStatus_suspended(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -11588,7 +11588,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_desiredStatusTerminatedUpdate(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -11624,7 +11624,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_desiredStatusOnCreation(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -11651,7 +11651,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_resourcePolicyCollocate(instance, suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -11723,7 +11723,7 @@ resource "google_compute_resource_policy" "foo" {
 func testAccComputeInstance_resourcePolicySpread(instance, suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -11766,7 +11766,7 @@ resource "google_compute_resource_policy" "foo" {
 func testAccComputeInstance_subnetworkUpdate(suffix, instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		family  = "debian-11"
+		family  = "debian-13"
 		project = "debian-cloud"
 	}
 
@@ -11844,7 +11844,7 @@ func testAccComputeInstance_subnetworkUpdate(suffix, instance string) string {
 func testAccComputeInstance_subnetworkUpdateTwo(suffix, instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		family  = "debian-11"
+		family  = "debian-13"
 		project = "debian-cloud"
 	}
 
@@ -11918,7 +11918,7 @@ func testAccComputeInstance_subnetworkUpdateTwo(suffix, instance string) string 
 func testAccComputeInstance_subnetworkProjectExpectError(suffix, instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		family  = "debian-11"
+		family  = "debian-13"
 		project = "debian-cloud"
 	}
 
@@ -11957,7 +11957,7 @@ func testAccComputeInstance_subnetworkProjectExpectError(suffix, instance string
 func testAccComputeInstance_networkIpUpdate(suffix, instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		family  = "debian-11"
+		family  = "debian-13"
 		project = "debian-cloud"
 	}
 
@@ -12003,7 +12003,7 @@ func testAccComputeInstance_networkIpUpdate(suffix, instance string) string {
 func testAccComputeInstance_networkIpUpdateByHand(suffix, instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		family  = "debian-11"
+		family  = "debian-13"
 		project = "debian-cloud"
 	}
 
@@ -12049,7 +12049,7 @@ func testAccComputeInstance_networkIpUpdateByHand(suffix, instance string) strin
 func testAccComputeInstance_networkIpUpdateWithComputeAddress(suffix, instance string) string {
 	return fmt.Sprintf(`
 	data "google_compute_image" "my_image" {
-		family  = "debian-11"
+		family  = "debian-13"
 		project = "debian-cloud"
 	}
 
@@ -12095,7 +12095,7 @@ func testAccComputeInstance_networkIpUpdateWithComputeAddress(suffix, instance s
 func testAccComputeInstance_queueCountSet(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -12207,7 +12207,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_provisioningModelEmptyString(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family    = "debian-11"
+  family    = "debian-13"
   project   = "debian-cloud"
 }
 
@@ -12346,7 +12346,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -12513,7 +12513,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_metadataStartupScript(instance, machineType, metadata string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -12545,7 +12545,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_metadataStartupScript_gracefulSwitch(instance, machineType, metadata string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -12605,7 +12605,7 @@ resource "google_compute_network" "vpc_network" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -12628,7 +12628,7 @@ resource "google_compute_disk" "debian" {
 func testAccComputeInstance_nic_securityPolicyCreateWithOneNicAndTwoAccessConfigs(suffix, policy, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -12730,7 +12730,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsWithTwoSecurityPoliciesAndStatus(suffix, policy, instance, policyToSetOne, desiredStatus string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -12807,7 +12807,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(suffix, policy, policy2, instance, policyToSetOne, policyToSetTwo string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -12979,7 +12979,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPoliciesRemoveAccessConfig(suffix, policy, policy2, instance, policyToSetOne, policyToSetTwo string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -13145,7 +13145,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndAccessConfigsWithEmptyAndNullSecurityPolicies(suffix, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -13217,7 +13217,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsUpdateAccessConfig(suffix, policy, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -13325,7 +13325,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsRemoveAccessConfig(suffix, policy, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -13426,7 +13426,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_networkAttachment(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -13482,7 +13482,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_networkAttachmentUpdate(networkAttachment, region, suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -13562,7 +13562,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_nicStackTypeUpdate(suffix, region, stack_type, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -13760,7 +13760,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_autoDeleteUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -13786,7 +13786,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_keyRevocationActionType(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -13813,7 +13813,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_guestOsFeatures(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -13840,7 +13840,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_igmpQuery_v2(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -13879,7 +13879,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_nicStackTypeUpdate_ipv6(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -13925,7 +13925,7 @@ func testAccComputeInstance_instanceEncryption_SelfLinkServiceAccount(context ma
 data "google_compute_default_service_account" "default" {}
 
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -13955,7 +13955,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_snapshot_init(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -13986,7 +13986,7 @@ resource "google_compute_snapshot" "foobar" {
 func testAccComputeInstance_snapshot(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -14047,7 +14047,7 @@ resource "google_compute_disk" "zonal" {
   name    = "%{disk_name}"
   type    = "pd-ssd"
   zone    = "us-central1-a"
-  image   = "debian-cloud/debian-11"
+  image   = "debian-cloud/debian-13"
   size    = 50
 }
 
@@ -14082,7 +14082,7 @@ resource "google_compute_instance" "instance" {
 func testAccComputeInstance_snapshotEncryption_KMS(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -14138,7 +14138,7 @@ data "google_compute_default_service_account" "default" {
 func testAccComputeInstance_snapshotEncryption_RawKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -14194,7 +14194,7 @@ resource "google_compute_instance" "foobar2" {
 func testAccComputeInstance_snapshotEncryption_RsaKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -14251,7 +14251,7 @@ resource "google_compute_instance" "foobar2" {
 func testAccComputeInstance_imageEncryption_KMS(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -14298,7 +14298,7 @@ data "google_compute_default_service_account" "default" {
 func testAccComputeInstance_imageEncryption_RawKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -14341,7 +14341,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_imageEncryption_RsaKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -14384,7 +14384,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_rsaBootDiskEncryption(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -14415,7 +14415,7 @@ data "google_compute_default_service_account" "default" {
 func testAccComputeInstance_attachedDisk_RSAencryption(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -14460,7 +14460,7 @@ data "google_compute_default_service_account" "default" {
 func testAccComputeInstance_workloadIdentity(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -14506,7 +14506,7 @@ resource "google_compute_instance" "foobar" {
 func testAccComputeInstance_noWorkloadIdentity(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_endpoint_test.go.tmpl
@@ -178,7 +178,7 @@ resource "google_compute_instance" "default" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_endpoints_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_endpoints_test.go.tmpl
@@ -231,7 +231,7 @@ resource "google_compute_instance" "default" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_packet_mirroring_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_packet_mirroring_test.go
@@ -68,7 +68,7 @@ resource "google_compute_instance" "mirror" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -159,7 +159,7 @@ resource "google_compute_instance" "mirror" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_per_instance_config_test.go
@@ -344,7 +344,7 @@ resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
   zone  = google_compute_instance_group_manager.igm.zone
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   physical_block_size_bytes = 4096
 }
 
@@ -361,7 +361,7 @@ resource "google_compute_disk" "disk2" {
 func testAccComputePerInstanceConfig_igm(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -470,7 +470,7 @@ resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
   zone  = google_compute_instance_group_manager.igm.zone
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   physical_block_size_bytes = 4096
 }
 
@@ -573,7 +573,7 @@ resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
   zone  = google_compute_instance_group_manager.igm.zone
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   physical_block_size_bytes = 4096
 }
 `, context) + testAccComputePerInstanceConfig_igm(context)
@@ -648,7 +648,7 @@ resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
   zone  = google_compute_instance_group_manager.igm.zone
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   physical_block_size_bytes = 4096
 }
 `, context) + testAccComputePerInstanceConfig_igm(context)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_autoscaler_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_autoscaler_test.go.tmpl
@@ -118,7 +118,7 @@ func TestAccComputeRegionAutoscaler_scaleInControl(t *testing.T) {
 func testAccComputeRegionAutoscaler_scaffolding(itName, tpName, igmName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -721,7 +721,7 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -804,7 +804,7 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -838,7 +838,7 @@ resource "google_compute_instance" "instance2" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -1255,7 +1255,7 @@ resource "google_compute_instance_group" "group" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1394,7 +1394,7 @@ func testAccComputeRegionBackendService_withBackend(
 	serviceName, igName, itName, checkName string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1464,7 +1464,7 @@ func testAccComputeRegionBackendService_withBackendMultiNic(
         serviceName, net1Name, net2Name, igName, itName, checkName string, timeout int64) string {
         return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1566,7 +1566,7 @@ func testAccComputeRegionBackendService_withInvalidInternalBackend(
   serviceName, igName, itName, checkName string) string {
   return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1650,7 +1650,7 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 data "google_compute_image" "debian_image" {
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 
@@ -1923,7 +1923,7 @@ func testAccComputeRegionBackendService_withMaxInFlightRequests(
 	serviceName, igName, itName, checkName string, maxInFlight int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1986,7 +1986,7 @@ func testAccComputeRegionBackendService_withMaxInFlightRequestsPerInstance(
 	serviceName, igName, itName, checkName string, maxPerInstance int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2082,7 +2082,7 @@ resource "google_compute_region_backend_service" "lipsum" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2145,7 +2145,7 @@ func testAccComputeRegionBackendService_withTrafficDuration(
 	serviceName, igName, itName, checkName, duration string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2390,7 +2390,7 @@ resource "google_compute_instance_template" "default" {
   machine_type = "e2-micro"
 
   disk {
-    source_image = "debian-cloud/debian-11"
+    source_image = "debian-cloud/debian-13"
     auto_delete  = true
     boot         = true
   }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
@@ -585,7 +585,7 @@ func testAccComputeRegionDisk_hyperdisk(diskName, refSelector string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "disk" {
 	name  = "%s"
-	image = "debian-cloud/debian-11"
+	image = "debian-cloud/debian-13"
 	size  = 50
 	type  = "pd-ssd"
 	zone  = "us-central1-a"
@@ -615,7 +615,7 @@ func testAccComputeRegionDisk_hyperdiskUpdated(diskName, refSelector string) str
 	return fmt.Sprintf(`
 resource "google_compute_disk" "disk" {
 	name  = "%s"
-	image = "debian-cloud/debian-11"
+	image = "debian-cloud/debian-13"
 	size  = 50
 	type  = "pd-ssd"
 	zone  = "us-central1-a"
@@ -647,7 +647,7 @@ func testAccComputeRegionDisk_basic(diskName, refSelector string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "disk" {
   name  = "%s"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   size  = 50
   type  = "pd-ssd"
   zone  = "us-central1-a"
@@ -672,7 +672,7 @@ func testAccComputeRegionDisk_basicUpdated(diskName, refSelector string) string 
 	return fmt.Sprintf(`
 resource "google_compute_disk" "disk" {
   name  = "%s"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   size  = 50
   type  = "pd-ssd"
   zone  = "us-central1-a"
@@ -705,7 +705,7 @@ func testAccComputeRegionDisk_encryption(diskName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "disk" {
   name  = "%s"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   size  = 50
   type  = "pd-ssd"
   zone  = "us-central1-a"
@@ -736,7 +736,7 @@ func testAccComputeRegionDisk_deleteDetach(instanceName, diskName, regionDiskNam
 	return fmt.Sprintf(`
 resource "google_compute_disk" "disk" {
   name  = "%s"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   size  = 50
   type  = "pd-ssd"
   zone  = "us-central1-a"
@@ -763,7 +763,7 @@ resource "google_compute_instance" "inst" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -792,7 +792,7 @@ func testAccComputeRegionDisk_diskClone(diskName, refSelector string) string {
 	  
 	  resource "google_compute_disk" "disk" {
 		name  = "%s"
-		image = "debian-11-bullseye-v20220719"
+		image = "debian-13-trixie-v20260827"
 		size  = 50
 		type  = "pd-ssd"
 		zone  = "us-central1-a"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
@@ -627,7 +627,7 @@ func testAccCheckRegionInstanceGroupManagerDestroyProducer(t *testing.T) func(s 
 func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -692,7 +692,7 @@ resource "google_compute_region_instance_group_manager" "igm-no-tp" {
 func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -735,7 +735,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_update(template, target, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -807,7 +807,7 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
 func testAccRegionInstanceGroupManager_update2(template1, target1, target2, template2, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -921,7 +921,7 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
 func testAccRegionInstanceGroupManager_update3(template1, target1, target2, template2, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1007,7 +1007,7 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
 func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1058,7 +1058,7 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
 func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1115,7 +1115,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic-2" {
 func testAccRegionInstanceGroupManager_autoHealingPolicies(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1173,7 +1173,7 @@ resource "google_compute_http_health_check" "zero" {
 func testAccRegionInstanceGroupManager_autoHealingPoliciesRemoved(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1227,7 +1227,7 @@ resource "google_compute_http_health_check" "zero" {
 func testAccRegionInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1295,7 +1295,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_distributionPolicyEmpty(template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1341,7 +1341,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1388,7 +1388,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_distributionPolicyUpdate(template, igm string, zones []string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1436,7 +1436,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1494,7 +1494,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 func testAccRegionInstanceGroupManager_rollingUpdatePolicySetToDefault(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1553,7 +1553,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1606,7 +1606,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy3(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1664,7 +1664,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 func testAccRegionInstanceGroupManager_stateful(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 resource "google_compute_network" "igm-basic" {
@@ -1738,7 +1738,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_statefulUpdate(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 resource "google_compute_network" "igm-basic" {
@@ -1812,7 +1812,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_statefulRemoved(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 resource "google_compute_network" "igm-basic" {
@@ -1869,7 +1869,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_statefulUnordered(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -1956,7 +1956,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_stoppedSuspendedTargetSize(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2011,7 +2011,7 @@ resource "google_compute_region_instance_group_manager" "sr-igm" {
 func testAccRegionInstanceGroupManager_stoppedSuspendedTargetSizeUpdate(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2065,7 +2065,7 @@ resource "google_compute_region_instance_group_manager" "sr-igm" {
 func testAccRegionInstanceGroupManager_instanceFlexibilityPolicy(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -2126,7 +2126,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_instanceFlexibilityPolicyUpdate(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -2185,7 +2185,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_instanceFlexibilityPolicyUpdateToEmptyBlock(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -2236,7 +2236,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 func testAccRegionInstanceGroupManager_instanceFlexibilityPolicyRemove(network, template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -2287,7 +2287,7 @@ func testAccRegionInstanceGroupManager_instanceFlexibilityPolicyAdditionalOverri
 	return acctest.Nprintf(`
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2408,7 +2408,7 @@ func testAccRegionInstanceGroupManager_instanceFlexibilityPolicyAdditionalOverri
 	return acctest.Nprintf(`
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2540,7 +2540,7 @@ func testAccRegionInstanceGroupManager_instanceFlexibilityPolicyAdditionalOverri
 	return acctest.Nprintf(`
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2631,7 +2631,7 @@ func TestAccRegionInstanceGroupManager_targetSizePolicy(t *testing.T) {
 func testAccRegionInstanceGroupManager_targetSizePolicy(template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2702,7 +2702,7 @@ resource "google_compute_region_instance_group_manager" "igm-tsp" {
 func testAccRegionInstanceGroupManager_resourceManagerTags(template_name, tag_name, igm_name, project_id string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2800,7 +2800,7 @@ func TestAccRegionInstanceGroupManager_resourcePoliciesWorkloadPolicyUpdate(t *t
 func testAccRegionInstanceGroupManager_resourcePoliciesWorkloadPolicyUpdate(suffix, workloadPolicy string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2894,7 +2894,7 @@ resource "google_compute_region_instance_group_manager" "igm-workload-policy" {
 func testAccRegionInstanceGroupManager_resourcePoliciesWorkloadPolicyUpdate2(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -2003,7 +2003,7 @@ func TestAccComputeRegionInstanceTemplate_networkAttachment(t *testing.T) {
 func testAccComputeRegionInstanceTemplate_networkAttachment(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2060,7 +2060,7 @@ func TestAccComputeRegionInstanceTemplate_dynamicNic(t *testing.T) {
 func testAccComputeRegionInstanceTemplate_dynamicNic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2195,7 +2195,7 @@ resource "google_compute_storage_pool" "example" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2871,7 +2871,7 @@ func testAccCheckComputeRegionInstanceTemplateHasDiskResourcePolicy(instanceTemp
 func testAccComputeRegionInstanceTemplate_basic(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -2915,7 +2915,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_hostErrorTimeoutSeconds(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3024,7 +3024,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_metadataGceContainerDeclaration(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3069,7 +3069,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_preemptible(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3113,7 +3113,7 @@ resource "google_compute_address" "foo" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3148,7 +3148,7 @@ resource "google_compute_address" "foo" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3197,7 +3197,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_networkTier(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3223,7 +3223,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_networkIP(suffix, networkIP string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3252,7 +3252,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_networkIPAddress(suffix, ipAddress string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3281,7 +3281,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_disksInvalid(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3420,7 +3420,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_regionDisks(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3464,7 +3464,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_diskIops(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3491,7 +3491,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_diskIopsThroughput(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3520,7 +3520,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_subnet_auto(network, suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3567,7 +3567,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3660,7 +3660,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3692,7 +3692,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_startup_script(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3724,7 +3724,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_primaryAliasIpRange(i string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3772,7 +3772,7 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3813,7 +3813,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_maintenance_interval(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3860,7 +3860,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_guestAccelerator(i string, count uint8) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3896,7 +3896,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_minCpuPlatform(i string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3929,7 +3929,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_soleTenantInstanceTemplate(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -3979,7 +3979,7 @@ resource "google_compute_resource_policy" "foo" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4023,7 +4023,7 @@ resource "google_compute_resource_policy" "foo" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4058,7 +4058,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_reservationAffinityInstanceTemplate_nonSpecificReservation(templateName, consumeReservationType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4088,7 +4088,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_reservationAffinityInstanceTemplate_specificReservation(templateName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4499,7 +4499,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_imageResourceTest(diskName string, imageName string, imageDescription string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -4533,7 +4533,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_diskResourcePolicies(suffix string, policyName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 resource "google_compute_region_instance_template" "foobar" {
@@ -4619,7 +4619,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_queueCount(instanceTemplateName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 
@@ -4647,7 +4647,7 @@ data "google_compute_default_service_account" "default" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4725,7 +4725,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_flexStart(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4780,7 +4780,7 @@ resource "google_compute_region_instance_template" "foobar" {
   tags           = ["foo", "bar"]
 
   disk {
-    source_image = "debian-cloud/debian-11"
+    source_image = "debian-cloud/debian-13"
     auto_delete  = true
     boot         = true
   }
@@ -4819,7 +4819,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_provisioningModelEmptyString(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4850,7 +4850,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_spot(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4892,7 +4892,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_spot_maxRunDuration(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4938,7 +4938,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_maxRunDuration_onInstanceStopAction(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -4987,7 +4987,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_onInstanceStopAction_terminationTime(suffix string, terminationTime string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5027,7 +5027,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_localSsdRecoveryTimeout(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5070,7 +5070,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionalInstanceTemplate_partnerMetadata(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5135,7 +5135,7 @@ resource "google_kms_crypto_key_iam_member" "crypto_key" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5211,7 +5211,7 @@ resource "google_kms_crypto_key_iam_member" "crypto_key" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5270,7 +5270,7 @@ resource "google_tags_tag_value" "value" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5304,7 +5304,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_keyRevocationActionType(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5332,7 +5332,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_sourceImageEncryptionKey_RawKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5376,7 +5376,7 @@ resource "google_compute_region_instance_template" "template" {
 func testAccComputeRegionInstanceTemplate_sourceImageEncryptionKey_RsaKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5420,7 +5420,7 @@ resource "google_compute_region_instance_template" "template" {
 func testAccComputeRegionInstanceTemplate_sourceSnapshotEncryptionKey_RawKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5474,7 +5474,7 @@ resource "google_compute_region_instance_template" "template" {
 func testAccComputeRegionInstanceTemplate_sourceSnapshotEncryptionKey_RsaKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5528,7 +5528,7 @@ resource "google_compute_region_instance_template" "template" {
 func testAccComputeRegionInstanceTemplate_diskEncryptionKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5561,7 +5561,7 @@ data "google_compute_default_service_account" "default" {
 func testAccComputeRegionInstanceTemplate_GuestOsFeatures(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5590,7 +5590,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_gracefulShutdown(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5629,7 +5629,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_schedulingSkipGuestOSShutdown(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5658,7 +5658,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_schedulingPreemptionNoticeDuration(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -5727,7 +5727,7 @@ resource "google_compute_region_instance_template" "foobar" {
   region       = "us-central1"
 
   disk {
-    source_image = "debian-cloud/debian-11"
+    source_image = "debian-cloud/debian-13"
     auto_delete  = true
     boot         = true
   }
@@ -5747,7 +5747,7 @@ resource "google_compute_region_instance_template" "foobar" {
 func testAccComputeRegionInstanceTemplate_workloadIdentity(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_network_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_network_endpoint_test.go.tmpl
@@ -211,7 +211,7 @@ resource "google_compute_region_network_endpoint_group" default {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
   provider           = google-beta
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_per_instance_config_test.go
@@ -343,7 +343,7 @@ resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
   zone  = "us-central1-c"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   physical_block_size_bytes = 4096
 }
 
@@ -360,7 +360,7 @@ resource "google_compute_disk" "disk2" {
 func testAccComputeRegionPerInstanceConfig_rigm(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -478,7 +478,7 @@ resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
   zone  = "us-central1-c"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   physical_block_size_bytes = 4096
 }
 
@@ -582,7 +582,7 @@ resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
   zone  = "us-central1-c"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   physical_block_size_bytes = 4096
 }
 `, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
@@ -658,7 +658,7 @@ resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
   zone  = "us-central1-c"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   physical_block_size_bytes = 4096
 }
 `, context) + testAccComputeRegionPerInstanceConfig_rigm(context)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_resource_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_resource_policy_test.go.tmpl
@@ -122,7 +122,7 @@ func TestAccComputeResourcePolicy_guestFlushEmptyValue(t *testing.T) {
 func testAccComputeResourcePolicy_attached(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_route_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_route_test.go
@@ -116,7 +116,7 @@ resource "google_compute_route" "foobar" {
 func testAccComputeRoute_hopInstance(instanceName, zone, suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.tmpl
@@ -1360,7 +1360,7 @@ resource "google_compute_instance" "foobar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer_test.go.tmpl
@@ -83,7 +83,7 @@ resource "google_compute_instance" "instance" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_snapshot_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_snapshot_test.go
@@ -66,7 +66,7 @@ func TestAccComputeSnapshot_encryptionCMEK(t *testing.T) {
 func testAccComputeSnapshot_encryption(snapshotName string, diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -194,7 +194,7 @@ resource "google_compute_snapshot" "snapshot" {
 }
 
 data "google_compute_image" "debian" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -242,7 +242,7 @@ resource "google_tags_tag_value" "tag_value" {
 }
 
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
@@ -1488,7 +1488,7 @@ resource "google_compute_instance" "vm" {
   zone         = "us-central1-a"
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {
@@ -1543,7 +1543,7 @@ resource "google_compute_instance" "vm" {
   zone         = "us-central1-a"
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {
@@ -1734,7 +1734,7 @@ resource "google_compute_instance" "vm" {
   zone         = "us-central1-a"
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_instance_test.go.tmpl
@@ -85,7 +85,7 @@ resource "google_compute_subnetwork" "default" {
 
 data "google_compute_image" "vmimage" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_pool_test.go.tmpl
@@ -223,7 +223,7 @@ func testAccCheckComputeTargetPoolHealthCheck(targetPool, healthCheck string) re
 func testAccComputeTargetPool_basic(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
-  family  = "debian-11"
+  family  = "debian-13"
   project = "debian-cloud"
 }
 
@@ -283,7 +283,7 @@ resource "google_compute_instance" "foo" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 
@@ -299,7 +299,7 @@ resource "google_compute_instance" "bar" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
 

--- a/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
@@ -418,7 +418,7 @@ resource "google_compute_instance" "default" {
 	zone         = "us-central1-a"
 	boot_disk {
 		initialize_params {
-			image = "debian-11-bullseye-v20241009"
+			image = "debian-13-trixie-v20260827"
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/networkmanagement/data_source_network_management_connectivity_test_run_test.go
+++ b/mmv1/third_party/terraform/services/networkmanagement/data_source_network_management_connectivity_test_run_test.go
@@ -108,7 +108,7 @@ resource "google_compute_subnetwork" "subnet" {
 }	
 
 data "google_compute_image" "debian_11" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/networkmanagement/resource_network_management_connectivity_test_resource_test.go
+++ b/mmv1/third_party/terraform/services/networkmanagement/resource_network_management_connectivity_test_resource_test.go
@@ -135,7 +135,7 @@ resource "google_compute_subnetwork" "subnet" {
 }	
 
 data "google_compute_image" "debian_9" {
-	family  = "debian-11"
+	family  = "debian-13"
 	project = "debian-cloud"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/tags/resource_tags_tag_binding_collection_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/tags/resource_tags_tag_binding_collection_test.go.tmpl
@@ -623,7 +623,7 @@ func testAccTagsTagBindingCollection_oob_config(context map[string]interface{}) 
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 
@@ -1109,7 +1109,7 @@ func testAccTagsTagBindingCollection_restorationConfig(context map[string]interf
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 
@@ -1211,7 +1211,7 @@ func testAccTagsTagBindingCollection_regional_basic(context map[string]interface
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 
@@ -1302,7 +1302,7 @@ func testAccTagsTagBindingCollection_forceNewConfig1(context map[string]interfac
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 
@@ -1364,7 +1364,7 @@ func testAccTagsTagBindingCollection_forceNewConfig2(context map[string]interfac
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 
@@ -1452,7 +1452,7 @@ func testAccTagsTagBindingCollection_regionalMismatchConfig(context map[string]i
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 
@@ -1708,7 +1708,7 @@ func testAccTagsTagBindingCollection_nonAuthoritativeConfig(context map[string]i
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
   provider = google-beta
-  family   = "debian-11"
+  family   = "debian-13"
   project  = "debian-cloud"
 }
 

--- a/mmv1/third_party/terraform/services/tags/resource_tags_test.go
+++ b/mmv1/third_party/terraform/services/tags/resource_tags_test.go
@@ -1471,7 +1471,7 @@ resource "google_compute_instance" "default" {
 	zone         = "us-central1-a"
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {
@@ -1532,7 +1532,7 @@ resource "google_compute_instance" "default" {
 	zone         = "us-central1-a"
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {
@@ -1599,7 +1599,7 @@ resource "google_compute_instance" "default" {
 	zone         = "us-central1-a"
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-11"
+      image = "debian-cloud/debian-13"
     }
   }
   network_interface {

--- a/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.tmpl
@@ -95,7 +95,7 @@ resource "google_compute_disk" "disk" {
   provider = google-beta
 
   name  = "tf-test-tpu-disk-%{random_suffix}"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   size  = 10
   type  = "pd-ssd"
   zone  = "us-central1-c"
@@ -150,7 +150,7 @@ resource "google_compute_disk" "disk" {
   provider = google-beta
 
   name  = "tf-test-tpu-disk-%{random_suffix}"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   size  = 10
   type  = "pd-ssd"
   zone  = "us-central1-c"
@@ -160,7 +160,7 @@ resource "google_compute_disk" "disk2" {
   provider = google-beta
 
   name  = "tf-test-tpu-disk2-%{random_suffix}"
-  image = "debian-cloud/debian-11"
+  image = "debian-cloud/debian-13"
   size  = 10
   type  = "pd-ssd"
   zone  = "us-central1-c"


### PR DESCRIPTION
Debian 11 compute image families have been removed from GCP Compute Engine. This PR updates references in tests, samples, and example templates from Debian 11 to Debian 13.

```release-note:bug
compute: updated examples to use `debian-13` in place of `debian-11`
```