### PR TITLE
ces: add proactive_execution_enabled to agent callbacks

### DIFF
--- a/mmv1/products/ces/Agent.yaml
+++ b/mmv1/products/ces/Agent.yaml
@@ -91,6 +91,15 @@ properties:
           description: |-
             Whether the callback is disabled. Disabled callbacks are ignored by the
             agent.
+        - name: proactiveExecutionEnabled
+          type: Boolean
+          description: |-
+            If enabled, the callback will also be executed on intermediate model
+            outputs. This setting only affects after model callback.
+            **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+            executed after receiving all model responses. Enabling proactive execution
+            may have negative implication on the execution cost and latency, and
+            should only be enabled in rare situations.
         - name: pythonCode
           type: String
           required: true
@@ -114,6 +123,15 @@ properties:
           description: |-
             Whether the callback is disabled. Disabled callbacks are ignored by the
             agent.
+        - name: proactiveExecutionEnabled
+          type: Boolean
+          description: |-
+            If enabled, the callback will also be executed on intermediate model
+            outputs. This setting only affects after model callback.
+            **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+            executed after receiving all model responses. Enabling proactive execution
+            may have negative implication on the execution cost and latency, and
+            should only be enabled in rare situations.
         - name: pythonCode
           type: String
           required: true
@@ -137,6 +155,15 @@ properties:
           description: |-
             Whether the callback is disabled. Disabled callbacks are ignored by the
             agent.
+        - name: proactiveExecutionEnabled
+          type: Boolean
+          description: |-
+            If enabled, the callback will also be executed on intermediate model
+            outputs. This setting only affects after model callback.
+            **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+            executed after receiving all model responses. Enabling proactive execution
+            may have negative implication on the execution cost and latency, and
+            should only be enabled in rare situations.
         - name: pythonCode
           type: String
           required: true
@@ -159,6 +186,15 @@ properties:
           description: |-
             Whether the callback is disabled. Disabled callbacks are ignored by the
             agent.
+        - name: proactiveExecutionEnabled
+          type: Boolean
+          description: |-
+            If enabled, the callback will also be executed on intermediate model
+            outputs. This setting only affects after model callback.
+            **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+            executed after receiving all model responses. Enabling proactive execution
+            may have negative implication on the execution cost and latency, and
+            should only be enabled in rare situations.
         - name: pythonCode
           type: String
           required: true
@@ -182,6 +218,15 @@ properties:
           description: |-
             Whether the callback is disabled. Disabled callbacks are ignored by the
             agent.
+        - name: proactiveExecutionEnabled
+          type: Boolean
+          description: |-
+            If enabled, the callback will also be executed on intermediate model
+            outputs. This setting only affects after model callback.
+            **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+            executed after receiving all model responses. Enabling proactive execution
+            may have negative implication on the execution cost and latency, and
+            should only be enabled in rare situations.
         - name: pythonCode
           type: String
           required: true
@@ -205,6 +250,15 @@ properties:
           description: |-
             Whether the callback is disabled. Disabled callbacks are ignored by the
             agent.
+        - name: proactiveExecutionEnabled
+          type: Boolean
+          description: |-
+            If enabled, the callback will also be executed on intermediate model
+            outputs. This setting only affects after model callback.
+            **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+            executed after receiving all model responses. Enabling proactive execution
+            may have negative implication on the execution cost and latency, and
+            should only be enabled in rare situations.
         - name: pythonCode
           type: String
           required: true

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -116,6 +116,16 @@ properties:
                       Whether the callback is disabled. Disabled callbacks are ignored by the
                       agent.
                     output: true
+                  - name: proactiveExecutionEnabled
+                    type: Boolean
+                    description: |-
+                      If enabled, the callback will also be executed on intermediate model
+                      outputs. This setting only affects after model callback.
+                      **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+                      executed after receiving all model responses. Enabling proactive execution
+                      may have negative implication on the execution cost and latency, and
+                      should only be enabled in rare situations.
+                    output: true
                   - name: pythonCode
                     type: String
                     description: The python code to execute for the callback.
@@ -141,6 +151,16 @@ properties:
                     description: |-
                       Whether the callback is disabled. Disabled callbacks are ignored by the
                       agent.
