### PR TITLE
cloudrunv2: add google_cloud_run_v2_instance resource (beta)

### DIFF
--- a/mmv1/products/cloudrunv2/Instance.yaml
+++ b/mmv1/products/cloudrunv2/Instance.yaml
@@ -1,0 +1,829 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'Instance'
+min_version: beta
+description: |
+  An Instance represents a single group of containers running in a region.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/run/docs/'
+  api: 'https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.instances'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/instances/{{name}}'
+base_url: 'projects/{{project}}/locations/{{location}}/instances'
+self_link: 'projects/{{project}}/locations/{{location}}/instances/{{name}}'
+create_url: 'projects/{{project}}/locations/{{location}}/instances?instanceId={{name}}'
+update_verb: 'PATCH'
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/instances/{{name}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: true
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_attribute: 'name'
+  base_url: 'projects/{{project}}/locations/{{location}}/instances/{{name}}'
+  import_format:
+    - 'projects/{{project}}/locations/{{location}}/instances/{{name}}'
+    - '{{name}}'
+custom_code:
+  pre_delete: 'templates/terraform/pre_delete/cloudrunv2_instance_deletion_policy.go.tmpl'
+taint_resource_on_failed_create: true
+samples:
+  - name: 'cloudrunv2_instance_basic'
+    primary_resource_id: 'default'
+    min_version: beta
+    steps:
+      - name: 'cloudrunv2_instance_basic'
+        min_version: beta
+        resource_id_vars:
+          cloud_run_instance_name: 'cloudrun-instance'
+        ignore_read_extra:
+          - 'deletion_protection'
+  - name: 'cloudrunv2_instance_limits'
+    primary_resource_id: 'default'
+    min_version: beta
+    steps:
+      - name: 'cloudrunv2_instance_limits'
+        min_version: beta
+        resource_id_vars:
+          cloud_run_instance_name: 'cloudrun-instance'
+        ignore_read_extra:
+          - 'deletion_protection'
+  - name: 'cloudrunv2_instance_full'
+    primary_resource_id: 'default'
+    min_version: beta
+    steps:
+      - name: 'cloudrunv2_instance_full'
+        min_version: beta
+        resource_id_vars:
+          cloud_run_instance_name: 'cloudrun-instance'
+        vars:
+          ingress: 'INGRESS_TRAFFIC_ALL'
+          restart_policy: 'ON_FAILURE'
+          label_env: 'staging'
+        ignore_read_extra:
+          - 'deletion_protection'
+      # Test in-place update of labels, restart policy, and ingress
+      - name: 'cloudrunv2_instance_full'
+        min_version: beta
+        resource_id_vars:
+          cloud_run_instance_name: 'cloudrun-instance'
+        vars:
+          ingress: 'INGRESS_TRAFFIC_INTERNAL_ONLY'
+          restart_policy: 'ALWAYS'
+          label_env: 'production'
+        ignore_read_extra:
+          - 'deletion_protection'
+virtual_fields:
+  - name: 'deletion_protection'
+    description: |
+      Whether Terraform will be prevented from destroying the instance. Defaults to true.
+      When a `terraform destroy` or `terraform apply` would delete the instance,
+      the command will fail if this field is not set to false in Terraform state.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the instance will fail.
+      When the field is set to false, deleting the instance is allowed.
+    type: Boolean
+    default_value: true
+parameters:
+  - name: 'location'
+    type: String
+    description: The location of the cloud run instance
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      Name of the Instance.
+    url_param_only: true
+    required: true
+    immutable: true
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/resource_from_self_link.go.tmpl'
+  - name: 'description'
+    type: String
+    description: |
+      User-provided description of the Instance. This field currently has a 512-character limit.
+  - name: 'uid'
+    type: String
+    description: |
+      Server assigned unique identifier for the trigger. The value is a UUID4 string and guaranteed to remain unchanged until the resource is deleted.
+    output: true
+  - name: 'generation'
+    type: String
+    description: |
+      A number that monotonically increases every time the user modifies the desired state. Please note that unlike v1, this is an int64 value. As with most Google APIs, its JSON representation will be a string instead of an integer.
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: |-
+      Unstructured key value map that can be used to organize and categorize objects. User-provided labels are shared with Google's billing system, so they can be used to filter, or break down billing charges by team, component,
+      environment, state, etc. For more information, visit https://docs.cloud.google.com/resource-manager/docs/creating-managing-labels or https://cloud.google.com/run/docs/configuring/labels.
+
+      Cloud Run API v2 does not support labels with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected.
+      All system labels in v1 now have a corresponding field in v2 Instance.
+  - name: 'annotations'
+    type: KeyValueAnnotations
+    description: |-
+      Unstructured key value map that may be set by external tools to store and arbitrary metadata. They are not queryable and should be preserved when modifying objects.
+
+      Cloud Run API v2 does not support annotations with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected in new resources.
+      All system annotations in v1 now have a corresponding field in v2 Instance.
+
+      This field follows Kubernetes annotations' namespacing, limits, and rules.
+  - name: 'createTime'
+    type: Time
+    description: |-
+      The creation time.
+    output: true
+  - name: 'updateTime'
+    type: Time
+    description: |-
+      The last-modified time.
+    output: true
+  - name: 'deleteTime'
+    type: Time
+    description: |-
+      The deletion time.
+    output: true
+  - name: 'expireTime'
+    type: Time
+    description: |-
+      For a deleted resource, the time after which it will be permanently deleted.
+    output: true
+  - name: 'creator'
+    type: String
+    description: |-
+      Email address of the authenticated creator.
+    output: true
+  - name: 'lastModifier'
+    type: String
+    description: |-
+      Email address of the last authenticated modifier.
+    output: true
+  - name: 'client'
+    type: String
+    description: |
+      Arbitrary identifier for the API client.
+  - name: 'clientVersion'
+    type: String
+    description: |
+      Arbitrary version identifier for the API client.
+  - name: 'launchStage'
+    type: Enum
+    description: |
+      The launch stage as defined by [Google Cloud Platform Launch Stages](https://cloud.google.com/products#product-launch-stages). Cloud Run supports ALPHA, BETA, and GA. If no value is specified, GA is assumed. Set the launch stage to a preview stage on input to allow use of preview features in that stage. On read (or output), describes whether the resource uses preview features.
+
+      For example, if ALPHA is provided as input, but only BETA and GA-level features are used, this field will be BETA on output.
+    default_from_api: true
+    enum_values:
+      - 'UNIMPLEMENTED'
+      - 'PRELAUNCH'
+      - 'EARLY_ACCESS'
+      - 'ALPHA'
+      - 'BETA'
+      - 'GA'
+      - 'DEPRECATED'
+  - name: 'binaryAuthorization'
+    type: NestedObject
+    description: |
+      Settings for the Binary Authorization feature.
+    properties:
+      - name: 'useDefault'
+        type: Boolean
+        description: |
+          If True, indicates to use the default project's binary authorization policy. If False, binary authorization will be disabled.
+        conflicts:
+          - 'policy'
+      - name: 'policy'
+        type: String
+        description: |
+          The path to a binary authorization policy. Format: projects/{project}/platforms/cloudRun/{policy-name}
+        conflicts:
+          - 'use_default'
+      - name: 'breakglassJustification'
+        type: String
+        description: |
+          If present, indicates to use Breakglass using this justification. If useDefault is False, then it must be empty. For more information on breakglass, see https://cloud.google.com/binary-authorization/docs/using-breakglass
+  - name: 'vpcAccess'
+    type: NestedObject
+    description: |-
+      VPC Access configuration to use for this Instance. For more information, visit https://cloud.google.com/run/docs/configuring/connecting-vpc.
+    properties:
+      - name: 'egress'
+        type: Enum
+        description: |-
+          Traffic VPC egress settings.
+        enum_values:
+          - 'ALL_TRAFFIC'
+          - 'PRIVATE_RANGES_ONLY'
+      - name: 'networkInterfaces'
+        type: Array
+        description: |-
+          Direct VPC subnetwork connectivity.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'network'
+              type: String
+              description: |-
+                The VPC network that the subnetwork belongs to.
+            - name: 'subnetwork'
+              type: String
+              description: |-
+                The subnetwork that the Cloud Run resource will get IPs from.
+            - name: 'tags'
+              type: Array
+              description: |-
+                Network tags applied to this Instance.
+              item_type:
+                type: String
+  - name: 'serviceAccount'
+    type: String
+    description: |-
+      Email address of the IAM service account associated with the Instance. The service account represents the identity of the running Instance, and determines what permissions the instance has.
+  - name: 'containers'
+    type: Array
+    description: |-
+      Holds the single container that defines the unit of execution for this Instance.
+    required: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: |-
+            Name of the container specified as a DNS_LABEL.
+        - name: 'image'
+          type: String
+          description: |-
+            URL of the Container image in Google Container Registry or Google Artifact Registry. More info: https://kubernetes.io/docs/concepts/containers/images
+          required: true
+        - name: 'command'
+          type: Array
+          description: |-
+            Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+          item_type:
+            type: String
+        - name: 'args'
+          type: Array
+          description: |-
+            Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+          item_type:
+            type: String
+        - name: 'env'
+          type: Array
+          description: |-
+            List of environment variables to set in the container.
+          is_set: true
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'name'
+                type: String
+                description: |-
+                  Name of the environment variable. Must be a C_IDENTIFIER, and mnay not exceed 32768 characters.
+                required: true
+              - name: 'value'
+                type: String
+                default_value: ""
+                description: |-
+                  Literal value of the environment variable. Defaults to "" and the maximum allowed length is 32768 characters. Variable references are not supported in Cloud Run.
+              - name: 'valueSource'
+                type: NestedObject
+                description: |-
+                  Source for the environment variable's value.
+                properties:
+                  - name: 'secretKeyRef'
+                    type: NestedObject
+                    description: |-
+                      Selects a secret and a specific version from Cloud Secret Manager.
+                    properties:
+                      - name: 'secret'
+                        type: String
+                        description: |-
+                          The name of the secret in Cloud Secret Manager. Format: {secretName} if the secret is in the same project. projects/{project}/secrets/{secretName} if the secret is in a different project.
+                        required: true
+                      - name: 'version'
+                        type: String
+                        description: |-
+                          The Cloud Secret Manager secret version. Can be 'latest' for the latest value or an integer for a specific version.
+                        required: true
+        - name: 'resources'
+          type: NestedObject
+          description: |-
+            Compute Resource requirements by this container. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+          default_from_api: true
+          properties:
+            - name: 'limits'
+              type: KeyValuePairs
+              description: |-
+                Only memory and CPU are supported. Use key `cpu` for CPU limit, `memory` for memory limit. Note: The only supported values for CPU are '1', '2', '4', '6', and '8'. Setting 4 CPU requires at least 2Gi of memory, setting 6 or more CPU requires at least 4Gi of memory. The values of the map is string form of the 'quantity' k8s type: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+              default_from_api: true
+        - name: 'ports'
+          type: Array
+          description: |-
+            List of ports to expose from the container. Only a single port can be specified. The specified ports must be listening on all interfaces (0.0.0.0) within the container to be accessible.
+
+            If omitted, a port number will be chosen and passed to the container through the PORT environment variable for the container to listen on
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'name'
+                type: String
+                description: |-
+                  If specified, used to specify which protocol to use. Allowed values are "http1" and "h2c".
+              - name: 'containerPort'
+                type: Integer
+                description: |-
+                  Port number the container listens on. This must be a valid TCP port number, 0 < containerPort < 65536.
+        - name: 'volumeMounts'
+          type: Array
+          description: |-
+            Volume to mount into the container's filesystem.
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'name'
+                type: String
+                description: |-
+                  This must match the Name of a Volume.
+                required: true
+              - name: 'mountPath'
+                type: String
+                description: |-
+                  Path within the container at which the volume should be mounted. Must not contain ':'. For Cloud SQL volumes, it can be left empty, or must otherwise be /cloudsql. All instances defined in the Volume will be available as /cloudsql/[instance]. For more information on Cloud SQL volumes, visit https://cloud.google.com/sql/docs/mysql/connect-run
+                required: true
+              - name: 'subPath'
+                type: String
+                description: |-
+                  Path within the volume from which the container's volume should be mounted.
+        - name: 'workingDir'
+          type: String
+          description: |-
+            Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image.
+        - name: 'livenessProbe'
+          type: NestedObject
+          description: |-
+            Periodic probe of container liveness. Container will be restarted if the probe fails.
+          properties:
+            - name: 'initialDelaySeconds'
+              default_value: 0
+              description: |-
+                Optional. Number of seconds after the container has started before the probe is initiated. Defaults to 0 seconds. Minimum value is 0. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240.
+              type: Integer
+            - name: 'timeoutSeconds'
+              default_value: 1
+              description: |-
+                Optional. Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 3600. Must be smaller than period_seconds.
+              type: Integer
+            - name: 'periodSeconds'
+              default_value: 10
+              description: |-
+                Optional. How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. Must be greater or equal than timeout_seconds.
+              type: Integer
+            - name: 'failureThreshold'
+              default_value: 3
+              description: |-
+                Optional. Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+              type: Integer
+            - name: 'httpGet'
+              description: |-
+                Optional. HTTPGet specifies the http request to perform. Exactly one of httpGet, tcpSocket, or grpc must be specified.
+              type: NestedObject
+              properties:
+                - name: 'path'
+                  description: |-
+                    Optional. Path to access on the HTTP server. Defaults to '/'.
+                  type: String
+                - name: 'port'
+                  description: |-
+                    Optional. Port number to access on the container. Must be in the range 1 to 65535. If not specified, defaults to the exposed port of the container, which is the value of container.ports[0].containerPort.
+                  type: Integer
+                - name: 'httpHeaders'
+                  description: |-
+                    Optional. Custom headers to set in the request. HTTP allows repeated headers.
+                  type: Array
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'name'
+                        description: |-
+                          Required. The header field name
+                        type: String
+                      - name: 'value'
+                        description: |-
+                          Optional. The header field value
+                        type: String
+            - name: 'tcpSocket'
+              description: |-
+                Optional. TCPSocket specifies an action involving a TCP port. Exactly one of httpGet, tcpSocket, or grpc must be specified.
+              type: NestedObject
+              properties:
+                - name: 'port'
+                  description: |-
+                    Optional. Port number to access on the container. Must be in the range 1 to 65535. If not specified, defaults to the exposed port of the container, which is the value of container.ports[0].containerPort.
+                  type: Integer
+            - name: 'grpc'
+              description: |-
+                Optional. GRPC specifies an action involving a gRPC port. Exactly one of httpGet, tcpSocket, or grpc must be specified.
+              type: NestedObject
+              properties:
+                - name: 'port'
+                  description: |-
+                    Optional. Port number of the gRPC service. Number must be in the range 1 to 65535. If not specified, defaults to the exposed port of the container, which is the value of container.ports[0].containerPort.
+                  type: Integer
+                - name: 'service'
+                  description: |-
+                    Optional. Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md ). If this is not specified, the default behavior is defined by gRPC
+                  type: String
+        - name: 'startupProbe'
+          type: NestedObject
+          description: |-
+            Startup probe of application within the container. All other probes are disabled if a startup probe is provided, until it succeeds. Container will not be added to service endpoints if the probe fails.
+          properties:
+            - name: 'initialDelaySeconds'
+              default_value: 0
+              description: |-
+                Optional. Number of seconds after the container has started before the probe is initiated. Defaults to 0 seconds. Minimum value is 0. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240.
+              type: Integer
+            - name: 'timeoutSeconds'
+              default_value: 1
+              description: |-
+                Optional. Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 3600. Must be smaller than period_seconds.
+              type: Integer
+            - name: 'periodSeconds'
+              default_value: 10
+              description: |-
+                Optional. How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1. Maximum value for liveness probe is 3600. Maximum value for startup probe is 240. Must be greater or equal than timeout_seconds.
+              type: Integer
+            - name: 'failureThreshold'
+              default_value: 3
+              description: |-
+                Optional. Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+              type: Integer
+            - name: 'httpGet'
+              description: |-
+                Optional. HTTPGet specifies the http request to perform. Exactly one of httpGet, tcpSocket, or grpc must be specified.
+              type: NestedObject
+              properties:
+                - name: 'path'
+                  description: |-
+                    Optional. Path to access on the HTTP server. Defaults to '/'.
+                  type: String
+                - name: 'port'
+                  description: |-
+                    Optional. Port number to access on the container. Must be in the range 1 to 65535. If not specified, defaults to the exposed port of the container, which is the value of container.ports[0].containerPort.
+                  type: Integer
+                - name: 'httpHeaders'
+                  description: |-
+                    Optional. Custom headers to set in the request. HTTP allows repeated headers.
+                  type: Array
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'name'
+                        description: |-
+                          Required. The header field name
+                        type: String
+                      - name: 'value'
+                        description: |-
+                          Optional. The header field value
+                        type: String
+            - name: 'tcpSocket'
+              description: |-
+                Optional. TCPSocket specifies an action involving a TCP port. Exactly one of httpGet, tcpSocket, or grpc must be specified.
+              type: NestedObject
+              properties:
+                - name: 'port'
+                  description: |-
+                    Optional. Port number to access on the container. Must be in the range 1 to 65535. If not specified, defaults to the exposed port of the container, which is the value of container.ports[0].containerPort.
+                  type: Integer
+            - name: 'grpc'
+              description: |-
+                Optional. GRPC specifies an action involving a gRPC port. Exactly one of httpGet, tcpSocket, or grpc must be specified.
+              type: NestedObject
+              properties:
+                - name: 'port'
+                  description: |-
+                    Optional. Port number of the gRPC service. Number must be in the range 1 to 65535. If not specified, defaults to the exposed port of the container, which is the value of container.ports[0].containerPort.
+                  type: Integer
+                - name: 'service'
+                  description: |-
+                    Optional. Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md ). If this is not specified, the default behavior is defined by gRPC
+                  type: String
+  - name: 'volumes'
+    type: Array
+    description: |-
+      A list of Volumes to make available to containers.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: |-
+            Volume's name.
+          required: true
+        - name: 'secret'
+          type: NestedObject
+          description: |-
+            Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+          properties:
+            - name: 'secret'
+              type: String
+              description: |-
+                The name of the secret in Cloud Secret Manager. Format: {secret} if the secret is in the same project. projects/{project}/secrets/{secret} if the secret is in a different project.
+              required: true
+            - name: 'defaultMode'
+              type: Integer
+              description: |-
+                Integer representation of mode bits to use on created files by default. Must be a value between 0000 and 0777 (octal), defaulting to 0444. Directories within the path are not affected by this setting.
+            - name: 'items'
+              type: Array
+              description: |-
+                If unspecified, the volume will expose a file whose name is the secret, relative to VolumeMount.mount_path. If specified, the key will be used as the version to fetch from Cloud Secret Manager and the path will be the name of the file exposed in the volume. When items are defined, they must specify a path and a version.
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: 'path'
+                    type: String
+                    description: |-
+                      The relative path of the secret in the container.
+                    required: true
+                  - name: 'version'
+                    type: String
+                    description: |-
+                      The Cloud Secret Manager secret version. Can be 'latest' for the latest value or an integer for a specific version
+                  - name: 'mode'
+                    type: Integer
+                    description: |-
+                      Integer octal mode bits to use on this file, must be a value between 01 and 0777 (octal). If 0 or not set, the Volume's default mode will be used.
+        - name: 'cloudSqlInstance'
+          type: NestedObject
+          description: |-
+            For Cloud SQL volumes, contains the specific instances that should be mounted. Visit https://cloud.google.com/sql/docs/mysql/connect-run for more information on how to connect Cloud SQL and Cloud Run.
+          properties:
+            - name: 'instances'
+              type: Array
+              description: |-
+                The Cloud SQL instance connection names, as can be found in https://console.cloud.google.com/sql/instances. Visit https://cloud.google.com/sql/docs/mysql/connect-run for more information on how to connect Cloud SQL and Cloud Run. Format: {project}:{location}:{instance}
+              is_set: true
+              item_type:
+                type: String
+        - name: 'emptyDir'
+          type: NestedObject
+          description: |-
+            Ephemeral storage used as a shared volume.
+          properties:
+            - name: 'medium'
+              type: Enum
+              description: |-
+                The different types of medium supported for EmptyDir.
+              default_value: "MEMORY"
+              enum_values:
+                - 'MEMORY'
+                - 'DISK'
+            - name: 'sizeLimit'
+              type: String
+              description: |-
+                Limit on the storage usable by this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. This field's values are of the 'Quantity' k8s type: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir.
+        - name: 'gcs'
+          type: NestedObject
+          description: |-
+            Cloud Storage bucket mounted as a volume using GCSFuse. This feature is only supported in the gen2 execution environment.
+          properties:
+            - name: 'bucket'
+              type: String
+              description: GCS Bucket name
+              required: true
+            - name: 'readOnly'
+              type: Boolean
+              description: If true, mount the GCS bucket as read-only
+              required: false
+            - name: 'mountOptions'
+              type: Array
+              description: |
+                A list of flags to pass to the gcsfuse command for configuring this volume.
+                Flags should be passed without leading dashes.
+              item_type:
+                type: String
+        - name: 'nfs'
+          type: NestedObject
+          description: Represents an NFS mount.
+          properties:
+            - name: 'server'
+              type: String
+              description: Hostname or IP address of the NFS server
+              required: true
+            - name: 'path'
+              type: String
+              description: Path that is exported by the NFS server.
+              required: true
+            - name: 'readOnly'
+              type: Boolean
+              description: If true, mount the NFS volume as read only
+              required: false
+  - name: 'encryptionKey'
+    type: String
+    description: |-
+      A reference to a customer managed encryption key (CMEK) to use to encrypt this container image. For more information, go to https://cloud.google.com/run/docs/securing/using-cmek
+  - name: 'encryptionKeyRevocationAction'
+    type: Enum
+    description: |-
+      The action to take if the encryption key is revoked.
+    enum_values:
+      - 'PREVENT_NEW'
+      - 'SHUTDOWN'
+  - name: 'encryptionKeyShutdownDuration'
+    type: String
+    description: |-
+      If encryptionKeyRevocationAction is SHUTDOWN, the duration before shutting down all instances. The minimum increment is 1 hour.
+
+      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
+  - name: 'ingress'
+    type: Enum
+    description: |-
+      Provides the ingress settings for this Instance. On output, returns the currently observed ingress settings, or INGRESS_TRAFFIC_UNSPECIFIED if no revision is active.
+    enum_values:
+      - 'INGRESS_TRAFFIC_ALL'
+      - 'INGRESS_TRAFFIC_INTERNAL_ONLY'
+      - 'INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER'
+  - name: 'invokerIamDisabled'
+    type: Boolean
+    description: |-
+      Disables IAM permission check for run.routes.invoke for callers of this Instance. For more information, visit https://cloud.google.com/run/docs/securing/managing-access#invoker_check.
+  - name: 'defaultUriDisabled'
+    type: Boolean
+    description: |-
+      Disables public resolution of the default URI of this Instance.
+  - name: 'restartPolicy'
+    type: Enum
+    description: |-
+      Restart policy for the Instance. If not provided, the default is ON_FAILURE.
+    enum_values:
+      - 'ALWAYS'
+      - 'ON_FAILURE'
+      - 'NEVER'
+  - name: 'observedGeneration'
+    type: String
+    description: |
+      The generation of this Instance currently serving traffic. See comments in reconciling for additional information on reconciliation process in Cloud Run. Please note that unlike v1, this is an int64 value. As with most Google APIs, its JSON representation will be a string instead of an integer.
+    output: true
+  - name: 'logUri'
+    type: String
+    description: |
+      The Google Console URI to obtain logs for the Instance.
+    output: true
+  - name: 'terminalCondition'
+    type: NestedObject
+    description: |
+      The Condition of this Instance, containing its readiness status, and detailed error information in case it did not reach a serving state. See comments in reconciling for additional information on reconciliation process in Cloud Run.
+    output: true
+    properties:
+      - name: 'type'
+        type: String
+        description: |-
+          type is used to communicate the status of the reconciliation process. See also: https://github.com/knative/serving/blob/main/docs/spec/errors.md#error-conditions-and-reporting Types common to all resources include: * "Ready": True when the Resource is ready.
+        output: true
+      - name: 'state'
+        type: String
+        description: |-
+          State of the condition.
+        output: true
+      - name: 'message'
+        type: String
+        description: |-
+          Human readable message indicating details about the current status.
+        output: true
+      - name: 'lastTransitionTime'
+        type: Time
+        description: |-
+          Last time the condition transitioned from one status to another.
+        output: true
+      - name: 'severity'
+        type: String
+        description: |-
+          How to interpret failures of this condition, one of Error, Warning, Info
+        output: true
+      - name: 'reason'
+        type: String
+        description: |-
+          A common (instance-level) reason for this condition.
+        output: true
+      - name: 'instanceReason'
+        type: String
+        description: |-
+          A reason for the instance condition.
+        output: true
+  - name: 'conditions'
+    type: Array
+    description: |-
+      The Conditions of all other associated sub-resources. They contain additional diagnostics information in case the Instance does not reach its Serving state. See comments in reconciling for additional information on reconciliation process in Cloud Run.
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'type'
+          type: String
+          description: |-
+            type is used to communicate the status of the reconciliation process. See also: https://github.com/knative/serving/blob/main/docs/spec/errors.md#error-conditions-and-reporting Types common to all resources include: * "Ready": True when the Resource is ready.
+          output: true
+        - name: 'state'
+          type: String
+          description: |-
+            State of the condition.
+          output: true
+        - name: 'message'
+          type: String
+          description: |-
+            Human readable message indicating details about the current status.
+          output: true
+        - name: 'lastTransitionTime'
+          type: Time
+          description: |-
+            Last time the condition transitioned from one status to another.
+
+            A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+          output: true
+        - name: 'severity'
+          type: String
+          description: |-
+            How to interpret failures of this condition, one of Error, Warning, Info
+          output: true
+        - name: 'reason'
+          type: String
+          description: |-
+            A common (instance-level) reason for this condition.
+          output: true
+        - name: 'instanceReason'
+          type: String
+          description: |-
+            A reason for the instance condition.
+          output: true
+  - name: 'containerStatuses'
+    type: Array
+    description: |-
+      Status information for each of the specified containers. The status includes the resolved digest for specified images.
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: |-
+            The name of the container, if specified.
+          output: true
+        - name: 'imageDigest'
+          type: String
+          description: |-
+            ImageDigest holds the resolved digest for the image specified and resolved during the creation of Revision. This field holds the digest value regardless of whether a tag or digest was originally specified in the Container object.
+          output: true
+  - name: 'satisfiesPzs'
+    type: Boolean
+    description: |-
+      Reserved for future use. True if this service satisfies zone separation.
+    output: true
+  - name: 'urls'
+    type: Array
+    description: |-
+      All URLs serving traffic for this Instance.
+    output: true
+    item_type:
+      type: String
+  - name: 'reconciling'
+    type: Boolean
+    description: |
+      Returns true if the Instance is currently being acted upon by the system to bring it into the desired state.
+
+      When a new Instance is created, or an existing one is updated, Cloud Run will asynchronously perform all necessary steps to bring the Instance to the desired serving state. This process is called reconciliation. While reconciliation is in process, observedGeneration will have a transient value that might mismatch the intended state: Once reconciliation is over (and this field is false), there are two possible outcomes: reconciliation succeeded and the serving state matches the Instance, or there was an error, and reconciliation failed. This state can be found in terminalCondition.state.
+    output: true
+  - name: 'etag'
+    type: String
+    description: |
+      A system-generated fingerprint for this version of the resource. May be used to detect modification conflict during updates.
+    output: true

