### PR TITLE
compute: add expose_host_topology to instance and instance template s…

### DIFF
--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -658,6 +658,10 @@ properties:
           Defines whether the instance is preemptible. This can only be set
           during instance creation, it cannot be set or changed after the
           instance has been created.
+      - name: 'exposeHostTopology'
+        type: Boolean
+        description: |
+          Opt-in flag to expose the hashed physical host ID in the VM's ResourceStatus.
   - name: 'reservationAffinity'
     type: NestedObject
     description: |

--- a/mmv1/products/compute/InstanceTemplate.yaml
+++ b/mmv1/products/compute/InstanceTemplate.yaml
@@ -14,6 +14,14 @@ properties:
       Name of the resource.
     required: true
     immutable: true
+  - name: 'scheduling'
+    type: NestedObject
+    description: Sets the scheduling options for this instance.
+    properties:
+      - name: 'exposeHostTopology'
+        type: Boolean
+        description: |
+          Opt-in flag to expose the hashed physical host ID in the VM's ResourceStatus.
 iam_policy:
   parent_resource_attribute: 'name'
   base_url: 'projects/{{project}}/global/instanceTemplates/{{name}}'

--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -267,6 +267,9 @@ func expandScheduling(v interface{}) (map[string]interface{}, error) {
 			result["localSsdRecoveryTimeout"] = transformedLocalSsdRecoveryTimeout
 		}
 	}
+	if v, ok := original["expose_host_topology"]; ok {
+		result["exposeHostTopology"] = v.(bool)
+	}
 	if v, ok := original["termination_time"]; ok && v.(string) != "" {
 		result["terminationTime"] = v.(string)
 	}
@@ -421,6 +424,10 @@ func flattenScheduling(resp map[string]interface{}) []map[string]interface{} {
 
 	if ois, ok := resp["onInstanceStopAction"].(map[string]interface{}); ok {
 		schedulingMap["on_instance_stop_action"] = flattenOnInstanceStopAction(ois)
+	}
+
+	if eth, ok := resp["exposeHostTopology"].(bool); ok {
+		schedulingMap["expose_host_topology"] = eth
 	}
 
 	if h := getInt(resp["hostErrorTimeoutSeconds"]); h != 0 {
@@ -1356,6 +1363,10 @@ func schedulingHasChangeWithoutReboot(d *schema.ResourceData) bool {
 		return true
 	}
 {{- end }}
+
+	if oScheduling["expose_host_topology"] != newScheduling["expose_host_topology"] {
+		return true
+	}
 
 	return false
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -121,6 +121,7 @@ var (
 		"scheduling.0.preemption_notice_duration",
 {{- end }}
 		"scheduling.0.local_ssd_recovery_timeout",
+		"scheduling.0.expose_host_topology",
 	}
 
 	shieldedInstanceConfigKeys = []string{
@@ -1372,6 +1373,12 @@ be from 0 to 999,999,999 inclusive.`,
 							},
 						},
 						{{- end }}
+						"expose_host_topology": {
+							Type:         schema.TypeBool,
+							Optional:     true,
+							AtLeastOneOf: schedulingKeys,
+							Description:  `Opt-in flag to expose the hashed physical host ID in the VM's ResourceStatus.`,
+						},
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_meta.yaml.tmpl
@@ -218,6 +218,7 @@ fields:
   - api_field: 'resourcePolicies'
   - api_field: 'scheduling.automaticRestart'
   - api_field: 'scheduling.availabilityDomain'
+  - api_field: 'scheduling.exposeHostTopology'
   - api_field: 'scheduling.gracefulShutdown.enabled'
   - api_field: 'scheduling.gracefulShutdown.maxDuration.nanos'
   - api_field: 'scheduling.gracefulShutdown.maxDuration.seconds'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_meta.yaml.tmpl
@@ -229,6 +229,7 @@ fields:
   - api_field: 'resourcePolicies'
   - api_field: 'scheduling.automaticRestart'
   - api_field: 'scheduling.availabilityDomain'
+  - api_field: 'scheduling.exposeHostTopology'
 {{- if ne $.TargetVersionName "ga" }}
   - api_field: 'scheduling.gracefulShutdown.enabled'
   - api_field: 'scheduling.gracefulShutdown.maxDuration.nanos'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_meta.yaml.tmpl
@@ -232,6 +232,7 @@ fields:
   - api_field: 'resourcePolicies'
   - api_field: 'scheduling.automaticRestart'
   - api_field: 'scheduling.availabilityDomain'
+  - api_field: 'scheduling.exposeHostTopology'
 {{- if ne $.TargetVersionName "ga" }}
   - api_field: 'scheduling.gracefulShutdown.enabled'
   - api_field: 'scheduling.gracefulShutdown.maxDuration.nanos'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -48,6 +48,7 @@ var (
 		"scheduling.0.preemption_notice_duration",
 {{- end }}
 		"scheduling.0.local_ssd_recovery_timeout",
+		"scheduling.0.expose_host_topology",
 	}
 
 	shieldedInstanceTemplateConfigKeys = []string{
@@ -1023,6 +1024,13 @@ be from 0 to 999,999,999 inclusive.`,
 							},
 						},
 {{- end }}
+						"expose_host_topology": {
+							Type:         schema.TypeBool,
+							Optional:     true,
+							ForceNew:     true,
+							AtLeastOneOf: schedulingInstTemplateKeys,
+							Description:  `Opt-in flag to expose the hashed physical host ID in the VM's ResourceStatus.`,
+						},
 					},
 				},
 			},
