### PR TITLE
ces: add extra_tool_call_behavior to google_ces_app

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -366,6 +366,22 @@ properties:
                   SEMANTIC_SIMILARITY_CHANNEL_UNSPECIFIED
                   TEXT
                   AUDIO
+          - name: toolMatchingSettings
+            type: NestedObject
+            description: |-
+              The tool matching settings. An extra tool call is a tool call that is
+              present in the execution but does not match any tool call in the golden
+              expectation.
+            properties:
+              - name: extraToolCallBehavior
+                type: Enum
+                description: |-
+                  Defines the behavior when an extra tool call is encountered. An extra
+                  tool call is a tool call that is present in the execution but does
+                  not match any tool call in the golden expectation.
+                enum_values:
+                  - 'FAIL'
+                  - 'ALLOW'
       - name: goldenHallucinationMetricBehavior
         type: Enum
         description: |-

--- a/mmv1/products/ces/AppVersion.yaml
+++ b/mmv1/products/ces/AppVersion.yaml
@@ -715,6 +715,24 @@ properties:
                           TEXT
                           AUDIO
                         output: true
+                  - name: toolMatchingSettings
+                    type: NestedObject
+                    description: |-
+                      The tool matching settings. An extra tool call is a tool call that is
+                      present in the execution but does not match any tool call in the golden
+                      expectation.
+                    output: true
+                    properties:
+                      - name: extraToolCallBehavior
+                        type: String
+                        description: |-
+                          Defines the behavior when an extra tool call is encountered. An extra
+                          tool call is a tool call that is present in the execution but does
+                          not match any tool call in the golden expectation.
+                          Possible values:
+                          FAIL
+                          ALLOW
+                        output: true
               - name: goldenHallucinationMetricBehavior
                 type: String
                 description: |-

--- a/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
@@ -103,6 +103,9 @@ resource "google_ces_app" "ces_app_basic" {
       expectation_level_metrics_thresholds {
         tool_invocation_parameter_correctness_threshold = 1.0
       }
+      tool_matching_settings {
+        extra_tool_call_behavior = "ALLOW"
+      }
     }
     golden_hallucination_metric_behavior   = "ENABLED"
     scenario_hallucination_metric_behavior = "ENABLED"

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -171,6 +171,9 @@ resource "google_ces_app" "ces_app_basic" {
       expectation_level_metrics_thresholds {
         tool_invocation_parameter_correctness_threshold = 1.0
       }
+      tool_matching_settings {
+        extra_tool_call_behavior = "ALLOW"
+      }
     }
     golden_hallucination_metric_behavior   = "ENABLED"
     scenario_hallucination_metric_behavior = "ENABLED"
@@ -393,6 +396,9 @@ resource "google_ces_app" "ces_app_basic" {
       }
       expectation_level_metrics_thresholds {
         tool_invocation_parameter_correctness_threshold = 0.1
+      }
+      tool_matching_settings {
+        extra_tool_call_behavior = "FAIL"
       }
     }
     golden_hallucination_metric_behavior   = "DISABLED"


### PR DESCRIPTION
Added field coverage for `evaluationMetricsThresholds.goldenEvaluationMetricsThresholds.toolMatchingSettings.extraToolCallBehavior` on `google_ces_app` (`ces:v1:App`).

reference: b/550549281

```release-note:enhancement
ces: added `evaluation_metrics_thresholds.golden_evaluation_metrics_thresholds.tool_matching_settings.extra_tool_call_behavior` field to `google_ces_app`
```
