### PR TITLE
Add architecture to compute machine types data source

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_machine_types.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_machine_types.go.tmpl
@@ -34,6 +34,11 @@ func DataSourceGoogleComputeMachineTypes() *schema.Resource {
 							Computed:    true,
 							Description: `The name of the machine type.`,
 						},
+						"architecture": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The architecture of the machine type, either X86_64 or ARM64 when reported by the API. May be empty for legacy machine types.`,
+						},
 						"guest_cpus": {
 							Type:        schema.TypeInt,
 							Computed:    true,
@@ -255,6 +260,7 @@ func flattenDatasourceGoogleComputeMachineTypesListV2(v interface{}) []map[strin
 		}
 		machineType := map[string]interface{}{
 			"name":                             mt["name"],
+			"architecture":                     mt["architecture"],
 			"guest_cpus":                       mt["guestCpus"],
 			"memory_mb":                        mt["memoryMb"],
 			{{- if ne $.TargetVersionName "ga" }}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_machine_types_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_machine_types_test.go
@@ -21,6 +21,7 @@ func TestAccDataSourceGoogleComputeMachineTypes_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// We can't guarantee machine type availability in a given project and zone, so we'll check set-ness rather than correctness
 					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.name", regexp.MustCompile(`^[a-z0-9-]+$`)),
+					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.architecture", regexp.MustCompile(`^(X86_64|ARM64)$`)),
 					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.guest_cpus", regexp.MustCompile(`^\d+$`)),
 					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.memory_mb", regexp.MustCompile(`^\d+$`)),
 					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.maximum_persistent_disks", regexp.MustCompile(`^\d+$`)),
@@ -38,7 +39,7 @@ const testAccComputeMachineTypes = `
 data "google_compute_zones" "available" {}
 
 data "google_compute_machine_types" "test" {
-	filter = "guest_cpus > 0"
+	filter = "architecture = \"X86_64\""
 	zone   = data.google_compute_zones.available.names[0]
 }
 `

--- a/mmv1/third_party/terraform/website/docs/d/compute_machine_types.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_machine_types.html.markdown
@@ -104,6 +104,8 @@ The following attributes are exported:
 
 * `name` - The name of the machine type.
 
+* `architecture` - The architecture of the machine type, either `X86_64` or `ARM64` when reported by the API. May be empty for legacy machine types.
+
 * `description` - A textual description of the machine type.
 
 * `bundled_local_ssds` - ([Beta](../guides/provider_versions.html.markdown)) The configuration of bundled local SSD for the machine type. Structure is [documented below](#nested_bundled_local_ssds).


### PR DESCRIPTION
Adds the `architecture` field to the `google_compute_machine_types` data source.

The Compute Engine API returns `ARM64` or `X86_64` for newer machine types, but the provider did not expose it. Some legacy machine types omit the field, so `architecture` may be empty in those cases.

This allows Terraform configurations to select architecture-compatible machine images without relying on machine-family naming conventions.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23992
Related to https://github.com/hashicorp/terraform-provider-google/issues/29150

Tested by generating the complete GA and beta providers and running:

- `TestAccDataSourceGoogleComputeMachineTypes_basic` on GA
- `TestAccDataSourceGoogleComputeMachineTypes_basic` on beta

Both tests passed against the live Compute Engine API.

```release-note:enhancement
compute: added `architecture` field to `google_compute_machine_types` data source
```
