### PR TITLE
ces: add transfer_rules to google_ces_agent

### DIFF
--- a/mmv1/products/ces/Agent.yaml
+++ b/mmv1/products/ces/Agent.yaml
@@ -353,6 +353,72 @@ properties:
           description: The tools IDs to filter the toolset.
           item_type:
             type: String
+  - name: transferRules
+    type: Array
+    description: |-
+      List of transfer rules for the agent.
+      If multiple rules match, the first one in the list will be used.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: childAgent
+          type: String
+          required: true
+          description: |-
+            The resource name of the child agent the rule applies to.
+            Format: `projects/{project}/locations/{location}/apps/{app}/agents/{agent}`
+        - name: deterministicTransfer
+          type: NestedObject
+          description: |-
+            Deterministic transfer rule. When the condition evaluates to true, the
+            transfer occurs.
+          properties:
+            - name: expressionCondition
+              type: NestedObject
+              description: |-
+                A rule that evaluates a session state condition. If the condition
+                evaluates to true, the transfer occurs.
+              properties:
+                - name: expression
+                  type: String
+                  required: true
+                  description: The string representation of cloud.api.Expression condition.
+            - name: pythonCodeCondition
+              type: NestedObject
+              description: |-
+                A rule that uses Python code block to evaluate the conditions. If the
+                condition evaluates to true, the transfer occurs.
+              properties:
+                - name: pythonCode
+                  type: String
+                  required: true
+                  description: |-
+                    The python code to execute. The function must be named
+                    `should_trigger_transfer_callback`.
+        - name: direction
+          type: Enum
+          required: true
+          description: |-
+            The direction of the transfer.
+          enum_values:
+            - PARENT_TO_CHILD
+            - CHILD_TO_PARENT
+        - name: disablePlannerTransfer
+          type: NestedObject
+          description: |-
+            A rule that prevents the planner from transferring to the target agent.
+          properties:
+            - name: expressionCondition
+              type: NestedObject
+              required: true
+              description: |-
+                If the condition evaluates to true, planner will not be allowed to
+                transfer to the target agent.
+              properties:
+                - name: expression
+                  type: String
+                  required: true
+                  description: The string representation of cloud.api.Expression condition.
   - name: updateTime
     type: String
     description: Timestamp when the agent was last updated.

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -402,6 +402,77 @@ properties:
                     output: true
                     item_type:
                       type: String
+            - name: transferRules
+              type: Array
+              description: |-
+                List of transfer rules for the agent.
+                If multiple rules match, the first one in the list will be used.
+              output: true
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: childAgent
+                    type: String
+                    description: |-
+                      The resource name of the child agent the rule applies to.
+                      Format: `projects/{project}/locations/{location}/apps/{app}/agents/{agent}`
+                    output: true
+                  - name: deterministicTransfer
+                    type: NestedObject
+                    description: |-
+                      Deterministic transfer rule. When the condition evaluates to true, the
+                      transfer occurs.
+                    output: true
+                    properties:
+                      - name: expressionCondition
+                        type: NestedObject
+                        description: |-
+                          A rule that evaluates a session state condition. If the condition
+                          evaluates to true, the transfer occurs.
+                        output: true
+                        properties:
+                          - name: expression
+                            type: String
+                            description: The string representation of cloud.api.Expression condition.
+                            output: true
+                      - name: pythonCodeCondition
+                        type: NestedObject
+                        description: |-
+                          A rule that uses Python code block to evaluate the conditions. If the
+                          condition evaluates to true, the transfer occurs.
+                        output: true
+                        properties:
+                          - name: pythonCode
+                            type: String
+                            description: |-
+                              The python code to execute. The function must be named
+                              `should_trigger_transfer_callback`.
+                            output: true
+                  - name: direction
+                    type: String
+                    description: |-
+                      The direction of the transfer.
+                      Possible values:
+                      * PARENT_TO_CHILD
+                      * CHILD_TO_PARENT
+                    output: true
+                  - name: disablePlannerTransfer
+                    type: NestedObject
+                    description: |-
+                      A rule that prevents the planner from transferring to the target agent.
+                    output: true
+                    properties:
+                      - name: expressionCondition
+                        type: NestedObject
+                        description: |-
+                          If the condition evaluates to true, planner will not be allowed to
+                          transfer to the target agent.
+                        output: true
+                        properties:
+                          - name: expression
+                            type: String
+                            description: The string representation of cloud.api.Expression condition.
+                            output: true
             - name: updateTime
               type: String
               description: Timestamp when the agent was last updated.

