### PR TITLE
gkebackup: add list resources

### DIFF
--- a/mmv1/products/gkebackup/BackupChannel.yaml
+++ b/mmv1/products/gkebackup/BackupChannel.yaml
@@ -39,6 +39,7 @@ async:
   result:
     resource_inside_response: true
 autogen_async: true
+generate_list_resource: true
 custom_code:
 samples:
   - name: gkebackup_backupchannel_basic

--- a/mmv1/products/gkebackup/BackupPlan.yaml
+++ b/mmv1/products/gkebackup/BackupPlan.yaml
@@ -43,6 +43,7 @@ async:
   result:
     resource_inside_response: true
 autogen_async: true
+generate_list_resource: true
 include_in_tgc_next: true
 custom_code:
 samples:

--- a/mmv1/products/gkebackup/RestoreChannel.yaml
+++ b/mmv1/products/gkebackup/RestoreChannel.yaml
@@ -39,6 +39,7 @@ async:
   result:
     resource_inside_response: true
 autogen_async: true
+generate_list_resource: true
 custom_code:
 samples:
   - name: gkebackup_restorechannel_basic

--- a/mmv1/products/gkebackup/RestorePlan.yaml
+++ b/mmv1/products/gkebackup/RestorePlan.yaml
@@ -43,6 +43,7 @@ async:
   result:
     resource_inside_response: true
 autogen_async: true
+generate_list_resource: true
 include_in_tgc_next: true
 custom_code:
 samples:


### PR DESCRIPTION
Adds list-resource generation for the following gkebackup resources:

- `google_gkebackup_backup_channel`
- `google_gkebackup_backup_plan`
- `google_gkebackup_restore_channel`
- `google_gkebackup_restore_plan`

```release-note:new-list-resource
`google_gkebackup_backup_channel`
```

```release-note:new-list-resource
`google_gkebackup_backup_plan`
```

```release-note:new-list-resource
`google_gkebackup_restore_channel`
```

```release-note:new-list-resource
`google_gkebackup_restore_plan`
```

Tests: Acceptance tests PASSED (confirmed by Validator agent).