@@ -2353,6 +2361,7 @@ func expandResourceComputeInstanceTemplateScheduling(d *schema.ResourceData, met
 		{"provisioningModel", "ProvisioningModel"},
 		{"instanceTerminationAction", "InstanceTerminationAction"},
 		{"skipGuestOsShutdown", "SkipGuestOsShutdown"},
+		{"exposeHostTopology", "ExposeHostTopology"},
 	} {
 		if _, ok := expanded[pair[0]]; ok {
 			schedulingTyped.ForceSendFields = append(schedulingTyped.ForceSendFields, pair[1])

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_meta.yaml.tmpl
@@ -201,6 +201,8 @@ fields:
     api_field: 'properties.scheduling.automaticRestart'
   - field: 'scheduling.availability_domain'
     api_field: 'properties.scheduling.availabilityDomain'
+  - field: 'scheduling.expose_host_topology'
+    api_field: 'properties.scheduling.exposeHostTopology'
 {{- if ne $.TargetVersionName "ga" }}
   - api_field: 'properties.scheduling.gracefulShutdown.enabled'
     field: 'scheduling.graceful_shutdown.enabled'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -6230,3 +6230,67 @@ resource "google_compute_instance_template" "foobar" {
 `, suffix, suffix, suffix)
 }
 {{- end }}
+
+func TestAccComputeInstanceTemplate_schedulingExposeHostTopology(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate map[string]interface{}
+	var templateName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_schedulingExposeHostTopology(templateName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "scheduling.0.expose_host_topology", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeInstanceTemplate_schedulingExposeHostTopology(templateName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "scheduling.0.expose_host_topology", "false"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeInstanceTemplate_schedulingExposeHostTopology(template string, expose bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  disk {
+    source_image = "debian-cloud/debian-11"
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    expose_host_topology = %t
+  }
+}
+`, template, expose)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -14702,3 +14702,64 @@ resource "google_compute_instance" "foobar" {
 `, context)
 }
 
+func TestAccComputeInstance_schedulingExposeHostTopology(t *testing.T) {
+	t.Parallel()
+
+	var instance map[string]interface{}
+	var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_schedulingExposeHostTopology(instanceName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.expose_host_topology", "true"),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			{
+				Config: testAccComputeInstance_schedulingExposeHostTopology(instanceName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.expose_host_topology", "false"),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+		},
+	})
+}
+
+func testAccComputeInstance_schedulingExposeHostTopology(instance string, expose bool) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    expose_host_topology = %t
+  }
+}
+`, instance, expose)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -984,6 +984,13 @@ be from 0 to 999,999,999 inclusive.`,
 							},
 						},
 {{- end }}
+						"expose_host_topology": {
+							Type:         schema.TypeBool,
+							Optional:     true,
+							ForceNew:     true,
+							AtLeastOneOf: schedulingInstTemplateKeys,
+							Description:  `Opt-in flag to expose the hashed physical host ID in the VM's ResourceStatus.`,
+						},
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_meta.yaml.tmpl
@@ -199,6 +199,8 @@ fields:
     api_field: 'properties.scheduling.automaticRestart'
   - field: 'scheduling.availability_domain'
     api_field: 'properties.scheduling.availabilityDomain'
+  - field: 'scheduling.expose_host_topology'
+    api_field: 'properties.scheduling.exposeHostTopology'
 {{- if ne $.TargetVersionName "ga" }}
   - api_field: 'properties.scheduling.gracefulShutdown.enabled'
     field: 'scheduling.graceful_shutdown.enabled'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -5788,3 +5788,68 @@ resource "google_compute_region_instance_template" "foobar" {
 }
 `, suffix, suffix, suffix, suffix, suffix, suffix)
 }
+
+func TestAccComputeRegionInstanceTemplate_schedulingExposeHostTopology(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate map[string]interface{}
+	var templateName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_schedulingExposeHostTopology(templateName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "scheduling.0.expose_host_topology", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionInstanceTemplate_schedulingExposeHostTopology(templateName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "scheduling.0.expose_host_topology", "false"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeRegionInstanceTemplate_schedulingExposeHostTopology(template string, expose bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  disk {
+    source_image = "debian-cloud/debian-11"
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    expose_host_topology = %t
+  }
+}
+`, template, expose)
+}

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -617,6 +617,8 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `preemption_notice_duration` - (Optional) [Beta](../guides/provider_versions.html.markdown) Specifies the Metadata Service preemption notice duration before the GCE ACPI G2 Soft Off signal is triggered for Spot VMs only. If not specified, there will be no wait before the G2 Soft Off signal is triggered. Structure is [documented below](#nested_preemption_notice_duration).
 
+* `expose_host_topology` - (Optional) Opt-in flag to expose the hashed physical host ID in the VM's ResourceStatus.
+
 <a name="nested_graceful_shutdown"></a>The `graceful_shutdown` block supports:
 
 * `enabled` - (Required) Opts-in for graceful shutdown.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -711,6 +711,8 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `preemption_notice_duration` - (Optional) [Beta](../guides/provider_versions.html.markdown) Specifies the Metadata Service preemption notice duration before the GCE ACPI G2 Soft Off signal is triggered for Spot VMs only. If not specified, there will be no wait before the G2 Soft Off signal is triggered. Structure is [documented below](#nested_preemption_notice_duration).
 
+* `expose_host_topology` - (Optional) Opt-in flag to expose the hashed physical host ID in the VM's ResourceStatus.
+
 <a name="nested_graceful_shutdown"></a>The `graceful_shutdown` block supports:
 
 * `enabled` - (Required) Opts-in for graceful shutdown.

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -670,6 +670,8 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `host_error_timeout_seconds` - (Optional) Specifies the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.
 
+* `expose_host_topology` - (Optional) Opt-in flag to expose the hashed physical host ID in the VM's ResourceStatus.
+
 * `max_run_duration` -  (Optional)  The duration of the instance. Instance will run and be terminated after then, the termination action could be defined in `instance_termination_action`. Only support `DELETE` `instance_termination_action` at this point. Structure is [documented below](#nested_max_run_duration).
 
 <a name="nested_max_run_duration"></a>The `max_run_duration` block supports:


### PR DESCRIPTION
Adds `expose_host_topology` field to `scheduling` for `google_compute_instance`, `google_compute_instance_template`, and `google_compute_region_instance_template` across GA (`v1`) and `beta`.

This field allows exposing host topology / hashed physical host ID to the VM instance.

Tested against GCE API and verified with acceptance tests on `google_compute_instance`, `google_compute_instance_template`, and `google_compute_region_instance_template`.

```release-note:enhancement
compute: added `expose_host_topology` field to `google_compute_instance` resource
```
```release-note:enhancement
compute: added `expose_host_topology` field to `google_compute_instance_template` resource
```
```release-note:enhancement
compute: added `expose_host_topology` field to `google_compute_region_instance_template` resource
```