### PR TITLE
ces: add metric_analysis_settings to google_ces_app

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -437,6 +437,20 @@ properties:
             description: |-
               Controls the retention window for the conversation.
               If not set, the conversation will be retained for 365 days.
+      - name: metricAnalysisSettings
+        type: NestedObject
+        allow_empty_object: true
+        description: |-
+          Settings to describe the conversation data collection behaviors for the LLM
+          analysis pipeline for the app.
+        properties:
+          - name: llmMetricsOptedOut
+            type: Boolean
+            send_empty_value: true
+            description: |-
+              Whether to collect conversation data for llm analysis metrics. If true,
+              conversation data will not be collected for llm analysis metrics;
+              otherwise, conversation data will be collected.
       - name: redactionConfig
         type: NestedObject
         description: Configuration to instruct how sensitive data should be handled.

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -835,6 +835,21 @@ properties:
                       Controls the retention window for the conversation.
                       If not set, the conversation will be retained for 365 days.
                     output: true
+              - name: metricAnalysisSettings
+                type: NestedObject
+                allow_empty_object: true
+                description: |-
+                  Settings to describe the conversation data collection behaviors for the LLM
+                  analysis pipeline for the app.
+                output: true
+                properties:
+                  - name: llmMetricsOptedOut
+                    type: Boolean
+                    description: |-
+                      Whether to collect conversation data for llm analysis metrics. If true,
+                      conversation data will not be collected for llm analysis metrics;
+                      otherwise, conversation data will be collected.
+                    output: true
               - name: redactionConfig
                 type: NestedObject
                 description: Configuration to instruct how sensitive data should be handled.

--- a/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
@@ -82,6 +82,10 @@ resource "google_ces_app" "ces_app_basic" {
     conversation_logging_settings {
       disable_conversation_logging = true
     }
+
+    metric_analysis_settings {
+      llm_metrics_opted_out = false
+    }
   }
 
   model_settings {

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -138,6 +138,10 @@ resource "google_ces_app" "ces_app_basic" {
       disable_conversation_logging = true
       retention_window = "86400s"
     }
+
+    metric_analysis_settings {
+      llm_metrics_opted_out = false
+    }
   }
 
   model_settings {
@@ -346,6 +350,10 @@ resource "google_ces_app" "ces_app_basic" {
     conversation_logging_settings {
       disable_conversation_logging = true
       retention_window = "172800s"
+    }
+
+    metric_analysis_settings {
+      llm_metrics_opted_out = true
     }
   }
 


### PR DESCRIPTION
Added field coverage for `loggingSettings.metricAnalysisSettings.llmMetricsOptedOut` on `google_ces_app` (`ces:v1:App`).

reference: b/550548187

```release-note:enhancement
ces: added `logging_settings.metric_analysis_settings` field to `google_ces_app`
```
