### PR TITLE
ces: add evaluation_metrics_thresholds hallucination fields to App

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -330,9 +330,6 @@ properties:
         type: Enum
         description: |-
           The hallucination metric behavior for golden evaluations.
-          Possible values:
-          DISABLED
-          ENABLED
         enum_values:
           - DISABLED
           - ENABLED
@@ -340,9 +337,6 @@ properties:
         type: Enum
         description: |-
           The hallucination metric behavior for scenario evaluations.
-          Possible values:
-          DISABLED
-          ENABLED
         enum_values:
           - DISABLED
           - ENABLED

--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -326,6 +326,26 @@ properties:
                 description: |-
                   The success threshold for semantic similarity. Must be an integer
                   between 0 and 4. Default is >= 3.
+      - name: goldenHallucinationMetricBehavior
+        type: Enum
+        description: |-
+          The hallucination metric behavior for golden evaluations.
+          Possible values:
+          DISABLED
+          ENABLED
+        enum_values:
+          - DISABLED
+          - ENABLED
+      - name: scenarioHallucinationMetricBehavior
+        type: Enum
+        description: |-
+          The hallucination metric behavior for scenario evaluations.
+          Possible values:
+          DISABLED
+          ENABLED
+        enum_values:
+          - DISABLED
+          - ENABLED
   - name: globalInstruction
     type: String
     description: |-

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -706,6 +706,22 @@ properties:
                           The success threshold for semantic similarity. Must be an integer
                           between 0 and 4. Default is >= 3.
                         output: true
+              - name: goldenHallucinationMetricBehavior
+                type: String
+                description: |-
+                  The hallucination metric behavior for golden evaluations.
+                  Possible values:
+                  DISABLED
+                  ENABLED
+                output: true
+              - name: scenarioHallucinationMetricBehavior
+                type: String
+                description: |-
+                  The hallucination metric behavior for scenario evaluations.
+                  Possible values:
+                  DISABLED
+                  ENABLED
+                output: true
           - name: globalInstruction
             type: String
             description: |-

--- a/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
@@ -99,6 +99,8 @@ resource "google_ces_app" "ces_app_basic" {
         tool_invocation_parameter_correctness_threshold = 1.0
       }
     }
+    golden_hallucination_metric_behavior   = "ENABLED"
+    scenario_hallucination_metric_behavior = "ENABLED"
   }
 
 variable_declarations {

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -155,6 +155,8 @@ resource "google_ces_app" "ces_app_basic" {
         tool_invocation_parameter_correctness_threshold = 1.0
       }
     }
+    golden_hallucination_metric_behavior   = "ENABLED"
+    scenario_hallucination_metric_behavior = "ENABLED"
   }
 
   variable_declarations {
@@ -364,6 +366,8 @@ resource "google_ces_app" "ces_app_basic" {
         tool_invocation_parameter_correctness_threshold = 0.1
       }
     }
+    golden_hallucination_metric_behavior   = "DISABLED"
+    scenario_hallucination_metric_behavior = "DISABLED"
   }
 
   variable_declarations {


### PR DESCRIPTION
Added field coverage for `evaluationMetricsThresholds.goldenHallucinationMetricBehavior` and `evaluationMetricsThresholds.scenarioHallucinationMetricBehavior` (as `Enum` fields with values `DISABLED` and `ENABLED`) on `google_ces_app`.

reference: b/550549046

```release-note:enhancement
ces: added `evaluation_metrics_thresholds.golden_hallucination_metric_behavior` and `evaluation_metrics_thresholds.scenario_hallucination_metric_behavior` fields to `google_ces_app` and `google_ces_app_version`
```
