### PR TITLE
Add Secure Source Manager support to Developer Connect Connection resource

### DIFF
--- a/mmv1/products/developerconnect/Connection.yaml
+++ b/mmv1/products/developerconnect/Connection.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: Connection
-description: A connection for GitHub, GitHub Enterprise, GitLab, and GitLab Enterprise.
+description: A connection for GitHub, GitHub Enterprise, GitLab, GitLab Enterprise, Bitbucket Cloud, Bitbucket Data Center, and Secure Source Manager.
 references:
   guides:
     Official Documentation: https://cloud.google.com/developer-connect/docs/overview
@@ -139,6 +139,13 @@ samples:
       - name: developer_connect_connection_http_conn_bearer
         resource_id_vars:
           connection_name: tf-test-connection
+  - name: developer_connect_connection_securesourcemanager
+    primary_resource_id: my-connection
+    steps:
+      - name: developer_connect_connection_securesourcemanager
+        resource_id_vars:
+          connection_name: tf-test-connection
+          instance_id: tf-test-instance
 parameters:
   - name: location
     type: String
@@ -631,3 +638,14 @@ properties:
           in Cloud KMS, the key should be in the format of
           `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
         required: true
+  - name: secureSourceManagerInstanceConfig
+    type: NestedObject
+    description: Configuration for connections to an instance of Secure Source Manager.
+    properties:
+      - name: instance
+        type: String
+        description: |-
+          Required. Immutable. The Secure Source Manager instance resource name,
+          formatted as `projects/*/locations/*/instances/*`.
+        required: true
+        immutable: true

--- a/mmv1/templates/terraform/samples/services/developerconnect/developer_connect_connection_securesourcemanager.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/developerconnect/developer_connect_connection_securesourcemanager.tf.tmpl
@@ -1,0 +1,39 @@
+data "google_project" "project" {}
+
+resource "google_project_service_identity" "devconnect_p4sa" {
+  service = "developerconnect.googleapis.com"
+}
+
+resource "google_project_iam_member" "devconnect_sa_role" {
+  project = data.google_project.project.project_id
+  role    = "roles/developerconnect.serviceAgent"
+  member  = google_project_service_identity.devconnect_p4sa.member
+}
+
+resource "google_project_iam_member" "devconnect_ssm_linker" {
+  project = data.google_project.project.project_id
+  role    = "roles/securesourcemanager.developerConnectLinker"
+  member  = google_project_service_identity.devconnect_p4sa.member
+}
+
+resource "google_secure_source_manager_instance" "instance" {
+    location = "us-east1"
+    instance_id = "{{index $.ResourceIdVars "instance_id"}}"
+
+    # Prevent accidental deletions.
+    deletion_policy = "DELETE"
+}
+
+resource "google_developer_connect_connection" "{{$.PrimaryResourceId}}" {
+    location = "us-east1"
+    connection_id = "{{index $.ResourceIdVars "connection_name"}}"
+
+    secure_source_manager_instance_config {
+        instance = google_secure_source_manager_instance.instance.name
+    }
+
+    depends_on = [
+        google_project_iam_member.devconnect_sa_role,
+        google_project_iam_member.devconnect_ssm_linker
+    ]
+}


### PR DESCRIPTION
This PR adds support for Secure Source Manager (SSM) connections to the `google_developer_connect_connection` resource via `secure_source_manager_instance_config`.
- Added `secureSourceManagerInstanceConfig` property to `Connection.yaml`.
- Added sample configuration & automated acceptance test template.
- Verified compilation across Beta and GA providers.
- Acceptance test passed in `google-beta`: `TestAccDeveloperConnectConnection_developerConnectConnectionSecuresourcemanagerExample`.
Reference: b/550463206

```release-note:enhancement
developerconnect: added `secure_source_manager_instance_config` field to `google_developer_connect_connection`
```