### PR TITLE
ces: add semantic_similarity_channel to google_ces_app

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -358,6 +358,14 @@ properties:
                 description: |-
                   The success threshold for semantic similarity. Must be an integer
                   between 0 and 4. Default is >= 3.
+              - name: semanticSimilarityChannel
+                type: String
+                description: |-
+                  The semantic similarity channel to use for evaluation.
+                  Possible values:
+                  SEMANTIC_SIMILARITY_CHANNEL_UNSPECIFIED
+                  TEXT
+                  AUDIO
       - name: goldenHallucinationMetricBehavior
         type: Enum
         description: |-

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -706,6 +706,15 @@ properties:
                           The success threshold for semantic similarity. Must be an integer
                           between 0 and 4. Default is >= 3.
                         output: true
+                      - name: semanticSimilarityChannel
+                        type: String
+                        description: |-
+                          The semantic similarity channel to use for evaluation.
+                          Possible values:
+                          SEMANTIC_SIMILARITY_CHANNEL_UNSPECIFIED
+                          TEXT
+                          AUDIO
+                        output: true
               - name: goldenHallucinationMetricBehavior
                 type: String
                 description: |-

--- a/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
@@ -98,6 +98,7 @@ resource "google_ces_app" "ces_app_basic" {
       turn_level_metrics_thresholds {
         semantic_similarity_success_threshold        = 3
         overall_tool_invocation_correctness_threshold = 1.0
+        semantic_similarity_channel                   = "TEXT"
       }
       expectation_level_metrics_thresholds {
         tool_invocation_parameter_correctness_threshold = 1.0

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -166,6 +166,7 @@ resource "google_ces_app" "ces_app_basic" {
       turn_level_metrics_thresholds {
         semantic_similarity_success_threshold        = 3
         overall_tool_invocation_correctness_threshold = 1.0
+        semantic_similarity_channel                   = "TEXT"
       }
       expectation_level_metrics_thresholds {
         tool_invocation_parameter_correctness_threshold = 1.0
@@ -388,6 +389,7 @@ resource "google_ces_app" "ces_app_basic" {
       turn_level_metrics_thresholds {
         semantic_similarity_success_threshold        = 4
         overall_tool_invocation_correctness_threshold = 0.1
+        semantic_similarity_channel                   = "AUDIO"
       }
       expectation_level_metrics_thresholds {
         tool_invocation_parameter_correctness_threshold = 0.1


### PR DESCRIPTION
Added field coverage for `evaluationMetricsThresholds.goldenEvaluationMetricsThresholds.turnLevelMetricsThresholds.semanticSimilarityChannel` on `google_ces_app` (`ces:v1:App`).

reference: b/550549199

```release-note:enhancement
ces: added `evaluation_metrics_thresholds.golden_evaluation_metrics_thresholds.turn_level_metrics_thresholds.semantic_similarity_channel` field to `google_ces_app`
```
