### PR TITLE
container: add skip_node_pool_refresh to google_container_cluster data source

### DIFF
--- a/mmv1/third_party/terraform/services/container/data_source_google_container_cluster.go
+++ b/mmv1/third_party/terraform/services/container/data_source_google_container_cluster.go
@@ -18,6 +18,9 @@ func DataSourceGoogleContainerCluster() *schema.Resource {
 
 	// Set 'Optional' schema elements
 	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project", "location")
+	// skip_node_pool_refresh is an input to the read path (flattenClusterNodePools),
+	// so it must be settable instead of computed-only. See resource_container_cluster.go.
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "skip_node_pool_refresh")
 
 	return &schema.Resource{
 		Read:   datasourceContainerClusterRead,

--- a/mmv1/third_party/terraform/services/container/data_source_google_container_cluster_test.go
+++ b/mmv1/third_party/terraform/services/container/data_source_google_container_cluster_test.go
@@ -61,6 +61,26 @@ func TestAccContainerClusterDatasource_regional(t *testing.T) {
 	})
 }
 
+func TestAccContainerClusterDatasource_skipNodePoolRefresh(t *testing.T) {
+	t.Parallel()
+
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerClusterDatasource_skipNodePoolRefresh(acctest.RandString(t, 10), networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_container_cluster.kubes", "node_pool.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccContainerClusterDatasource_zonal(suffix, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "kubes" {
@@ -77,6 +97,28 @@ resource "google_container_cluster" "kubes" {
 data "google_container_cluster" "kubes" {
   name     = google_container_cluster.kubes.name
   location = google_container_cluster.kubes.location
+}
+`, suffix, networkName, subnetworkName)
+}
+
+func testAccContainerClusterDatasource_skipNodePoolRefresh(suffix, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "kubes" {
+  name               = "tf-test-cluster-%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
+}
+
+data "google_container_cluster" "kubes" {
+  name     = google_container_cluster.kubes.name
+  location = google_container_cluster.kubes.location
+
+  skip_node_pool_refresh = true
 }
 `, suffix, networkName, subnetworkName)
 }

--- a/mmv1/third_party/terraform/website/docs/d/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_cluster.html.markdown
@@ -49,6 +49,14 @@ favour of `location`.
 * `region` (Optional) - The region this cluster has been created in. Deprecated
 in favour of `location`.
 
+* `skip_node_pool_refresh` (Optional) - Whether to skip refreshing the GKE
+cluster's node pool list during the data source read. Setting this to `true`
+prevents the provider from querying the GKE API for node pools, which resolves
+long read times on clusters with a large number of node pools. When enabled,
+the `node_pool` attribute will be empty (`[]`), even if node pools exist. See
+[the resource documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster)
+for details.
+
 - - -
 
 * `project` - (Optional) The project in which the resource belongs. If it


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29171

# Description

The `skip_node_pool_refresh` performance flag added to the `google_container_cluster` resource in #17968 is not usable from the corresponding data source: `DatasourceSchemaFromResourceSchema` copies every resource field as computed-only, so the flag exists on the data source but cannot be set.

The data source read path already honors the flag — `datasourceContainerClusterRead` delegates to `resourceContainerClusterRead`, which skips the node pool flattening in `flattenClusterNodePools` when the flag is set. This PR makes the field settable via `AddOptionalFieldsToSchema`, so users with clusters that have a high node pool count can opt out of the node pool read:

```tf
data "google_container_cluster" "my_cluster" {
  name     = "my-cluster"
  location = "us-east1-a"

  skip_node_pool_refresh = true
}
```

When enabled, the data source's `node_pool` attribute remains empty (`[]`), matching the resource-side behavior.

## Testing

- Generated the `google` provider locally and confirmed the diff is scoped to the data source, its test, and the data source docs
- Provider builds and `go vet`/`go test ./google/services/container/` pass (including `TestUnitFlattenClusterNodePools`)
- A local check confirmed the generated data source schema marks `skip_node_pool_refresh` as Optional while `node_pool` stays computed-only
- Added `TestAccContainerClusterDatasource_skipNodePoolRefresh`, mirroring the existing data source tests, which asserts `node_pool.# = 0` when the flag is set (requires a real GCP project / VCR cassette to run)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: added `skip_node_pool_refresh` field to `google_container_cluster` data source. When set to true, the data source skips reading node pools from the API, resolving long read times on clusters with a large number of node pools. Note that this results in `node_pool` being set to an empty list
```

🤖 Generated with [OpenCode](https://opencode.ai) (GPT-5.6 Terra)