+                    output: true
+                  - name: proactiveExecutionEnabled
+                    type: Boolean
+                    description: |-
+                      If enabled, the callback will also be executed on intermediate model
+                      outputs. This setting only affects after model callback.
+                      **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+                      executed after receiving all model responses. Enabling proactive execution
+                      may have negative implication on the execution cost and latency, and
+                      should only be enabled in rare situations.
                     output: true
                   - name: pythonCode
                     type: String
@@ -168,6 +188,16 @@ properties:
                       Whether the callback is disabled. Disabled callbacks are ignored by the
                       agent.
                     output: true
+                  - name: proactiveExecutionEnabled
+                    type: Boolean
+                    description: |-
+                      If enabled, the callback will also be executed on intermediate model
+                      outputs. This setting only affects after model callback.
+                      **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+                      executed after receiving all model responses. Enabling proactive execution
+                      may have negative implication on the execution cost and latency, and
+                      should only be enabled in rare situations.
+                    output: true
                   - name: pythonCode
                     type: String
                     description: The python code to execute for the callback.
@@ -192,6 +222,16 @@ properties:
                     description: |-
                       Whether the callback is disabled. Disabled callbacks are ignored by the
                       agent.
+                    output: true
+                  - name: proactiveExecutionEnabled
+                    type: Boolean
+                    description: |-
+                      If enabled, the callback will also be executed on intermediate model
+                      outputs. This setting only affects after model callback.
+                      **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+                      executed after receiving all model responses. Enabling proactive execution
+                      may have negative implication on the execution cost and latency, and
+                      should only be enabled in rare situations.
                     output: true
                   - name: pythonCode
                     type: String
@@ -219,6 +259,16 @@ properties:
                       Whether the callback is disabled. Disabled callbacks are ignored by the
                       agent.
                     output: true
+                  - name: proactiveExecutionEnabled
+                    type: Boolean
+                    description: |-
+                      If enabled, the callback will also be executed on intermediate model
+                      outputs. This setting only affects after model callback.
+                      **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+                      executed after receiving all model responses. Enabling proactive execution
+                      may have negative implication on the execution cost and latency, and
+                      should only be enabled in rare situations.
+                    output: true
                   - name: pythonCode
                     type: String
                     description: The python code to execute for the callback.
@@ -244,6 +294,16 @@ properties:
                     description: |-
                       Whether the callback is disabled. Disabled callbacks are ignored by the
                       agent.
+                    output: true
+                  - name: proactiveExecutionEnabled
+                    type: Boolean
+                    description: |-
+                      If enabled, the callback will also be executed on intermediate model
+                      outputs. This setting only affects after model callback.
+                      **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+                      executed after receiving all model responses. Enabling proactive execution
+                      may have negative implication on the execution cost and latency, and
+                      should only be enabled in rare situations.
                     output: true
                   - name: pythonCode
                     type: String
@@ -1416,6 +1476,16 @@ properties:
                         Whether the callback is disabled. Disabled callbacks are ignored by the
                         agent.
                       output: true
+                    - name: proactiveExecutionEnabled
+                      type: Boolean
+                      description: |-
+                        If enabled, the callback will also be executed on intermediate model
+                        outputs. This setting only affects after model callback.
+                        **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+                        executed after receiving all model responses. Enabling proactive execution
+                        may have negative implication on the execution cost and latency, and
+                        should only be enabled in rare situations.
+                      output: true
                     - name: pythonCode
                       type: String
                       description: The python code to execute for the callback.
@@ -1436,6 +1506,16 @@ properties:
                       description: |-
                         Whether the callback is disabled. Disabled callbacks are ignored by the
                         agent.
+                      output: true
+                    - name: proactiveExecutionEnabled
+                      type: Boolean
+                      description: |-
+                        If enabled, the callback will also be executed on intermediate model
+                        outputs. This setting only affects after model callback.
+                        **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+                        executed after receiving all model responses. Enabling proactive execution
+                        may have negative implication on the execution cost and latency, and
+                        should only be enabled in rare situations.
                       output: true
                     - name: pythonCode
                       type: String
@@ -1458,6 +1538,16 @@ properties:
                         Whether the callback is disabled. Disabled callbacks are ignored by the
                         agent.
                       output: true
