### PR TITLE
sql: refresh settingsVersion before updating google_sql_database_instance

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -2779,6 +2779,14 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 
 	databaseVersion := d.Get("database_version").(string)
 
+	// Capture the planned settings before any of the conditional
+	// resourceSqlDatabaseInstanceRead calls below run. Those reads call d.Set("settings", ...),
+	// and helper/schema resolves d.Get through the "set" level in preference to "diff", so a
+	// d.Get("settings") issued after a read returns the instance's remote values rather than the
+	// planned ones. Capturing it late silently drops the user's change: the apply reports success
+	// and the same diff reappears on the next plan.
+	desiredSetting := d.Get("settings")
+
 	// Check if the activation policy is being updated. If it is being changed to ALWAYS this should be done first.
 	if d.HasChange("settings.0.activation_policy") && d.Get("settings.0.activation_policy").(string) == "ALWAYS" {
 		instance = &sqladmin.DatabaseInstance{Settings: &sqladmin.Settings{ActivationPolicy: "ALWAYS"}}
@@ -3048,7 +3056,6 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
     	}
 	}
 
-	desiredSetting := d.Get("settings")
 	instance = &sqladmin.DatabaseInstance{
 		Settings: expandSqlDatabaseInstanceSettings(desiredSetting.([]interface{}), databaseVersion),
 	}
@@ -3072,7 +3079,31 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 	// Instance.Patch operation on completion updates the settings proto version by +8. As terraform does not know this it tries
 	// to make an update call with the proto version before patch and fails. To resolve this issue we update the setting version
 	// before making the update call.
