### PR TITLE
compute: don't flatten API-provided boot disk resource_policies into an unset field

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -4750,14 +4751,6 @@ func flattenBootDisk(d *schema.ResourceData, disk map[string]interface{}, config
 
 	diskDetails, err := getDisk(diskSource, d, config)
 
-	// Resource policies can get autofilled from the API and on this field and this will cause the instance to recreate
-	// This overrides any value set by the API not to cause a diff when the user didn't set this in their config.
-	if diskDetails != nil {
-		if d.Get("boot_disk.0.initialize_params.0.resource_policies.0") == nil || d.Get("boot_disk.0.initialize_params.0.resource_policies") == nil {
-			delete(diskDetails, "resourcePolicies")
-		}
-	}
-
 	if err != nil {
 		log.Printf("[WARN] Cannot retrieve boot disk details: %s", err)
 
@@ -4768,6 +4761,17 @@ func flattenBootDisk(d *schema.ResourceData, disk map[string]interface{}, config
 			result["initialize_params"] = m
 		}
 	} else {
+		// The policies attached to the disk are not necessarily the ones set through
+		// initialize_params: the API can autofill them, and they can also be attached
+		// out of band with google_compute_disk_resource_policy_attachment, which can
+		// leave more of them on the disk than this field's MaxItems allows. Only mirror
+		// them back when the field is actually set, so that an unset field does not gain
+		// a value that would force the instance to recreate. This also means an import
+		// leaves the field unset.
+		if v, ok := d.GetOkExists("boot_disk.0.initialize_params.0.resource_policies"); !ok || tpgresource.IsEmptyValue(reflect.ValueOf(v)) {
+			delete(diskDetails, "resourcePolicies")
+		}
+
 		diskType, _ := diskDetails["type"].(string)
 		storagePool, _ := diskDetails["storagePool"].(string)
 		var replicaZones []string

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_flatten_boot_disk_internal_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_flatten_boot_disk_internal_test.go
@@ -1,0 +1,230 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+const (
+	testFlattenBootDiskInstanceID = "projects/test-project/zones/us-central1-a/instances/test-instance"
+	testFlattenBootDiskSource     = "projects/test-project/zones/us-central1-a/disks/test-disk"
+	testFlattenBootDiskPath       = "/projects/test-project/zones/us-central1-a/disks/test-disk"
+	testFlattenBootDiskImage      = "projects/debian-cloud/global/images/family/debian-11"
+	testFlattenBootDiskPolicy     = "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/resourcePolicies/policy-a"
+)
+
+// The disk can carry resource policies that were never set through
+// boot_disk.initialize_params, either because the API autofilled them or because
+// they were attached out of band with
+// google_compute_disk_resource_policy_attachment. There can be more of them than
+// the field's MaxItems allows.
+var testFlattenBootDiskAPIPolicies = []interface{}{
+	testFlattenBootDiskPolicy,
+	"https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/resourcePolicies/policy-b",
+}
+
+// A freshly planned resource, as flattenBootDisk sees it while reading back a
+// create.
+func testFlattenBootDiskConfigData(t *testing.T, resourcePolicies []interface{}) *schema.ResourceData {
+	t.Helper()
+
+	initializeParams := map[string]interface{}{
+		"image": testFlattenBootDiskImage,
+	}
+	if resourcePolicies != nil {
+		initializeParams["resource_policies"] = resourcePolicies
+	}
+
+	return schema.TestResourceDataRaw(t, ResourceComputeInstance().Schema, map[string]interface{}{
+		"name":         "test-instance",
+		"machine_type": "e2-medium",
+		"project":      "test-project",
+		"zone":         "us-central1-a",
+		"boot_disk": []interface{}{
+			map[string]interface{}{
+				"initialize_params": []interface{}{initializeParams},
+			},
+		},
+		"network_interface": []interface{}{
+			map[string]interface{}{
+				"network": "default",
+			},
+		},
+	})
+}
+
+// A resource being refreshed, where the prior state carries whatever the previous
+// read wrote. Passing nil models an import, which starts from an empty state.
+func testFlattenBootDiskStateData(t *testing.T, resourcePolicies []string) *schema.ResourceData {
+	t.Helper()
+
+	attributes := map[string]string{}
+	if resourcePolicies != nil {
+		attributes = map[string]string{
+			"name":                                  "test-instance",
+			"machine_type":                          "e2-medium",
+			"project":                               "test-project",
+			"zone":                                  "us-central1-a",
+			"boot_disk.#":                           "1",
+			"boot_disk.0.initialize_params.#":       "1",
+			"boot_disk.0.initialize_params.0.image": testFlattenBootDiskImage,
+			"boot_disk.0.initialize_params.0.resource_policies.#": strconv.Itoa(len(resourcePolicies)),
+		}
+		for i, policy := range resourcePolicies {
+			attributes["boot_disk.0.initialize_params.0.resource_policies."+strconv.Itoa(i)] = policy
+		}
+	}
+
+	return ResourceComputeInstance().Data(&terraform.InstanceState{
+		ID:         testFlattenBootDiskInstanceID,
+		Attributes: attributes,
+	})
+}
+
+func TestComputeInstance_flattenBootDiskResourcePolicies(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		data         func(t *testing.T) *schema.ResourceData
+		wantPolicies interface{}
+	}{
+		"unset in config": {
+			data:         func(t *testing.T) *schema.ResourceData { return testFlattenBootDiskConfigData(t, nil) },
+			wantPolicies: nil,
+		},
+		"empty list in config": {
+			data:         func(t *testing.T) *schema.ResourceData { return testFlattenBootDiskConfigData(t, []interface{}{}) },
+			wantPolicies: nil,
+		},
+		"set in config": {
+			data: func(t *testing.T) *schema.ResourceData {
+				return testFlattenBootDiskConfigData(t, []interface{}{testFlattenBootDiskPolicy})
+			},
+			wantPolicies: testFlattenBootDiskAPIPolicies,
+		},
+		"unset in state": {
+			data:         func(t *testing.T) *schema.ResourceData { return testFlattenBootDiskStateData(t, []string{}) },
+			wantPolicies: nil,
+		},
+		"set in state": {
+			data: func(t *testing.T) *schema.ResourceData {
+				return testFlattenBootDiskStateData(t, []string{testFlattenBootDiskPolicy})
+			},
+			wantPolicies: testFlattenBootDiskAPIPolicies,
+		},
+		// On import there is no config and no prior state to tell whether the policies
+		// on the disk belong to initialize_params, so they are left out rather than
+		// imported into a field the config may not own.
+		"import": {
+			data:         func(t *testing.T) *schema.ResourceData { return testFlattenBootDiskStateData(t, nil) },
+			wantPolicies: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			config := testComputeInstanceFlattenBootDiskConfig(t, map[string]interface{}{
+				"resourcePolicies": testFlattenBootDiskAPIPolicies,
+				"sourceImage":      testFlattenBootDiskImage,
+				"type":             "projects/test-project/zones/us-central1-a/diskTypes/pd-balanced",
+			})
+
+			flattened := flattenBootDisk(tc.data(t), testFlattenBootDiskAttachedDisk(), config)
+
+			initializeParams, ok := flattened[0]["initialize_params"].([]map[string]interface{})
+			if !ok {
+				t.Fatalf("expected initialize_params to be []map[string]interface{}, got %T", flattened[0]["initialize_params"])
+			}
+
+			gotPolicies := initializeParams[0]["resource_policies"]
+			if !reflect.DeepEqual(gotPolicies, tc.wantPolicies) {
+				t.Fatalf("unexpected flattened resource_policies: got %#v, want %#v", gotPolicies, tc.wantPolicies)
+			}
+		})
+	}
+}
+
+func TestComputeInstance_flattenBootDiskResourcePolicies_handlesGetDiskError(t *testing.T) {
+	t.Parallel()
+
+	d := testFlattenBootDiskConfigData(t, []interface{}{})
+	config := testComputeInstanceFlattenBootDiskErrorConfig(t)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("flattenBootDisk panicked when disk lookup failed: %v", r)
+		}
+	}()
+
+	flattened := flattenBootDisk(d, testFlattenBootDiskAttachedDisk(), config)
+
+	if got, want := flattened[0]["initialize_params"], d.Get("boot_disk.0.initialize_params"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected initialize_params fallback when disk lookup fails: got %#v, want %#v", got, want)
+	}
+}
+
+func testFlattenBootDiskAttachedDisk() map[string]interface{} {
+	return map[string]interface{}{
+		"autoDelete": true,
+		"deviceName": "test-disk",
+		"mode":       "READ_WRITE",
+		"source":     testFlattenBootDiskSource,
+	}
+}
+
+func testComputeInstanceFlattenBootDiskConfig(t *testing.T, disk map[string]interface{}) *transport_tpg.Config {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method %q", r.Method)
+		}
+
+		if got, want := r.URL.Path, testFlattenBootDiskPath; got != want {
+			t.Errorf("unexpected path %q, want %q", got, want)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(disk); err != nil {
+			t.Errorf("encoding disk response: %v", err)
+		}
+	}))
+
+	t.Cleanup(server.Close)
+
+	return testComputeInstanceFlattenBootDiskServerConfig(server)
+}
+
+func testComputeInstanceFlattenBootDiskErrorConfig(t *testing.T) *transport_tpg.Config {
+	t.Helper()
+
+	// Not found rather than a server error, which the transport would retry.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"code":404,"message":"not found"}}`, http.StatusNotFound)
+	}))
+
+	t.Cleanup(server.Close)
+
+	return testComputeInstanceFlattenBootDiskServerConfig(server)
+}
+
+func testComputeInstanceFlattenBootDiskServerConfig(server *httptest.Server) *transport_tpg.Config {
+	return &transport_tpg.Config{
+		Client:          server.Client(),
+		Context:         context.Background(),
+		CustomEndpoints: map[string]string{Product.CustomEndpointField: server.URL + "/"},
+		Project:         "test-project",
+		UserAgent:       "test-agent",
+		Zone:            "us-central1-a",
+	}
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -565,6 +565,11 @@ func TestAccComputeInstance_diskResourcePolicies_attachmentDiff(t *testing.T) {
 				ResourceName:      "google_compute_instance.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
+				// The API reports the policies attached to the boot disk without saying
+				// whether they came from initialize_params or from a separate
+				// google_compute_disk_resource_policy_attachment, so an import leaves the
+				// field unset rather than claiming policies the config may not own.
+				ImportStateVerifyIgnore: []string{"boot_disk.0.initialize_params.0.resource_policies"},
 			},
 		},
 	})


