### PR TITLE
Add Vertex AI RagCorpus resource

### DIFF
--- a/mmv1/products/vertexai/RagCorpus.yaml
+++ b/mmv1/products/vertexai/RagCorpus.yaml
@@ -22,6 +22,7 @@ references:
 base_url: 'projects/{{project}}/locations/{{region}}/ragCorpora'
 self_link: 'projects/{{project}}/locations/{{region}}/ragCorpora/{{name}}'
 create_url: 'projects/{{project}}/locations/{{region}}/ragCorpora'
+collection_url_key: 'ragCorpora'
 update_verb: 'PATCH'
 update_mask: false
 generate_list_resource: true

--- a/mmv1/products/vertexai/RagCorpus.yaml
+++ b/mmv1/products/vertexai/RagCorpus.yaml
@@ -54,11 +54,11 @@ samples:
           display_name: 'rag-corpus-full'
           kms_key_name: 'kms-key'
         test_vars_overrides:
-          kms_key_name: 'kms.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+          kms_key_name: 'kms.BootstrapKMSKeyInLocation(t, "europe-west4").CryptoKey.Name'
 parameters:
   - name: 'region'
     type: String
-    description: The region of the RagCorpus. eg us-central1
+    description: The region of the RagCorpus. eg europe-west4
     url_param_only: true
     immutable: true
 properties:

--- a/mmv1/products/vertexai/RagCorpus.yaml
+++ b/mmv1/products/vertexai/RagCorpus.yaml
@@ -46,7 +46,7 @@ samples:
   - name: 'vertex_ai_rag_corpus_full'
     primary_resource_id: 'example'
     bootstrap_iam:
-      - member: "serviceAccount:service-{project_number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+      - member: "serviceAccount:service-{project_number}@gcp-sa-vertex-rag.iam.gserviceaccount.com"
         role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
     steps:
       - name: 'vertex_ai_rag_corpus_full'

