### PR TITLE
compute: add managed workload identity support to BackendService

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -188,6 +188,23 @@ samples:
         test_vars_overrides:
           # for backward compatible
           authentication_name: '"authentication" + randomSuffix'
+  - name: 'backend_service_identity'
+    primary_resource_id: 'default'
+    steps:
+      - name: 'backend_service_identity'
+        resource_id_vars:
+          backend_service_name: 'backend-service'
+          health_check_name: 'health-check'
+          identity: 'identity'
+        vars:
+          description: 'description'
+      - name: 'backend_service_identity'
+        resource_id_vars:
+          backend_service_name: 'backend-service'
+          health_check_name: 'health-check'
+          identity: 'identity'
+        vars:
+          description: 'updated description'
   - name: 'backend_service_dynamic_backends'
     primary_resource_id: 'default'
     exclude_test: true
@@ -1698,6 +1715,8 @@ properties:
           TLS connection to the backend, and requires that this string match a Subject Alternative Name (SAN) in the backend's
           server certificate. With a Regional Internet NEG backend, if the SNI is specified here, the load balancer uses it
           regardless of whether the Regional Internet NEG is specified with FQDN or IP address and port.
+        conflicts:
+          - 'identity'
       - name: 'subjectAltNames'
         type: Array
         description: |
@@ -1706,6 +1725,8 @@ properties:
           and requires that at least one SAN match one of the subjectAltNames in the list. This field is limited to 5 entries.
           When both sni and subjectAltNames are specified, the load balancer matches the backend certificate's SAN only to
           subjectAltNames.
+        conflicts:
+          - 'identity'
         item_type:
           type: NestedObject
           properties:
@@ -1727,6 +1748,21 @@ properties:
           Reference to the BackendAuthenticationConfig resource from the networksecurity.googleapis.com namespace.
           Can be used in authenticating TLS connections to the backend, as specified by the authenticationMode field.
           Can only be specified if authenticationMode is not NONE.
+        conflicts:
+          - 'identity'
+        diff_suppress_func: 'suppressAuthenticationConfigWhenIdentitySet'
+      - name: 'identity'
+        type: String
+        description: |
+          The fully-specified SPIFFE ID without the spiffe:// scheme. Must be in the format //<trust_domain>/ns/<namespace>/sa/<subject>.
+          The load balancer uses certificates and roots of trust provisioned by the Managed Workload Identity system for this identity.
+          The Trust Domain within the identity must refer to a valid Workload Identity Pool, from which the TrustConfig and CertificateIssuanceConfig are inherited.
+          If set, you cannot configure sni, subjectAltNames, or authenticationConfig manually.
+        immutable: true
+        conflicts:
+          - 'authenticationConfig'
+          - 'subjectAltNames'
+          - 'sni'
   - name: 'maxStreamDuration'
     type: NestedObject
     description: |

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -228,6 +228,23 @@ samples:
         test_vars_overrides:
           # for backward compatible
           authentication_name: '"authentication" + randomSuffix'
+  - name: 'region_backend_service_identity'
+    primary_resource_id: 'default'
+    steps:
+      - name: 'region_backend_service_identity'
+        resource_id_vars:
+          region_backend_service_name: 'backend-service'
+          health_check_name: 'health-check'
+          identity: 'identity'
+        vars:
+          description: 'description'
+      - name: 'region_backend_service_identity'
+        resource_id_vars:
+          region_backend_service_name: 'backend-service'
+          health_check_name: 'health-check'
+          identity: 'identity'
+        vars:
+          description: 'updated description'
 parameters:
   - name: 'region'
     type: ResourceRef
@@ -1754,6 +1771,8 @@ properties:
           TLS connection to the backend, and requires that this string match a Subject Alternative Name (SAN) in the backend's
           server certificate. With a Regional Internet NEG backend, if the SNI is specified here, the load balancer uses it
           regardless of whether the Regional Internet NEG is specified with FQDN or IP address and port.
+        conflicts:
+          - 'identity'
       - name: 'subjectAltNames'
         type: Array
         description: |