--- a/mmv1/templates/terraform/pre_delete/cloudrunv2_instance_deletion_policy.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/cloudrunv2_instance_deletion_policy.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy Instance without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_instance_basic.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_cloud_run_v2_instance" "{{$.PrimaryResourceId}}" {
+  name     = "{{index $.ResourceIdVars "cloud_run_instance_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+
+  containers {
+    image = "us-docker.pkg.dev/cloudrun/container/hello"
+  }
+}

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_instance_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_instance_full.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_cloud_run_v2_instance" "{{$.PrimaryResourceId}}" {
+  name     = "{{index $.ResourceIdVars "cloud_run_instance_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+  ingress = "{{index $.Vars "ingress"}}"
+  restart_policy = "{{index $.Vars "restart_policy"}}"
+
+  labels = {
+    "env" = "{{index $.Vars "label_env"}}"
+  }
+
+  containers {
+    image = "us-docker.pkg.dev/cloudrun/container/hello"
+    ports {
+      container_port = 8080
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_instance_limits.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_instance_limits.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_cloud_run_v2_instance" "{{$.PrimaryResourceId}}" {
+  name     = "{{index $.ResourceIdVars "cloud_run_instance_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+
+  containers {
+    image = "us-docker.pkg.dev/cloudrun/container/hello"
+    resources {
+      limits = {
+        cpu    = "2"
+        memory = "1024Mi"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds Terraform support for Cloud Run v2 Instance (`google_cloud_run_v2_instance`) in `google-beta`.

### Summary of Changes
- Adds `mmv1/products/cloudrunv2/Instance.yaml` schema definition with `min_version: beta`.
- Exposes core instance properties:
  - Containers configuration, environment variables, and resource limits (`cpu`, `memory`).
  - Probes (`startup_probe`, `liveness_probe`).
  - Volumes (`secret`, `cloud_sql_instance`, `empty_dir`, `gcs`, `nfs`) and volume mounts.
  - Direct VPC networking (`network_interfaces`, `egress`).
  - Ingress controls (`ingress`), restart policies (`restart_policy`), and CMEK (`encryption_key`).
  - IAM resources (`google_cloud_run_v2_instance_iam_*`).
  - Virtual field `deletion_protection` with pre-delete hook.
- Adds declarative sample templates and acceptance tests:
  - `cloudrunv2_instance_basic`: Minimal configuration.
  - `cloudrunv2_instance_limits`: Resource limits configuration.
  - `cloudrunv2_instance_full`: Full configuration with multi-step in-place `PATCH` update testing.
- Explicitly omits unreleased/unsupported preview features:
  - VPC connector (instances use Direct VPC)
  - GPU configurations (`node_selector`, `gpu_zonal_redundancy_disabled`)
  - IAP (`iap_enabled`)
  - Internal/gated fields (`termination_grace_period`, `sandboxes`, `ssh_enabled`)

```release-note:new-resource
cloudrun: added `google_cloud_run_v2_instance` resource and IAM resources (`google_cloud_run_v2_instance_iam_binding`, `google_cloud_run_v2_instance_iam_member`, `google_cloud_run_v2_instance_iam_policy`) (beta)
```