### PR TITLE
feat: add support for regex rewrite api in url map (v1)

### DIFF
--- a/mmv1/products/compute/RegionUrlMap.yaml
+++ b/mmv1/products/compute/RegionUrlMap.yaml
@@ -1025,6 +1025,33 @@ properties:
                           Prior to forwarding the request to the selected service, the request's host
                           header is replaced with contents of hostRewrite. The value must be between 1 and
                           255 characters.
+                      - name: 'regexRewrite'
+                        type: NestedObject
+                        description: |
+                          The regex rewrite to be applied to the URL. Only one of pathPrefixRewrite, pathTemplateRewrite, or regexRewrite may be specified.
+                        properties:
+                          - name: 'pathPattern'
+                            type: String
+                            description: |
+                              The regular expression used to match against the URL path.
+                              It uses RE2 syntax with the following constraints:
+                               - Any single character operators
+                               - Groups are allowed to have only submatch operator inside
+                               - Groups are allowed only without any char repetition, e.g. .*
+                               - Any char repetition, e.g. .*, is only allowed to be used in a single regex together with:
+                                   - Empty string operators
+                                   - Other repetitions
+                                   - Ranges
+                                   - Repetitions of ranges
+                               - Ranges are only allowed to have:
+                                   - Character range
+                                   - Digits range
+                                   - Symbols listed in characters allowed for ranges
+                          - name: 'pathSubstitution'
+                            type: String
+                            description: |
+                              Required when path pattern is specified. Used to rewrite matching parts of
+                              the path.
                       - name: 'pathPrefixRewrite'
                         type: String
                         description: |

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -2093,6 +2093,33 @@ properties:
                           Prior to forwarding the request to the selected service, the request's host
                           header is replaced with contents of hostRewrite. The value must be between 1 and
                           255 characters.
+                      - name: 'regexRewrite'
+                        type: NestedObject
+                        description: |
+                          The regex rewrite to be applied to the URL. Only one of pathPrefixRewrite, pathTemplateRewrite, or regexRewrite may be specified.
+                        properties:
+                          - name: 'pathPattern'
+                            type: String
+                            description: |
+                              The regular expression used to match against the URL path.
+                              It uses RE2 syntax with the following constraints:
+                               - Any single character operators
+                               - Groups are allowed to have only submatch operator inside
+                               - Groups are allowed only without any char repetition, e.g. .*
+                               - Any char repetition, e.g. .*, is only allowed to be used in a single regex together with:
+                                   - Empty string operators
+                                   - Other repetitions
+                                   - Ranges
+                                   - Repetitions of ranges
+                               - Ranges are only allowed to have:
+                                   - Character range
+                                   - Digits range
+                                   - Symbols listed in characters allowed for ranges
+                          - name: 'pathSubstitution'
+                            type: String
+                            description: |
+                              Required when path pattern is specified. Used to rewrite matching parts of
+                              the path.
                       - name: 'pathPrefixRewrite'
                         type: String
                         description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_url_map_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_url_map_test.go
@@ -1366,3 +1366,139 @@ resource "google_compute_region_backend_service" "home" {
 }
 `, randomSuffix, randomSuffix, randomSuffix)
 }
+
+func TestAccComputeRegionUrlMap_routeRulesRegexUrlRewrite(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeUrlMapDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionUrlMap_routeRulesRegexUrlRewrite(randomSuffix),
+			},
+			{
+				ResourceName:      "google_compute_region_url_map.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionUrlMap_routeRulesRegexUrlRewrite_update(randomSuffix),
+			},
+			{
+				ResourceName:      "google_compute_region_url_map.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeRegionUrlMap_routeRulesRegexUrlRewrite(randomSuffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  region                = "us-central1"
+  name                  = "regionurlmap-test-%s"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  health_checks         = [google_compute_region_health_check.zero.self_link]
+}
+
+resource "google_compute_region_health_check" "zero" {
+  region   = "us-central1"
+  name     = "regionurlmap-test-%s"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_url_map" "foobar" {
+  region          = "us-central1"
+  name            = "regionurlmap-test-%s"
+  default_service = google_compute_region_backend_service.foobar.self_link
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "mysite"
+  }
+
+  path_matcher {
+    name            = "mysite"
+    default_service = google_compute_region_backend_service.foobar.self_link
+
+    route_rules {
+      priority = 1
+      match_rules {
+        prefix_match = "/api/"
+      }
+      service = google_compute_region_backend_service.foobar.self_link
+      route_action {
+        url_rewrite {
+          host_rewrite = "dev.example.com"
+          regex_rewrite {
+            path_pattern      = "/api/(.*)"
+            path_substitution = "/v2/api/\\1"
+          }
+        }
+      }
+    }
+  }
+}
+`, randomSuffix, randomSuffix, randomSuffix)
+}
+
+func testAccComputeRegionUrlMap_routeRulesRegexUrlRewrite_update(randomSuffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  region                = "us-central1"
+  name                  = "regionurlmap-test-%s"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  health_checks         = [google_compute_region_health_check.zero.self_link]
+}
+
+resource "google_compute_region_health_check" "zero" {
+  region   = "us-central1"
+  name     = "regionurlmap-test-%s"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_url_map" "foobar" {
+  region          = "us-central1"
+  name            = "regionurlmap-test-%s"
+  default_service = google_compute_region_backend_service.foobar.self_link
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "mysite"
+  }
+
+  path_matcher {
+    name            = "mysite"
+    default_service = google_compute_region_backend_service.foobar.self_link
+
+    route_rules {
+      priority = 1
+      match_rules {
+        prefix_match = "/api/"
+      }
+      service = google_compute_region_backend_service.foobar.self_link
+      route_action {
+        url_rewrite {
+          host_rewrite = "stage.example.com"
+          regex_rewrite {
+            path_pattern      = "/api/v2/(.*)"
+            path_substitution = "/v3/api/\\1"
+          }
+        }
+      }
+    }
+  }
+}
+`, randomSuffix, randomSuffix, randomSuffix)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.tmpl
@@ -2572,3 +2572,127 @@ resource "google_compute_health_check" "default" {
 }
 `, suffix, suffix, suffix)
 }
