### PR TITLE
`MMv1/chore`: remove `WriteOnlyLegacy`

### DIFF
--- a/docs/content/reference/field.md
+++ b/docs/content/reference/field.md
@@ -120,25 +120,6 @@ write_only: true
 
 **Warning:** This field cannot be used in combination with `exactly_one_of` on multiple write-only fields. This is planned to be [fixed in the future](https://github.com/hashicorp/terraform-provider-google/issues/24327).
 
-### `write_only_legacy` (deprecated)
-If true, the field is considered "write-only", which means that its value will
-be obscured in Terraform output as well as not be stored in state. This field is meant to replace `sensitive` as it doesn't store the value in state.
-See [Ephemerality in Resources - Use Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only)
-for more information.
-
-Write-only fields are only supported in Terraform v1.11+. Because the provider supports earlier Terraform versions, write only fields must be paired with (mutually exclusive) `sensitive` fields covering the same functionality for compatibility with those older versions.
-This field cannot be used in conjunction with `immutable` or `sensitive`.
-
-**Note**: Due to write-only not being read from the API, it is not possible to update the field directly unless a sidecar field is used. (e.g. `password` as a write-only field and `password_wo_version` as an immutable field meant for updating).
-
-Example:
-
-```yaml
-write_only_legacy: true
-```
-
-**Deprecated**: This field is deprecated and will be removed in a future release.
-
 ### `ignore_read`
 If true, the provider sets the field's value in the resource state based only
 on the user's configuration. If false or unset, the provider sets the field's

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -801,7 +801,7 @@ func (r Resource) SensitiveProps() []*Type {
 func (r Resource) WriteOnlyProps() []*Type {
 	props := r.AllNestedProperties(r.RootProperties())
 	return google.Select(props, func(p *Type) bool {
-		return p.WriteOnlyLegacy || p.WriteOnly
+		return p.WriteOnly
 	})
 }
 
@@ -2591,7 +2591,7 @@ func (r Resource) TGCTestIgnorePropertiesToStrings() []string {
 	for _, tp := range r.AllNestedProperties(r.RootProperties()) {
 		if tp.UrlParamOnly {
 			props = append(props, google.Underscore(tp.Name))
-		} else if tp.IsMissingInCai || tp.IgnoreRead || tp.ClientSide || tp.WriteOnlyLegacy {
+		} else if tp.IsMissingInCai || tp.IgnoreRead || tp.ClientSide {
 			props = append(props, strings.Join(tp.Lineage(), "."))
 		}
 	}

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -181,10 +181,6 @@ type Type struct {
 	// For more information, see: https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/write-only-arguments
 	WriteOnly bool `yaml:"write_only,omitempty"`
 
-	// TODO: remove this field after all references are migrated
-	// see: https://github.com/GoogleCloudPlatform/magic-modules/pull/14933#pullrequestreview-3166578379
-	WriteOnlyLegacy bool `yaml:"write_only_legacy,omitempty"` // Adds `WriteOnlyLegacy: true` to the schema
-
 	// Does not set this value to the returned API value.  Useful for fields
 	// like secrets where the returned API value is not helpful.
 	IgnoreRead bool `yaml:"ignore_read,omitempty"`
@@ -516,11 +512,11 @@ func (t *Type) Validate(rName string) (es []error) {
 		es = append(es, fmt.Errorf("property %s 'default_value' and 'default_from_api' cannot be both set in resource %s ", fullFieldPath, rName))
 	}
 
-	if (t.WriteOnlyLegacy || t.WriteOnly) && (t.DefaultFromApi || t.Output) {
+	if t.WriteOnly && (t.DefaultFromApi || t.Output) {
 		es = append(es, fmt.Errorf("property %s cannot be write_only and default_from_api or output at the same time in resource %s", fullFieldPath, rName))
 	}
 
-	if (t.WriteOnlyLegacy || t.WriteOnly) && t.Sensitive {
+	if t.WriteOnly && t.Sensitive {
 		es = append(es, fmt.Errorf("property %s cannot be write_only and sensitive at the same time in resource %s", fullFieldPath, rName))
 	}
 
@@ -838,7 +834,7 @@ func (t Type) WriteOnlyProperties() []*Type {
 		}
 	case t.IsA("NestedObject"):
 		props = google.Select(t.UserProperties(), func(p *Type) bool {
-			return p.WriteOnlyLegacy || p.WriteOnly
+			return p.WriteOnly
 		})
 	case t.IsA("Map"):
 		props = google.Reject(t.ValueType.WriteOnlyProperties(), func(p *Type) bool {
@@ -894,7 +890,7 @@ func (t *Type) FieldType() []string {
 		ret = append(ret, "Output")
 	}
 
-	if t.WriteOnlyLegacy || t.WriteOnly {
+	if t.WriteOnly {
 		ret = append(ret, "Write-Only")
 	}
 
@@ -1409,8 +1405,8 @@ func (t *Type) IsForceNew() bool {
 		return t.Immutable
 	}
 
-	// WriteOnlyLegacy fields are never immutable
-	if t.WriteOnlyLegacy || t.WriteOnly {
+	// WriteOnly fields are never immutable
+	if t.WriteOnly {
 		return false
 	}
 

--- a/mmv1/api/type_test.go
+++ b/mmv1/api/type_test.go
@@ -132,13 +132,6 @@ func TestTypeFieldType(t *testing.T) {
 			expected: []string{},
 		},
 		{
-			description: "WriteOnlyLegacy field",
-			obj: Type{
-				WriteOnlyLegacy: true,
-			},
-			expected: []string{"Optional", "Write-Only"},
-		},
-		{
 			description: "WriteOnly field",
 			obj: Type{
 				WriteOnly: true,

--- a/mmv1/templates/terraform/custom_flatten/dataplex_entry_aspects.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/dataplex_entry_aspects.go.tmpl
@@ -15,7 +15,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
     transformed = append(transformed, map[string]interface{}{
 
   {{- range $prop := $.ItemType.UserProperties }}
-    {{- if not (or $prop.IgnoreRead $prop.WriteOnlyLegacy $prop.WriteOnly) }}
+    {{- if not (or $prop.IgnoreRead $prop.WriteOnly) }}
       "{{ underscore $prop.Name }}": flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ $prop.ApiName }}"], d, config),
     {{- end }}
   {{- end }}

--- a/mmv1/templates/terraform/custom_flatten/dataplex_entry_link_aspects.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/dataplex_entry_link_aspects.go.tmpl
@@ -15,7 +15,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
     transformed = append(transformed, map[string]interface{}{
 
   {{- range $prop := $.ItemType.UserProperties }}
-    {{- if not (or $prop.IgnoreRead $prop.WriteOnlyLegacy $prop.WriteOnly) }}
+    {{- if not (or $prop.IgnoreRead $prop.WriteOnly) }}
       "{{ underscore $prop.Name }}": flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ $prop.ApiName }}"], d, config),
     {{- end }}
   {{- end }}

--- a/mmv1/templates/terraform/flatten_property_method.go.tmpl
+++ b/mmv1/templates/terraform/flatten_property_method.go.tmpl
@@ -13,7 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License. */ -}}
 {{- define "flattenPropertyMethod" }}
-{{- if and (or $.WriteOnlyLegacy $.WriteOnly) }}
+{{- if $.WriteOnly }}
 {{- else if and $.CustomFlatten (not $.ShouldIgnoreCustomFlatten) }}
     {{- customTemplate $ $.CustomFlatten false -}}
 {{- else -}}
@@ -34,7 +34,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
         {{- end }}
   transformed := make(map[string]interface{})
         {{- range $prop := $.UserProperties }}
-            {{- if or $prop.WriteOnlyLegacy $prop.WriteOnly }}
+            {{- if $prop.WriteOnly }}
             {{- else if $prop.FlattenObject }}
     if {{ $prop.ApiName }} := flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ $prop.ApiName }}"], d, config); {{ $prop.ApiName }} != nil {
       obj := {{ $prop.ApiName }}.([]interface{})[0]
@@ -76,7 +76,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
   {{- end }}
 
   {{- range $prop := $.ItemType.UserProperties }}
-    {{- if not (or $prop.IgnoreRead $prop.WriteOnlyLegacy $prop.WriteOnly) }}
+    {{- if not (or $prop.IgnoreRead $prop.WriteOnly) }}
       "{{ underscore $prop.Name }}": flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ $prop.ApiName }}"], d, config),
     {{- end }}
   {{- end }}

--- a/mmv1/templates/terraform/property_documentation.html.markdown.tmpl
+++ b/mmv1/templates/terraform/property_documentation.html.markdown.tmpl
@@ -18,7 +18,7 @@
   {{- if $.Sensitive }}
   **Note**: This property is sensitive and will not be displayed in the plan.
   {{- end }}
-  {{- if or $.WriteOnlyLegacy $.WriteOnly }}
+  {{- if $.WriteOnly }}
   **Note**: This property is write-only and will not be read from the API.
 
   ~> **Note:** One of `{{ slice (underscore $.Name) 0 (sub (len (underscore $.Name)) 3) }}` or `{{ underscore $.Name }}` can only be set.

--- a/mmv1/templates/terraform/schema_property.go.tmpl
+++ b/mmv1/templates/terraform/schema_property.go.tmpl
@@ -164,7 +164,7 @@ Default value: {{ .ItemType.DefaultValue -}}
 {{ if .Sensitive -}}
     Sensitive: true,
 {{ end -}}
-{{ if or .WriteOnlyLegacy .WriteOnly -}}
+{{ if .WriteOnly -}}
   WriteOnly: true,
 {{ end -}}
 {{ if not (eq .DefaultValue nil ) -}}

--- a/mmv1/templates/tgc_next/cai2hcl/flatten_property_method_tgc.go.tmpl
+++ b/mmv1/templates/tgc_next/cai2hcl/flatten_property_method_tgc.go.tmpl
@@ -31,7 +31,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 	return tpgresource.GetResourceNameFromSelfLink(v.(string))
 }
 	{{ else }}
-    {{ if and (or $.WriteOnlyLegacy $.WriteOnly) }}
+    {{ if $.WriteOnly }}
     {{ else if and $.CustomFlatten (not $.ShouldIgnoreCustomFlatten) }}
         {{- customTemplate $ $.CustomFlatten false }}
     {{ else }}
@@ -54,7 +54,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
     {{- end }}
   transformed := make(map[string]interface{})
       {{- range $prop := $.UserProperties }}
-        {{- if or $prop.WriteOnlyLegacy $prop.WriteOnly }}
+        {{- if $prop.WriteOnly }}
         {{- else if $prop.FlattenObject }}
     if {{ $prop.ApiName }} := flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ $prop.ApiName }}"], d, config); {{ $prop.ApiName }} != nil {
       obj := {{ $prop.ApiName }}.([]interface{})[0]
@@ -100,7 +100,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
   {{- end }}
 
   {{- range $prop := $.ItemType.UserProperties }}
-    {{- if not (or $prop.IgnoreRead $prop.WriteOnlyLegacy $prop.WriteOnly) }}
+    {{- if not (or $prop.IgnoreRead $prop.WriteOnly) }}
       "{{ underscore $prop.Name }}": flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ $prop.ApiName }}"], d, config),
     {{- end }}
   {{- end }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

With 8.0.0 removing the use of writeOnlyLegacy in the initial write only fields, we can proceed with fully removing the write_only_legacy field since it only existed until the breaking changes were introduced

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