@@ -1762,6 +1781,8 @@ properties:
           and requires that at least one SAN match one of the subjectAltNames in the list. This field is limited to 5 entries.
           When both sni and subjectAltNames are specified, the load balancer matches the backend certificate's SAN only to
           subjectAltNames.
+        conflicts:
+          - 'identity'
         item_type:
           type: NestedObject
           properties:
@@ -1783,3 +1804,18 @@ properties:
           Reference to the BackendAuthenticationConfig resource from the networksecurity.googleapis.com namespace.
           Can be used in authenticating TLS connections to the backend, as specified by the authenticationMode field.
           Can only be specified if authenticationMode is not NONE.
+        conflicts:
+          - 'identity'
+        diff_suppress_func: 'suppressAuthenticationConfigWhenIdentitySet'
+      - name: 'identity'
+        type: String
+        description: |
+          The fully-specified SPIFFE ID without the spiffe:// scheme. Must be in the format //<trust_domain>/ns/<namespace>/sa/<subject>.
+          The load balancer uses certificates and roots of trust provisioned by the Managed Workload Identity system for this identity.
+          The Trust Domain within the identity must refer to a valid Workload Identity Pool, from which the TrustConfig and CertificateIssuanceConfig are inherited.
+          If set, you cannot configure sni, subjectAltNames, or authenticationConfig manually.
+        immutable: true
+        conflicts:
+          - 'authenticationConfig'
+          - 'subjectAltNames'
+          - 'sni'

--- a/mmv1/templates/terraform/constants/backend_service.go.tmpl
+++ b/mmv1/templates/terraform/constants/backend_service.go.tmpl
@@ -28,6 +28,14 @@ func suppressIapDiffWhenUnset(_ string, _, _ string, d *schema.ResourceData) boo
 	return iap.IsKnown() && iap.LengthInt() == 0
 }
 
+// suppress changes on authentication_config if identity is set.
+func suppressAuthenticationConfigWhenIdentitySet(k, old, new string, d *schema.ResourceData) bool {
+    if v, ok := d.GetOk("tls_settings.0.identity"); ok && v.(string) != "" {
+        return true
+    }
+    return false
+}
+
 // Whether the backend is a global or regional NEG
 func isNegBackend(backend map[string]interface{}) bool {
 	backendGroup, ok := backend["group"]

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_identity.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_identity.tf.tmpl
@@ -1,0 +1,17 @@
+resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
+  name          = "{{index $.ResourceIdVars "backend_service_name"}}"
+  health_checks = [google_compute_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol = "HTTPS"
+  tls_settings {
+    identity = "//test.global.123456789.workload.id.goog/ns/test-ns/sa/test-id"
+  }
+  description = "{{index $.Vars "description"}}"
+}
+
+resource "google_compute_health_check" "default" {
+  name = "{{index $.ResourceIdVars "health_check_name"}}"
+  http_health_check {
+    port = 80
+  }
+}

--- a/mmv1/templates/terraform/samples/services/compute/region_backend_service_identity.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_backend_service_identity.tf.tmpl
@@ -1,0 +1,19 @@
+resource "google_compute_region_backend_service" "{{$.PrimaryResourceId}}" {
+  region = "europe-north1"
+  name          = "{{index $.ResourceIdVars "region_backend_service_name"}}"
+  health_checks = [google_compute_region_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol = "HTTPS"
+  tls_settings {
+    identity = "//test.global.123456789.workload.id.goog/ns/test-ns/sa/test-id"
+  }
+  description = "{{index $.Vars "description"}}"
+}
+
+resource "google_compute_region_health_check" "default" {
+  name = "{{index $.ResourceIdVars "health_check_name"}}"
+  region = "europe-north1"
+  http_health_check {
+    port = 80
+  }
+}


### PR DESCRIPTION
Adds new field tls_settings.identity to the backend service resource.
Includes a custom diff suppress function to handle the authentication config generated by server when identity is set.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/29229

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added support for Backend mTLS with managed workload identity
```
