### PR TITLE
fix(colab_schedule) workbench runtime should allow_empty_object

### DIFF
--- a/mmv1/products/colab/Schedule.yaml
+++ b/mmv1/products/colab/Schedule.yaml
@@ -401,6 +401,7 @@ properties:
           - name: 'workbenchRuntime'
             type: NestedObject
             description: 'Configuration for a Workbench Instances-based environment.'
+            allow_empty_object: true
             properties: []
       - name: 'notebookExecutionJobId'
         type: String


### PR DESCRIPTION
According to the API docs[1] this property has no fields, thus it should `allow_empty_object` like it's done with several other resources.

[1] https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.notebookExecutionJobs#NotebookExecutionJob.WorkbenchRuntime

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
colab: fixed an issue in `google_colab_schedule` where `notebookExecutionJob.workbench_runtime` could not be configured with an empty value 
```