--- a/mmv1/products/vertexai/RagCorpus.yaml
+++ b/mmv1/products/vertexai/RagCorpus.yaml
@@ -1,0 +1,181 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RagCorpus'
+description: |-
+  A RAG corpus is a container for user data uploaded to Vertex AI RAG Engine for chunking, embedding, and indexing.
+references:
+  guides:
+    'Manage your RAG corpus': 'https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/rag-engine/manage-your-rag-corpus'
+  api: 'https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.ragCorpora'
+base_url: 'projects/{{project}}/locations/{{region}}/ragCorpora'
+self_link: 'projects/{{project}}/locations/{{region}}/ragCorpora/{{name}}'
+create_url: 'projects/{{project}}/locations/{{region}}/ragCorpora'
+update_verb: 'PATCH'
+update_mask: false
+generate_list_resource: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  type: OpAsync
+  operation:
+    base_url: '{{op_id}}'
+  actions: ['create', 'delete', 'update']
+  result:
+    resource_inside_response: true
+samples:
+  - name: 'vertex_ai_rag_corpus_basic'
+    primary_resource_id: 'example'
+    steps:
+      - name: 'vertex_ai_rag_corpus_basic'
+        resource_id_vars:
+          display_name: 'rag-corpus'
+  - name: 'vertex_ai_rag_corpus_full'
+    primary_resource_id: 'example'
+    bootstrap_iam:
+      - member: "serviceAccount:service-{project_number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+        role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+    steps:
+      - name: 'vertex_ai_rag_corpus_full'
+        resource_id_vars:
+          display_name: 'rag-corpus-full'
+          kms_key_name: 'kms-key'
+        test_vars_overrides:
+          kms_key_name: 'kms.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+parameters:
+  - name: 'region'
+    type: String
+    description: The region of the RagCorpus. eg us-central1
+    url_param_only: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: |-
+      The generated name of the RagCorpus, in the format
+      projects/{project}/locations/{location}/ragCorpora/{rag_corpus}.
+    output: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+  - name: 'displayName'
+    type: String
+    description: |-
+      Required. The display name of the RagCorpus. The name can be up to 128
+      characters long and can consist of any UTF-8 characters.
+    required: true
+  - name: 'description'
+    type: String
+    description: Optional. The description of the RagCorpus.
+  - name: 'createTime'
+    type: String
+    description: |-
+      Output only. Timestamp when this RagCorpus was created.
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: |-
+      Output only. Timestamp when this RagCorpus was last updated.
+    output: true
+  - name: 'corpusStatus'
+    type: NestedObject
+    description: Output only. RagCorpus state.
+    output: true
+    properties:
+      - name: 'state'
+        type: String
+        description: Output only. RagCorpus life state.
+        output: true
+      - name: 'errorStatus'
+        type: String
+        description: Output only. Only populated when the state is ERROR.
+        output: true
+  - name: 'vectorDbConfig'
+    type: NestedObject
+    description: Optional. Immutable. The config for the RAG-managed Vector DB.
+    immutable: true
+    properties:
+      - name: 'ragManagedDb'
+        type: NestedObject
+        description: The config for the default RAG-managed Vector DB.
+        allow_empty_object: true
+        send_empty_value: true
+        properties:
+          - name: 'knn'
+            type: NestedObject
+            description: Performs a KNN search on RagCorpus. This is the default choice if not specified.
+            exactly_one_of:
+              - vector_db_config.0.rag_managed_db.0.knn
+              - vector_db_config.0.rag_managed_db.0.ann
+            allow_empty_object: true
+            send_empty_value: true
+            properties: []
+          - name: 'ann'
+            type: NestedObject
+            description: Performs an ANN search on RagCorpus.
+            exactly_one_of:
+              - vector_db_config.0.rag_managed_db.0.knn
+              - vector_db_config.0.rag_managed_db.0.ann
+            properties:
+              - name: 'treeDepth'
+                type: Integer
+                description: The depth of the tree-based structure. Only depth values of 2 and 3 are supported. Default value is 2.
+                default_from_api: true
+              - name: 'leafCount'
+                type: Integer
+                description: Number of leaf nodes in the tree-based structure. Default value is 500.
+                default_from_api: true
+      - name: 'ragEmbeddingModelConfig'
+        type: NestedObject
+        description: Optional. Immutable. The embedding model config of the Vector DB.
+        immutable: true
+        properties:
+          - name: 'vertexPredictionEndpoint'
+            type: NestedObject
+            description: The Vertex AI Prediction Endpoint used for dense vector search.
+            properties:
+              - name: 'endpoint'
+                type: String
+                description: |-
+                  Required. The endpoint resource name. Format:
+                  projects/{project}/locations/{location}/publishers/{publisher}/models/{model}
+                  or projects/{project}/locations/{location}/endpoints/{endpoint}.
+                required: true
+              - name: 'model'
+                type: String
+                description: Output only. The resource name of the model that is deployed on the endpoint.
+                output: true
+              - name: 'modelVersionId'
+                type: String
+                description: Output only. Version ID of the model that is deployed on the endpoint.
+                output: true
+  - name: 'encryptionSpec'
+    type: NestedObject
+    description: |-
+      Optional. Immutable. The CMEK key name used to encrypt at-rest data
+      related to this corpus. Only applicable to RagManagedDb option for Vector
+      DB. This field can only be set at corpus creation time, and cannot be
+      updated or deleted.
+    immutable: true
+    properties:
+      - name: 'kmsKeyName'
+        type: String
+        description: |-
+          Required. The Cloud KMS resource identifier of the customer managed
+          encryption key used to protect the resource. Has the form:
+          projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key.
+          The key needs to be in the same region as where the resource is
+          created.
+        required: true
+        immutable: true

--- a/mmv1/products/vertexai/RagCorpus.yaml
+++ b/mmv1/products/vertexai/RagCorpus.yaml
@@ -61,6 +61,7 @@ parameters:
     type: String
     description: The region of the RagCorpus. eg europe-west4
     url_param_only: true