### PR DESCRIPTION
Picks up #16888, which was auto-closed for inactivity after its RECORDING run failed. Rebased onto current main, where `flattenBootDisk` works on raw `map[string]interface{}`, so the change is ported rather than replayed; the provider fix stays under @corymhall's authorship.

`flattenBootDisk` copies the boot disk's resource policies into `boot_disk.initialize_params.resource_policies`, reading them from a GET on the disk because the instance GET omits `initializeParams`. There, policies set inline at create time are indistinguishable from ones attached with `google_compute_disk_resource_policy_attachment`, so a disk with out of band policies populates a field the config never set, sometimes with more entries than its `MaxItems: 1`. The existing guard compared against `nil`, which a `TypeList` read never returns, so it never fired.

Abbreviated from `TestComputeInstance_flattenBootDiskResourcePolicies`:

```go
// the boot disk carries two policies, both attached with
// google_compute_disk_resource_policy_attachment, none through initialize_params
d := testFlattenBootDiskConfigData(t, nil) // config leaves resource_policies unset
params := flattenBootDisk(d, attachedDisk, config)[0]["initialize_params"].([]map[string]interface{})

params[0]["resource_policies"]
// before: []interface{}{".../policy-a", ".../policy-b"}
//         two entries in a MaxItems: 1 list, in a field the config never set
// after:  nil, the attachment's policies stay out of initialize_params
```

The guard now uses `GetOkExists` + `tpgresource.IsEmptyValue`, so that a present-but-empty value counts as unset, and it moves into the branch where the disk lookup succeeded, which is the only place the disk's own fields are read.

An import read starts from an empty state, so the field is left unset there too: nothing says whether the disk's policies belong to `initialize_params`, and importing them can overflow the list. Sibling fields in the same flatten (`snapshot`, `source_image_encryption_key`, `resource_manager_tags`) are already empty on import. Step 6 of `TestAccComputeInstance_diskResourcePolicies_attachmentDiff` failed on exactly this in the RECORDING run and now ignores the attribute; the two earlier import steps still assert that attachment policies do not leak into the field.

Internal tests cover the create, refresh and import shapes of the read plus the disk-lookup error path. All four unset-field cases fail against the old guard.

Context: https://github.com/pulumi/pulumi-gcp/issues/3666

```release-note:bug
compute: fixed `google_compute_instance` boot disk `initialize_params.resource_policies` being populated from the API when the field is not set in the config
```

