### PR TITLE
hypercomputecluster: Add support for `network_tags` and `existing_nfs` in `google_hypercomputecluster_cluster`

### DIFF
--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -788,6 +788,8 @@ func (t *Type) ExcludeIfNotInVersion(version *product.Version) {
 		}
 	} else if t.IsA("Array") && t.ItemType.IsA("NestedObject") {
 		t.ItemType.ExcludeIfNotInVersion(version)
+	} else if t.IsA("Map") && t.ValueType != nil {
+		t.ValueType.ExcludeIfNotInVersion(version)
 	}
 }
 

--- a/mmv1/products/hypercomputecluster/Cluster.yaml
+++ b/mmv1/products/hypercomputecluster/Cluster.yaml
@@ -101,6 +101,14 @@ properties:
                   description: |-
                     Specifies the time limit for created instances. Instances will be
                     terminated at the end of this duration.
+                - name: networkTags
+                  type: Array
+                  min_version: beta
+                  description: |-
+                    A list of network tags to attach to the VM instances.
+                    A maximum of 64 network tags are allowed.
+                  item_type:
+                    type: String
                 - name: zone
                   type: String
                   required: true
@@ -121,6 +129,14 @@ properties:
                     Name of the Compute Engine [machine
                     type](https://cloud.google.com/compute/docs/machine-resource) to use, e.g.
                     `n2-standard-2`.
+                - name: networkTags
+                  type: Array
+                  min_version: beta
+                  description: |-
+                    A list of network tags to attach to the VM instances.
+                    A maximum of 64 network tags are allowed.
+                  item_type:
+                    type: String
                 - name: zone
                   type: String
                   required: true
@@ -135,6 +151,14 @@ properties:
                 be created from a
                 [reservation](https://cloud.google.com/compute/docs/instances/reservations-overview).
               properties:
+                - name: networkTags
+                  type: Array
+                  min_version: beta
+                  description: |-
+                    A list of network tags to attach to the VM instances.
+                    A maximum of 64 network tags are allowed.
+                  item_type:
+                    type: String
                 - name: reservation
                   type: String
                   description: |-
@@ -154,6 +178,14 @@ properties:
                     Name of the Compute Engine [machine
                     type](https://cloud.google.com/compute/docs/machine-resource) to use, e.g.
                     `n2-standard-2`.
+                - name: networkTags
+                  type: Array
+                  min_version: beta
+                  description: |-
+                    A list of network tags to attach to the VM instances.
+                    A maximum of 64 network tags are allowed.
+                  item_type:
+                    type: String
                 - name: terminationAction
                   type: String
                   description: |-
@@ -358,6 +390,14 @@ properties:
                   Name of the Compute Engine [machine
                   type](https://cloud.google.com/compute/docs/machine-resource) to use for
                   login nodes, e.g. `n2-standard-2`.
+              - name: networkTags
+                type: Array
+                min_version: beta
+                description: |-
+                  A list of network tags to attach to the VM instances.
+                  A maximum of 64 network tags are allowed.
+                item_type:
+                  type: String
               - name: startupScript
                 type: String
                 description: |-
@@ -594,6 +634,26 @@ properties:
                   description: |-
                     Name of the Managed Lustre instance to import, in the format
                     `projects/{project}/locations/{location}/instances/{instance}`
+            - name: existingNfs
+              type: NestedObject
+              min_version: beta
+              description: |-
+                When set in a StorageResourceConfig, indicates that an existing NFS
+                share should be imported.
+              properties:
+                - name: mountOptions
+                  type: String
+                  description: |-
+                    Options to mount the NFS share, as expected by fs_mntops field in fstab(5),
+                    for example: "rw,vers=4.1,nconnect=2,noatime".
+                - name: remoteMount
+                  type: String
+                  required: true
+                  description: Remote mount path of the NFS share.
+                - name: serverIpAddress
+                  type: String
+                  required: true
+                  description: Server IP address of the NFS share.
             - name: newBucket
               type: NestedObject
               description: |-

--- a/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
+++ b/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
@@ -138,6 +138,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
         machine_type = "n2-standard-2"
         zone = "us-central1-a"
         termination_action = "STOP"
+        network_tags = ["tag1", "tag2"]
       }
     }
   }
@@ -165,6 +166,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
         labels = {
           old-key = "old-value"
         }
+        network_tags = ["tag1", "tag2"]
         startup_script = "#! /bin/bash"
         storage_configs {
           id = "storage-old"
@@ -235,6 +237,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
         machine_type = "n2-standard-2"
         zone = "us-central1-a"
         termination_action = "DELETE"
+        network_tags = ["tag1"]
       }
     }
   }
@@ -262,6 +265,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
         labels = {
           new-key = "new-value"
         }
+        network_tags = ["tag1"]
         storage_configs {
           id = "storage-new"
           local_mount = "/home"
@@ -410,6 +414,15 @@ resource "google_hypercomputecluster_cluster" "cluster" {
     }
   }
   storage_resources {
+    id = "nfs-existing"
+    config {
+      existing_nfs {
+        server_ip_address = google_filestore_instance.filestore_instance.networks[0].ip_addresses[0]
+        remote_mount      = "/${google_filestore_instance.filestore_instance.file_shares[0].name}"
+      }
+    }
+  }
+  storage_resources {
     id = "lustre-existing"
     config {
       existing_lustre {
@@ -551,7 +564,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
         description = "Lustre instance created via Terraform"
         filesystem = "lustrefs"
         lustre = "projects/${local.project_id}/locations/us-central1-a/instances/lustre-%{random_suffix}"
-          per_unit_storage_throughput = "1000"
+        per_unit_storage_throughput = "1000"
       }
     }
   }
@@ -561,6 +574,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
       new_on_demand_instances {
         machine_type = "n2-standard-2"
         zone = "us-central1-a"
+        network_tags = ["tag1", "tag2"]
       }
     }
   }
@@ -571,6 +585,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
         machine_type = "a3-megagpu-8g"
         max_duration = "6000s"
         zone = "us-central1-a"
+        network_tags = ["tag1", "tag2"]
       }
     }
   }
@@ -579,6 +594,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
     config {
       new_reserved_instances {
         reservation = google_compute_reservation.gce_reservation.id
+        network_tags = ["tag1", "tag2"]
       }
     }
   }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add support for `network_tags` and `existing_nfs` in `google_hypercomputecluster_cluster` in beta provider.

Additionally, add support for overriding `min_version` nested within Map structures.

b/522163251

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
hypercomputecluster: added `network_tags` field to `compute_resources` and `login_nodes`, added `existing_nfs` option for storage resources to `google_hypercomputecluster_cluster` resource (beta)
```