+    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_basic.tf.tmpl
@@ -1,7 +1,7 @@
 resource "google_vertex_ai_rag_corpus" "{{$.PrimaryResourceId}}" {
   display_name = "{{index $.ResourceIdVars "display_name"}}"
   description  = "A basic RAG corpus"
-  region       = "us-central1"
+  region       = "europe-west4"
 
   vector_db_config {
     rag_managed_db {

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_basic.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_vertex_ai_rag_corpus" "{{$.PrimaryResourceId}}" {
+  display_name = "{{index $.ResourceIdVars "display_name"}}"
+  description  = "A basic RAG corpus"
+  region       = "us-central1"
+
+  vector_db_config {
+    rag_managed_db {
+      knn {}
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_basic.tf.tmpl
@@ -7,5 +7,14 @@ resource "google_vertex_ai_rag_corpus" "{{$.PrimaryResourceId}}" {
     rag_managed_db {
       knn {}
     }
+
+    rag_embedding_model_config {
+      vertex_prediction_endpoint {
+        endpoint = "projects/${data.google_project.project.number}/locations/europe-west4/publishers/google/models/text-embedding-005"
+      }
+    }
   }
+}
+
+data "google_project" "project" {
 }

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_full.tf.tmpl
@@ -13,7 +13,7 @@ resource "google_vertex_ai_rag_corpus" "{{$.PrimaryResourceId}}" {
 
     rag_embedding_model_config {
       vertex_prediction_endpoint {
-        endpoint = "projects/${data.google_project.project.project_id}/locations/europe-west4/publishers/google/models/text-embedding-005"
+        endpoint = "projects/${data.google_project.project.number}/locations/europe-west4/publishers/google/models/text-embedding-005"
       }
     }
   }

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_full.tf.tmpl
@@ -1,7 +1,7 @@
 resource "google_vertex_ai_rag_corpus" "{{$.PrimaryResourceId}}" {
   display_name = "{{index $.ResourceIdVars "display_name"}}"
   description  = "A RAG corpus with a customer-managed encryption key"
-  region       = "us-central1"
+  region       = "europe-west4"
 
   vector_db_config {
     rag_managed_db {
@@ -13,7 +13,7 @@ resource "google_vertex_ai_rag_corpus" "{{$.PrimaryResourceId}}" {
 
     rag_embedding_model_config {
       vertex_prediction_endpoint {
-        endpoint = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"
+        endpoint = "projects/${data.google_project.project.project_id}/locations/europe-west4/publishers/google/models/text-embedding-005"
       }
     }
   }

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_rag_corpus_full.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_vertex_ai_rag_corpus" "{{$.PrimaryResourceId}}" {
+  display_name = "{{index $.ResourceIdVars "display_name"}}"
+  description  = "A RAG corpus with a customer-managed encryption key"
+  region       = "us-central1"
+
+  vector_db_config {
+    rag_managed_db {
+      ann {
+        tree_depth = 2
+        leaf_count = 500
+      }
+    }
+
+    rag_embedding_model_config {
+      vertex_prediction_endpoint {
+        endpoint = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"
+      }
+    }
+  }
+
+  encryption_spec {
+    kms_key_name = "{{index $.ResourceIdVars "kms_key_name"}}"
+  }
+}
+
+data "google_project" "project" {
+}

--- a/tools/issue-labeler/labeler/enrolled_teams.yml
+++ b/tools/issue-labeler/labeler/enrolled_teams.yml
@@ -48,6 +48,7 @@ service/aiplatform-prediction:
   - google_vertex_ai_model_garden_enable_model
 service/aiplatform-rag-engine:
   resources:
+  - google_vertex_ai_rag_corpus
   - google_vertex_ai_rag_engine_config
 service/aiplatform-semantic-governance:
   resources:


### PR DESCRIPTION
Adds Magic Modules support for a new Vertex AI RAG corpus Terraform resource.

Summary:
- Adds `RagCorpus` MMv1 schema for Vertex AI RAG Engine corpus creation, update, delete, import, and list-resource generation.
- Exposes RAG-managed DB configuration, embedding model configuration, and CMEK via `encryption_spec.kms_key_name`.
- Adds basic and CMEK-focused Terraform sample configs for generated acceptance test coverage.

```release-note:new-resource
`google_vertex_ai_rag_corpus`
```