+                    - name: proactiveExecutionEnabled
+                      type: Boolean
+                      description: |-
+                        If enabled, the callback will also be executed on intermediate model
+                        outputs. This setting only affects after model callback.
+                        **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+                        executed after receiving all model responses. Enabling proactive execution
+                        may have negative implication on the execution cost and latency, and
+                        should only be enabled in rare situations.
+                      output: true
                     - name: pythonCode
                       type: String
                       description: The python code to execute for the callback.
@@ -1478,6 +1568,16 @@ properties:
                       description: |-
                         Whether the callback is disabled. Disabled callbacks are ignored by the
                         agent.
+                      output: true
+                    - name: proactiveExecutionEnabled
+                      type: Boolean
+                      description: |-
+                        If enabled, the callback will also be executed on intermediate model
+                        outputs. This setting only affects after model callback.
+                        **ENABLE WITH CAUTION**. Typically after model callback only needs to be
+                        executed after receiving all model responses. Enabling proactive execution
+                        may have negative implication on the execution cost and latency, and
+                        should only be enabled in rare situations.
                       output: true
                     - name: pythonCode
                       type: String

--- a/mmv1/third_party/terraform/services/ces/ces_agent_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_agent_test.go
@@ -172,36 +172,42 @@ resource "google_ces_agent" "ces_agent_basic" {
     description = "Example callback"
     disabled    = true
     python_code = "def before_agent_callback(callback_context): return None"
+    proactive_execution_enabled = false
   }
 
   after_agent_callbacks {
     description = "Example callback"
     disabled    = true
     python_code = "def after_agent_callback(callback_context): return None"
+    proactive_execution_enabled = false
   }
 
   before_model_callbacks {
     description = "Example callback"
     disabled    = true
     python_code = "def before_model_callback(callback_context, llm_request): return None"
+    proactive_execution_enabled = false
   }
 
   after_model_callbacks {
     description = "Example callback"
     disabled    = true
     python_code = "def after_model_callback(callback_context, llm_response): return None"
+    proactive_execution_enabled = false
   }
 
   before_tool_callbacks {
     description = "Example callback"
     disabled    = true
     python_code = "def before_tool_callback(tool, input, callback_context): return None"
+    proactive_execution_enabled = false
   }
 
   after_tool_callbacks {
     description = "Example callback"
     disabled    = true
     python_code = "def after_tool_callback(tool, input, callback_context, tool_response): return None"
+    proactive_execution_enabled = false
   }
 
   tools = [
@@ -341,36 +347,42 @@ resource "google_ces_agent" "ces_agent_basic" {
     description = "Example callback"
     disabled    = false
     python_code = "def before_agent_callback(callback_context): return None"
+    proactive_execution_enabled = true
   }
 
   after_agent_callbacks {
     description = "Example callback"
     disabled    = false
     python_code = "def after_agent_callback(callback_context): return None"
+    proactive_execution_enabled = true
   }
 
   before_model_callbacks {
     description = "Example callback"
     disabled    = false
     python_code = "def before_model_callback(callback_context, llm_request): return None"
+    proactive_execution_enabled = true
   }
 
   after_model_callbacks {
     description = "Example callback"
     disabled    = false
     python_code = "def after_model_callback(callback_context, llm_response): return None"
+    proactive_execution_enabled = true
   }
 
   before_tool_callbacks {
     description = "Example callback"
     disabled    = false
     python_code = "def before_tool_callback(tool, input, callback_context): return None"
+    proactive_execution_enabled = true
   }
 
   after_tool_callbacks {
     description = "Example callback"
     disabled    = false
     python_code = "def after_tool_callback(tool, input, callback_context, tool_response): return None"
+    proactive_execution_enabled = true
   }
 
   // tools = [


### PR DESCRIPTION
Added field coverage for `proactiveExecutionEnabled` on `google_ces_agent` callbacks (`afterAgentCallbacks`, `afterModelCallbacks`, `afterToolCallbacks`, `beforeAgentCallbacks`, `beforeModelCallbacks`, `beforeToolCallbacks`).

reference: b/550549027

```release-note:enhancement
ces: added `proactive_execution_enabled` field to callbacks in `google_ces_agent`
```
