### PR TITLE
ces: add locked and web_widget_config security_settings to App

### DIFF
--- a/mmv1/products/ces/App.yaml
+++ b/mmv1/products/ces/App.yaml
@@ -43,6 +43,7 @@ samples:
         resource_id_vars:
           app_id: app-id
           display_name: my-app
+          secret_id: 1
   - name: ces_app_ambient_sound_gcs_uri
     primary_resource_id: ces_app_ambient_sound_gcs_uri
     steps:
@@ -250,6 +251,37 @@ properties:
           - name: webWidgetTitle
             type: String
             description: The title of the web widget.
+          - name: securitySettings
+            type: NestedObject
+            description: The security settings of the web widget.
+            properties:
+              - name: allowedOrigins
+                type: Array
+                description: |-
+                  The origins that are allowed to host the web widget. An origin is
+                  defined by RFC 6454. If empty, all origins are allowed.
+                  A maximum of 100 origins is allowed.
+                  Example: "https://example.com"
+                item_type:
+                  type: String
+              - name: enableOriginCheck
+                type: Boolean
+                description: |-
+                  Indicates whether origin check for the web widget is enabled.
+                  If `true`, the web widget will check the origin of the website that
+                  loads the web widget and only allow it to be loaded in the same origin
+                  or any of the allowed origins.
+              - name: enablePublicAccess
+                type: Boolean
+                description: |-
+                  Indicates whether public access to the web widget is enabled.
+                  If `true`, the web widget will be publicly accessible.
+                  If `false`, the web widget must be integrated with your own
+                  authentication and authorization system to return valid credentials for
+                  accessing the CES agent.
+              - name: enableRecaptcha
+                type: Boolean
+                description: Indicates whether reCAPTCHA verification for the web widget is enabled.
       - name: whatsappConfig
         type: NestedObject
         description: Configuration specific to WhatsApp deployments.
@@ -460,6 +492,11 @@ properties:
               detection of sensitive data types.
               Format:
               `projects/{project}/locations/{location}/inspectTemplates/{inspect_template}`
+  - name: locked
+    type: Boolean
+    description: |-
+      Indicates whether the app is locked for changes. If the app is locked,
+      modifications to the app resources will be rejected.
   - name: metadata
     type: KeyValuePairs
     description: |-

--- a/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_app_basic.tf.tmpl
@@ -1,7 +1,7 @@
 data "google_project" "project" {}
 
 resource "google_secret_manager_secret" "fake_private_key_secret" {
-  secret_id = "fake-pk-secret-app-tf1"
+  secret_id = "fake-pk-secret-app-tf{{index $.ResourceIdVars "secret_id"}}"
 
   replication {
     auto{}
@@ -163,6 +163,12 @@ variable_declarations {
       modality = "CHAT_ONLY"
       theme    = "LIGHT"
       web_widget_title = "Help Assistant"
+      security_settings {
+        enable_public_access = true
+        enable_origin_check  = false
+        enable_recaptcha     = false
+        allowed_origins      = ["https://example.com"]
+      }
     }
   }
 

--- a/mmv1/third_party/terraform/services/ces/ces_app_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_app_test.go
@@ -24,6 +24,11 @@ func TestAccCESApp_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCESApp_cesAppBasicExample_full(ctx),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_ces_app.ces_app_basic", "locked", "true"),
+					resource.TestCheckResourceAttr("google_ces_app.ces_app_basic", "default_channel_profile.0.web_widget_config.0.security_settings.0.enable_public_access", "true"),
+					resource.TestCheckResourceAttr("google_ces_app.ces_app_basic", "default_channel_profile.0.web_widget_config.0.security_settings.0.allowed_origins.0", "https://example.com"),
+				),
 			},
 			{
 				ResourceName:            "google_ces_app.ces_app_basic",
@@ -38,6 +43,12 @@ func TestAccCESApp_update(t *testing.T) {
 						plancheck.ExpectResourceAction("google_ces_app.ces_app_basic", plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_ces_app.ces_app_basic", "locked", "false"),
+					resource.TestCheckResourceAttr("google_ces_app.ces_app_basic", "default_channel_profile.0.web_widget_config.0.security_settings.0.enable_public_access", "false"),
+					resource.TestCheckResourceAttr("google_ces_app.ces_app_basic", "default_channel_profile.0.web_widget_config.0.security_settings.0.enable_origin_check", "true"),
+					resource.TestCheckResourceAttr("google_ces_app.ces_app_basic", "default_channel_profile.0.web_widget_config.0.security_settings.0.enable_recaptcha", "true"),
+				),
 			},
 			{
 				ResourceName:            "google_ces_app.ces_app_basic",
@@ -79,6 +90,7 @@ resource "google_ces_app" "ces_app_basic" {
   description = "Basic CES App example"
   display_name = "tf-test-my-app-%{random_suffix}"
   pinned = false
+  locked = true
   tool_execution_mode = "SEQUENTIAL"
 
   language_settings {
@@ -219,6 +231,12 @@ resource "google_ces_app" "ces_app_basic" {
       modality = "CHAT_ONLY"
       theme    = "LIGHT"
       web_widget_title = "Help Assistant"
+      security_settings {
+        enable_public_access = true
+        enable_origin_check  = false
+        enable_recaptcha     = false
+        allowed_origins      = ["https://example.com"]
+      }
     }
   }
 
@@ -288,6 +306,7 @@ resource "google_ces_app" "ces_app_basic" {
   description = "Updated CES App example"
   display_name = "tf-test-my-app%{random_suffix}"
   pinned = true
+  locked = false
   tool_execution_mode = "PARALLEL"
 
   language_settings {
@@ -428,6 +447,12 @@ resource "google_ces_app" "ces_app_basic" {
       modality = "CHAT_ONLY"
       theme    = "LIGHT"
       web_widget_title = "Help Assistant"
+      security_settings {
+        enable_public_access = false
+        enable_origin_check  = true
+        enable_recaptcha     = true
+        allowed_origins      = ["https://example.com", "https://example.org"]
+      }
     }
     whatsapp_config {
       waba_id = "123456789012345"


### PR DESCRIPTION
Added field coverage for `locked` and `defaultChannelProfile.webWidgetConfig.securitySettings` (`allowedOrigins`, `enableOriginCheck`, `enablePublicAccess`, `enableRecaptcha`) on `google_ces_app` (`ces:v1:App`).

reference: b/550549220

```release-note:enhancement
ces: added `locked` and `default_channel_profile.web_widget_config.security_settings` fields to `google_ces_app`
```