+
+func TestAccComputeUrlMap_routeRulesRegexUrlRewrite(t *testing.T) {
+  t.Parallel()
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy:             testAccCheckComputeUrlMapDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeUrlMap_routeRulesRegexUrlRewrite(acctest.RandString(t, 10)),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckComputeUrlMapExists(
+            t, "google_compute_url_map.foobar"),
+        ),
+      },
+      {
+        Config: testAccComputeUrlMap_routeRulesRegexUrlRewrite_update(acctest.RandString(t, 10)),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckComputeUrlMapExists(
+            t, "google_compute_url_map.foobar"),
+        ),
+      },
+    },
+  })
+}
+
+func testAccComputeUrlMap_routeRulesRegexUrlRewrite(suffix string) string {
+  return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name                  = "urlmap-test-%s"
+  health_checks         = [google_compute_http_health_check.zero.self_link]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "urlmap-test-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_url_map" "foobar" {
+  name            = "urlmap-test-%s"
+  default_service = google_compute_backend_service.foobar.self_link
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "mysite"
+  }
+
+  path_matcher {
+    name            = "mysite"
+    default_service = google_compute_backend_service.foobar.self_link
+
+    route_rules {
+      priority = 1
+      match_rules {
+        prefix_match = "/api/"
+      }
+      service = google_compute_backend_service.foobar.self_link
+      route_action {
+        url_rewrite {
+          host_rewrite = "dev.example.com"
+          regex_rewrite {
+            path_pattern      = "/api/(.*)"
+            path_substitution = "/v2/api/\\1"
+          }
+        }
+      }
+    }
+  }
+}
+`, suffix, suffix, suffix)
+}
+
+func testAccComputeUrlMap_routeRulesRegexUrlRewrite_update(suffix string) string {
+  return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name                  = "urlmap-test-%s"
+  health_checks         = [google_compute_http_health_check.zero.self_link]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "urlmap-test-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_url_map" "foobar" {
+  name            = "urlmap-test-%s"
+  default_service = google_compute_backend_service.foobar.self_link
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "mysite"
+  }
+
+  path_matcher {
+    name            = "mysite"
+    default_service = google_compute_backend_service.foobar.self_link
+
+    route_rules {
+      priority = 1
+      match_rules {
+        prefix_match = "/api/"
+      }
+      service = google_compute_backend_service.foobar.self_link
+      route_action {
+        url_rewrite {
+          host_rewrite = "stage.example.com"
+          regex_rewrite {
+            path_pattern      = "/api/v2/(.*)"
+            path_substitution = "/v3/api/\\1"
+          }
+        }
+      }
+    }
+  }
+}
+`, suffix, suffix, suffix)
+}


### PR DESCRIPTION
Adds support for the `regexRewrite` API field in the `url_rewrite` block for `google_compute_url_map` and `google_compute_region_url_map` resources in the GA `google` provider.

Resolves b/493449768

```release-note:enhancement
compute: added `regex_rewrite` field to `url_rewrite` block in `google_compute_url_map` and `google_compute_region_url_map`
```
