### PR TITLE
Build CI orchestration from the trusted base checkout

### DIFF
--- a/.ci/gcb-pr-downstream-generation-and-test.yml
+++ b/.ci/gcb-pr-downstream-generation-and-test.yml
@@ -43,8 +43,8 @@ steps:
           - origin/$_BASE_BRANCH
 
     # Build the CI orchestration binary before merging the proposed changes. Keep
-    # both the binary and its launcher outside the checkout so later steps cannot
-    # replace them through files from the head branch.
+    # the resulting binary and launcher in a separate pre-merge path so files from
+    # the head branch cannot replace the orchestration used by later steps.
     - name: 'gcr.io/graphite-docker-images/build-environment'
       id: build-magician-binary
       entrypoint: bash

--- a/.ci/gcb-pr-downstream-generation-and-test.yml
+++ b/.ci/gcb-pr-downstream-generation-and-test.yml
@@ -41,23 +41,41 @@ steps:
       args:
           - checkout
           - origin/$_BASE_BRANCH
+
+    # Build the CI orchestration binary before merging the proposed changes. Keep
+    # both the binary and its launcher outside the checkout so later steps cannot
+    # replace them through files from the head branch.
+    - name: 'gcr.io/graphite-docker-images/build-environment'
+      id: build-magician-binary
+      entrypoint: bash
+      args:
+          - -c
+          - |
+            set -euo pipefail
+            mkdir -p /workspace/.trusted-magician
+            cd /workspace/.ci/magician
+            go build -o /workspace/.trusted-magician/magician_binary
+            cat > /workspace/.trusted-magician/exec.sh <<'EOF'
+            #!/bin/bash
+            set -e
+            cd /workspace/.ci/magician
+            exec /workspace/.trusted-magician/magician_binary "$$@"
+            EOF
+            chmod 0555 /workspace/.trusted-magician/exec.sh
+
     - name: 'gcr.io/cloud-builders/git'
       id: merged
+      waitFor: ["build-magician-binary"]
       args:
           - merge
           - --no-ff
           - head/$_HEAD_BRANCH
 
     - name: 'gcr.io/graphite-docker-images/build-environment'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-      id: build-magician-binary
-      waitFor: ["merged"]
-
-    - name: 'gcr.io/graphite-docker-images/build-environment'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       id: remove-label
       secretEnv: ["GITHUB_TOKEN_MAGIC_MODULES"]
-      waitFor: ["build-magician-binary"]
+      waitFor: ["merged"]
       env:
         - BASE_BRANCH=$_BASE_BRANCH
       args:
@@ -66,10 +84,10 @@ steps:
           - 'awaiting-approval'
 
     - name: 'gcr.io/graphite-docker-images/build-environment'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       id: tpg-head
       secretEnv: ["GITHUB_TOKEN_DOWNSTREAMS"]
-      waitFor: ["build-magician-binary"]
+      waitFor: ["merged"]
       env:
         - BASE_BRANCH=$_BASE_BRANCH
       args:
@@ -80,10 +98,10 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/build-environment'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       id: tpg-base
       secretEnv: ["GITHUB_TOKEN_DOWNSTREAMS"]
-      waitFor: ["build-magician-binary"]
+      waitFor: ["merged"]
       env:
         - BASE_BRANCH=$_BASE_BRANCH
       args:
@@ -94,10 +112,10 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/build-environment'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN_DOWNSTREAMS"]
       id: tpgb-head
-      waitFor: ["build-magician-binary"]
+      waitFor: ["merged"]
       env:
         - BASE_BRANCH=$_BASE_BRANCH
       args:
@@ -108,10 +126,10 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/build-environment'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       id: tpgb-base
       secretEnv: ["GITHUB_TOKEN_DOWNSTREAMS"]
-      waitFor: ["build-magician-binary"]
+      waitFor: ["merged"]
       env:
         - BASE_BRANCH=$_BASE_BRANCH
       args:
@@ -122,10 +140,10 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/build-environment'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       id: tgc-head
       secretEnv: ["GITHUB_TOKEN_DOWNSTREAMS"]
