### PR TITLE
Query template doc update

### DIFF
--- a/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
+++ b/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
@@ -72,7 +72,7 @@ custom_code:
   post_create: "templates/terraform/post_create/bigquery_analytics_hub_query_template.go.tmpl"
   custom_delete: "templates/terraform/custom_delete/bigquery_analytics_hub_query_template.go.tmpl"
 custom_diff:
-  - "resourceBigqueryAnalyticsHubQueryTemplateCustomDiff"
+  - 'resourceBigqueryAnalyticsHubQueryTemplateCustomDiff'
 virtual_fields:
   - name: "submit"
     type: Boolean

--- a/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
+++ b/mmv1/products/bigqueryanalyticshub/QueryTemplate.yaml
@@ -20,6 +20,8 @@ description: |
   Represents a BigQuery Query Template within a Data Exchange.
   This resource defines a reusable SQL routine (e.g., a TVF) that can be
   shared or executed via the Data Exchange.
+  ~> **Note:** Approving a Query Template is not supported by Terraform. The approve flow includes steps that can only be performed through the Google Cloud console UI. You can still create a Query Template (e.g. a TVF) and add it as a listing to a Data Clean Room via Terraform, but the final approval must be done manually.
+
 references:
   guides:
     "Use query templates": "https://docs.cloud.google.com/bigquery/docs/query-templates"
@@ -70,7 +72,7 @@ custom_code:
   post_create: "templates/terraform/post_create/bigquery_analytics_hub_query_template.go.tmpl"
   custom_delete: "templates/terraform/custom_delete/bigquery_analytics_hub_query_template.go.tmpl"
 custom_diff:
-  - 'resourceBigqueryAnalyticsHubQueryTemplateCustomDiff'
+  - "resourceBigqueryAnalyticsHubQueryTemplateCustomDiff"
 virtual_fields:
   - name: "submit"
     type: Boolean


### PR DESCRIPTION
Adds a documentation callout to the `google_bigquery_analytics_hub_query_template` resource to explicitly state that query template approvals are not supported via Terraform.

Because approving a query template is a one-time, imperative workflow action rather than declarative infrastructure state, it was intentionally excluded from the provider. However, since we are seeing customer questions regarding how to approve templates in their IaC workflows, this note clarifies that while templates can be created and submitted via Terraform, the final approval step must be performed manually in the Google Cloud Console.
```release-note:none
```
