### PR TITLE
firebase: add list resources

### DIFF
--- a/mmv1/products/firebase/AndroidApp.yaml
+++ b/mmv1/products/firebase/AndroidApp.yaml
@@ -39,6 +39,8 @@ timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+generate_list_resource: true
+collection_url_key: 'apps'
 # Sweeper skipped as this resource has customized deletion.
 exclude_sweeper: true
 async:

--- a/mmv1/products/firebase/AppleApp.yaml
+++ b/mmv1/products/firebase/AppleApp.yaml
@@ -40,6 +40,8 @@ timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+generate_list_resource: true
+collection_url_key: 'apps'
 # Sweeper skipped as this resource has customized deletion.
 exclude_sweeper: true
 async:

--- a/mmv1/products/firebase/WebApp.yaml
+++ b/mmv1/products/firebase/WebApp.yaml
@@ -39,6 +39,8 @@ timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+generate_list_resource: true
+collection_url_key: 'apps'
 # Sweeper skipped as this resource has customized deletion.
 exclude_sweeper: true
 async:


### PR DESCRIPTION
Adds list-resource generation for the following firebase resources:

- `google_firebase_android_app`
- `google_firebase_apple_app`
- `google_firebase_web_app`

```release-note:new-list-resource
`google_firebase_android_app`
```

```release-note:new-list-resource
`google_firebase_apple_app`
```

```release-note:new-list-resource
`google_firebase_web_app`
```

Tests: Acceptance tests PASSED (confirmed by Validator agent).