-      waitFor: ["build-magician-binary"]
+      waitFor: ["merged"]
       env:
         - BASE_BRANCH=$_BASE_BRANCH
       args:
@@ -136,10 +154,10 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/build-environment'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       id: tgc-base
       secretEnv: ["GITHUB_TOKEN_DOWNSTREAMS"]
-      waitFor: ["build-magician-binary"]
+      waitFor: ["merged"]
       env:
         - BASE_BRANCH=$_BASE_BRANCH
       args:
@@ -150,10 +168,10 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/build-environment'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       id: tf-oics-head
       secretEnv: ["GITHUB_TOKEN_DOWNSTREAMS"]
-      waitFor: ["build-magician-binary"]
+      waitFor: ["merged"]
       env:
         - BASE_BRANCH=$_BASE_BRANCH
       args:
@@ -164,10 +182,10 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/build-environment'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       id: tf-oics-base
       secretEnv: ["GITHUB_TOKEN_DOWNSTREAMS"]
-      waitFor: ["build-magician-binary"]
+      waitFor: ["merged"]
       env:
         - BASE_BRANCH=$_BASE_BRANCH
       args:
@@ -178,7 +196,7 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/go-plus'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       id: diff
       secretEnv: ["GITHUB_TOKEN_DOWNSTREAMS", "GITHUB_TOKEN_MAGIC_MODULES"]
       args:
@@ -193,7 +211,7 @@ steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: tgc-test
       allowFailure: true
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN_MAGIC_MODULES"]
       waitFor: ["tpgb-head", "tpgb-base", "tgc-head", "tgc-base"]
       args:
@@ -204,7 +222,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: tgc-test-integration
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       allowFailure: true
       secretEnv: ["GITHUB_TOKEN_MAGIC_MODULES"]
       waitFor: ["tpgb-head", "tpgb-base", "tgc-head", "tgc-base"]
@@ -225,7 +243,7 @@ steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: tpgb-test
       allowFailure: true
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN_MAGIC_MODULES"]
       waitFor: ["tpgb-head", "tpgb-base"]
       args:
@@ -238,7 +256,7 @@ steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: tpg-test
       allowFailure: true
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN_MAGIC_MODULES"]
       waitFor: ["tpg-head", "tpg-base"]
       args:
@@ -250,7 +268,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: gcb-tpg-vcr-test
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN_DOWNSTREAMS", "GITHUB_TOKEN_MAGIC_MODULES", "GOOGLE_BILLING_ACCOUNT", "GOOGLE_CHRONICLE_INSTANCE_ID", "GOOGLE_CUST_ID", "GOOGLE_IDENTITY_USER", "GOOGLE_MASTER_BILLING_ACCOUNT", "GOOGLE_ORG", "GOOGLE_ORG_2", "GOOGLE_ORG_DOMAIN", "GOOGLE_PROJECT", "GOOGLE_PROJECT_NUMBER", "GOOGLE_SERVICE_ACCOUNT", "SA_KEY", "GOOGLE_PUBLIC_AVERTISED_PREFIX_DESCRIPTION", "GOOGLE_VMWAREENGINE_PROJECT"]
       waitFor: ["diff"]
       env:
@@ -268,7 +286,7 @@ steps:
         - "true"
 
     - name: 'gcr.io/graphite-docker-images/go-plus'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      entrypoint: '/workspace/.trusted-magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN_MAGIC_MODULES"]
       waitFor: ["diff"]
       args:


### PR DESCRIPTION
## Summary

The presubmit workflow currently merges proposed changes before building `.ci/magician`. Later build steps execute that binary while receiving Secret Manager-backed environment variables. As a result, changes to CI helper code in a pull request can replace the orchestration binary used by those steps.

This change:

- builds the Magician binary from the base branch before merging proposed changes
- preserves that pre-merge binary and launcher in a separate path
- uses the preserved launcher for subsequent generation and test steps

The proposed repository changes are still merged and tested as before; this only changes which version of the CI orchestration binary controls those steps.

## Testing

- `go test ./...` in `.ci/magician`
- parsed the Cloud Build YAML and verified all 16 secret-bearing steps use the preserved launcher
- `git diff --check`

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
