### PR TITLE
Add singular data source for retrieving a Cloud Build worker pool

### DIFF
--- a/mmv1/third_party/terraform/services/cloudbuild/data_source_google_cloudbuild_worker_pool.go
+++ b/mmv1/third_party/terraform/services/cloudbuild/data_source_google_cloudbuild_worker_pool.go
@@ -1,0 +1,57 @@
+package cloudbuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleCloudbuildWorkerPool() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceCloudbuildWorkerPool().Schema)
+
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name", "location")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleCloudbuildWorkerPoolRead,
+		Schema: dsSchema,
+	}
+
+}
+
+func dataSourceGoogleCloudbuildWorkerPoolRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/workerPools/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+
+	id = strings.ReplaceAll(id, "/locations/global/", "/")
+	d.SetId(id)
+
+	err = resourceCloudbuildWorkerPoolRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_cloudbuild_worker_pool",
+		ProductName: "cloudbuild",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceGoogleCloudbuildWorkerPool(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/cloudbuild/data_source_google_cloudbuild_worker_pool_test.go
+++ b/mmv1/third_party/terraform/services/cloudbuild/data_source_google_cloudbuild_worker_pool_test.go
@@ -1,0 +1,44 @@
+package cloudbuild_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/cloudbuild"
+)
+
+func TestAccDataSourceGoogleCloudbuildWorkerPool_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleCloudbuildWorkerPool_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_cloudbuild_worker_pool.foo", "google_cloudbuild_worker_pool.test-worker-pool"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleCloudbuildWorkerPool_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloudbuild_worker_pool" "test-worker-pool" {
+	location = "europe-west1"
+	name     = "manual-pool-%{random_suffix}"
+}
+
+data "google_cloudbuild_worker_pool" "foo" {
+	location = google_cloudbuild_worker_pool.test-worker-pool.location
+	name     = google_cloudbuild_worker_pool.test-worker-pool.name
+}`, context)
+
+}

--- a/mmv1/third_party/terraform/website/docs/d/cloudbuild_worker_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloudbuild_worker_pool.html.markdown
@@ -1,0 +1,39 @@
+---
+subcategory: "Cloud Build"
+description: |-
+  Get information about a Google Cloud Build worker pool.
+---
+
+# google_cloudbuild_worker_pool
+
+To get more information about Cloudbuild worker pool, see:
+
+* [API documentation](https://docs.cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.workerPools)
+* How-to Guides
+    * [Official Documentation](https://cloud.google.com/build/docs/automating-builds/create-manage-triggers)
+
+## Example Usage
+
+```hcl
+data "google_cloudbuild_worker_pool" "name" {
+  project  = "your-project-id"
+  name     = "your-pool"
+  location = "europe-west1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The Cloud Build location for the worker pool.
+
+* `name` - (Required) User-defined name of the worker pool.
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it is not provided, the provider project is used.
+
+- - -
+
+## Attributes Reference
+
+See [google_cloudbuild_worker_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_worker_pool) resource for details of the available attributes.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds a new data source `google_cloudbuild_worker_pool`, allowing to retrieve a Cloud Build worker pool.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/29238

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_cloudbuild_worker_pool`
```