--- a/mmv1/templates/terraform/samples/services/ces/ces_agent_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_agent_basic.tf.tmpl
@@ -171,5 +171,15 @@ resource "google_ces_agent" "ces_agent_basic" {
 
   child_agents = ["projects/${google_ces_app.ces_app_for_agent.project}/locations/us/apps/${google_ces_app.ces_app_for_agent.app_id}/agents/${google_ces_agent.ces_child_agent.agent_id}"]
 
+  transfer_rules {
+    child_agent = "projects/${google_ces_app.ces_app_for_agent.project}/locations/us/apps/${google_ces_app.ces_app_for_agent.app_id}/agents/${google_ces_agent.ces_child_agent.agent_id}"
+    direction   = "PARENT_TO_CHILD"
+    deterministic_transfer {
+      expression_condition {
+        expression = "true"
+      }
+    }
+  }
+
   llm_agent {}
 }

--- a/mmv1/third_party/terraform/services/ces/ces_agent_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_agent_test.go
@@ -219,6 +219,26 @@ resource "google_ces_agent" "ces_agent_basic" {
 
   child_agents = ["projects/${google_ces_app.ces_app_for_agent.project}/locations/us/apps/${google_ces_app.ces_app_for_agent.app_id}/agents/${google_ces_agent.ces_child_agent.agent_id}"]
 
+  transfer_rules {
+    child_agent = "projects/${google_ces_app.ces_app_for_agent.project}/locations/us/apps/${google_ces_app.ces_app_for_agent.app_id}/agents/${google_ces_agent.ces_child_agent.agent_id}"
+    direction   = "PARENT_TO_CHILD"
+    deterministic_transfer {
+      expression_condition {
+        expression = "true"
+      }
+    }
+  }
+
+  transfer_rules {
+    child_agent = "projects/${google_ces_app.ces_app_for_agent.project}/locations/us/apps/${google_ces_app.ces_app_for_agent.app_id}/agents/${google_ces_agent.ces_child_agent.agent_id}"
+    direction   = "PARENT_TO_CHILD"
+    disable_planner_transfer {
+      expression_condition {
+        expression = "false"
+      }
+    }
+  }
+
   llm_agent {}
 }
 `, context)
@@ -387,6 +407,16 @@ resource "google_ces_agent" "ces_agent_basic" {
   }
 
   child_agents = ["projects/${google_ces_app.ces_app_for_agent.project}/locations/us/apps/${google_ces_app.ces_app_for_agent.app_id}/agents/${google_ces_agent.ces_child_agent.agent_id}"]
+
+  transfer_rules {
+    child_agent = "projects/${google_ces_app.ces_app_for_agent.project}/locations/us/apps/${google_ces_app.ces_app_for_agent.app_id}/agents/${google_ces_agent.ces_child_agent.agent_id}"
+    direction   = "CHILD_TO_PARENT"
+    deterministic_transfer {
+      python_code_condition {
+        python_code = "def should_trigger_transfer_callback(callback_context): return True"
+      }
+    }
+  }
 
   llm_agent {}
 }


### PR DESCRIPTION
Added field coverage for `transferRules` on `google_ces_agent` (`ces:v1:Agent`).

reference: b/550548069

```release-note:enhancement
ces: added `transfer_rules` field to `google_ces_agent`
```