-	instance.Settings.SettingsVersion = int64(_settings["version"].(int))
+	//
+	// settings.version in state is only as fresh as the last read, and every
+	// resourceSqlDatabaseInstanceRead above is guarded by a d.HasChange. An update that changes
+	// none of those fields would therefore send a settingsVersion that the API has already moved
+	// past and be rejected with "Error 412: Condition does not match., staleData", leaving the
+	// user to run a refresh by hand. Fetch the current settingsVersion directly instead of calling
+	// resourceSqlDatabaseInstanceRead here: that read would d.Set the rest of the resource and, per
+	// the comment above, shadow the planned values that are still read from d below.
+	var currentInstance *sqladmin.DatabaseInstance
+	err = transport_tpg.Retry(transport_tpg.RetryOptions{
+		RetryFunc: func() (rerr error) {
+			currentInstance, rerr = NewClient(config, userAgent).Instances.Get(project, d.Get("name").(string)).Do()
+			return rerr
+		},
+		Timeout:              d.Timeout(schema.TimeoutRead),
+		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsSqlOperationInProgressError},
+	})
+	if err != nil {
+		return fmt.Errorf("Error, failed to read the current settings version for %s: %s", d.Get("name").(string), err)
+	}
+	if currentInstance.Settings != nil {
+		instance.Settings.SettingsVersion = currentInstance.Settings.SettingsVersion
+	} else {
+		instance.Settings.SettingsVersion = int64(_settings["version"].(int))
+	}
 	// Collation cannot be included in the update request
 	instance.Settings.Collation = ""
 	instance.Settings.DataCacheConfig = expandDataCacheConfig(_settings["data_cache_config"].([]interface{}))

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -10558,3 +10558,90 @@ resource "google_sql_database_instance" "instance" {
 `, instanceName, enforce)
 }
 
+
+// TestAccSqlDatabaseInstance_updateWithStaleSettingsVersion covers updating an instance from
+// state that Terraform has not refreshed. Between the two steps the instance's settingsVersion is
+// advanced out of band, and AdditionalCLIOptions makes every plan run with -refresh=false so that
+// the stale settingsVersion is still in state when the update is built. The update path only
+// refreshes settings.version inside d.HasChange guards, none of which this test trips, so without
+// an unconditional refresh of that one field the update is rejected with
+// "Error 412: Condition does not match., staleData".
+//
+// See https://github.com/hashicorp/terraform-provider-google/issues/15762.
+func TestAccSqlDatabaseInstance_updateWithStaleSettingsVersion(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "tf-test-" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		// The update step has to plan from the state the previous step wrote. A refresh would
+		// repair settings.version on its own and the scenario under test could not occur.
+		AdditionalCLIOptions: &resource.AdditionalCLIOptions{
+			Plan: resource.PlanOptions{NoRefresh: true},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testGoogleSqlDatabaseInstance_staleSettingsVersion, databaseName, "one"),
+			},
+			{
+				PreConfig: func() {
+					testAccSqlDatabaseInstanceBumpSettingsVersion(t, databaseName)
+				},
+				Config: fmt.Sprintf(testGoogleSqlDatabaseInstance_staleSettingsVersion, databaseName, "two"),
+				// Assert the planned label actually reached the API. An update that reads the
+				// instance before capturing the planned settings would send the remote values
+				// back, report success, and leave the same diff pending.
+				Check: resource.TestCheckResourceAttr(
+					"google_sql_database_instance.instance", "settings.0.user_labels.track", "two"),
+			},
+		},
+	})
+}
+
+var testGoogleSqlDatabaseInstance_staleSettingsVersion = `
+resource "google_sql_database_instance" "instance" {
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "MYSQL_5_7"
+  deletion_protection = false
+  settings {
+    tier = "db-g1-small"
+    user_labels = {
+      track = "%s"
+    }
+  }
+}
+`
+
+// testAccSqlDatabaseInstanceBumpSettingsVersion patches the instance outside of Terraform so that
+// its settingsVersion advances past the one recorded in state. It reuses the user_labels key the
+// test configuration manages so that the following apply overwrites it and no drift is left
+// behind.
+func testAccSqlDatabaseInstanceBumpSettingsVersion(t *testing.T, instance string) {
+	config := acctest.GoogleProviderConfig(t)
+	sqlAdminClient := sql.NewClient(config, config.UserAgent)
+
+	inst, err := sqlAdminClient.Instances.Get(config.Project, instance).Do()
+	if err != nil {
+		t.Errorf("Could not get database instance %q: %s", instance, err)
+		return
+	}
+
+	operation, err := sqlAdminClient.Instances.Patch(config.Project, instance, &sqladmin.DatabaseInstance{
+		Settings: &sqladmin.Settings{
+			SettingsVersion: inst.Settings.SettingsVersion,
+			UserLabels:      map[string]string{"track": "out-of-band"},
+		},
+	}).Do()
+	if err != nil {
+		t.Errorf("Could not patch database instance %q out of band: %s", instance, err)
+		return
+	}
+
+	if err := sql.SqlAdminOperationWaitTime(config, operation, config.Project, "Waiting for out-of-band patch", config.UserAgent, 10*time.Minute); err != nil {
+		t.Errorf("Could not wait for out-of-band patch to complete: %s", err)
+	}
+}


### PR DESCRIPTION
**Draft, not ready for review.** Opened in draft mode deliberately; please do not review yet.

`google_sql_database_instance` updates fail with `Error 412: Condition does not match., staleData` whenever Terraform applies from state it has not just refreshed, and the user has to run a refresh by hand to recover. `resourceSqlDatabaseInstanceUpdate` sets `instance.Settings.SettingsVersion` from `settings.version` in state, and every `resourceSqlDatabaseInstanceRead` in that function sits inside a `d.HasChange` guard, so an update that changes none of the guarded fields sends a `settingsVersion` that the API has already moved past. This is the regression reported in https://github.com/hashicorp/terraform-provider-google/issues/15762.

This fetches the current `settingsVersion` with a targeted `Instances.Get` rather than making one of the existing reads unconditional. A full `resourceSqlDatabaseInstanceRead` also calls `d.Set` for `settings`, `instance_type`, `node_count`, `replication_cluster` and others, and helper/schema resolves `d.Get` through the "set" level in preference to "diff", so an unconditional read would make every later `d.Get` in the update function return the instance's remote values instead of the planned ones.

That same shadowing is why the second change matters. `desiredSetting := d.Get("settings")` currently sits below the conditional reads, so whenever one of them fires (on an `activation_policy`, `database_version`, `maintenance_version` or `edition` change, for example) the planned settings have already been replaced by the remote ones and the rest of the user's `settings` change is dropped: the apply reports success and the same diff returns on the next plan. Hoisting the capture above the reads fixes that. `HasChange` and `GetChange` read at the "diff" level and are unaffected by `d.Set`, so the conditional blocks themselves behave exactly as before.

`TestAccSqlDatabaseInstance_updateWithStaleSettingsVersion` covers the failure: it advances the instance's `settingsVersion` out of band between two steps and sets `AdditionalCLIOptions` with `Plan.NoRefresh` so the harness plans with `-refresh=false` and the stale version survives into the update. The scenario used to be untestable because every step refreshed first. I have not run it against a real project yet, so it needs an acceptance run before this comes out of draft.

A downstream provider fork has carried a patch for this issue since the regression appeared, using an unconditional read instead of the targeted lookup used here; the hoisted `desiredSetting` capture comes from that patch.

```release-note:bug
sql: fixed `Error 412: Condition does not match., staleData` when updating `google_sql_database_instance` from state that has not been refreshed
```
