### PR TITLE
Ignore dynamic orchestration_state in OS Config V2 Policy Orchestrator tests

### DIFF
--- a/mmv1/third_party/terraform/services/osconfigv2/resource_os_config_v2_policy_orchestrator_for_folder_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/osconfigv2/resource_os_config_v2_policy_orchestrator_for_folder_test.go.tmpl
@@ -35,7 +35,8 @@ func TestAccOSConfigV2PolicyOrchestratorForFolder_basic(t *testing.T) {
 				ResourceName:            "google_os_config_v2_policy_orchestrator_for_folder.policy_orchestrator_for_folder",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"folder_id", "labels", "policy_orchestrator_id", "terraform_labels"},
+				// orchestration_state contains dynamic status fields (e.g. performed_actions, progress) that advance asynchronously in the background as the orchestrator runs.
+				ImportStateVerifyIgnore: []string{"folder_id", "labels", "orchestration_state", "policy_orchestrator_id", "terraform_labels"},
 			},
 			{
 				Config: testAccOSConfigV2PolicyOrchestratorForFolder_update(context),
@@ -49,7 +50,8 @@ func TestAccOSConfigV2PolicyOrchestratorForFolder_basic(t *testing.T) {
 				ResourceName:            "google_os_config_v2_policy_orchestrator_for_folder.policy_orchestrator_for_folder",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"folder_id", "labels", "policy_orchestrator_id", "terraform_labels"},
+				// orchestration_state contains dynamic status fields (e.g. performed_actions, progress) that advance asynchronously in the background as the orchestrator runs.
+				ImportStateVerifyIgnore: []string{"folder_id", "labels", "orchestration_state", "policy_orchestrator_id", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/osconfigv2/resource_os_config_v2_policy_orchestrator_for_organization_test.go
+++ b/mmv1/third_party/terraform/services/osconfigv2/resource_os_config_v2_policy_orchestrator_for_organization_test.go
@@ -41,10 +41,11 @@ func TestAccOSConfigV2PolicyOrchestratorForOrganization_basic(t *testing.T) {
 				Config: testAccOSConfigV2PolicyOrchestratorForOrganization_basic(context),
 			},
 			{
-				ResourceName:            "google_os_config_v2_policy_orchestrator_for_organization.policy_orchestrator_for_organization",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "organization_id", "policy_orchestrator_id", "terraform_labels"},
+				ResourceName:      "google_os_config_v2_policy_orchestrator_for_organization.policy_orchestrator_for_organization",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// orchestration_state contains dynamic status fields (e.g. performed_actions, progress) that advance asynchronously in the background as the orchestrator runs.
+				ImportStateVerifyIgnore: []string{"labels", "orchestration_state", "organization_id", "policy_orchestrator_id", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/osconfigv2/resource_os_config_v2_policy_orchestrator_test.go
+++ b/mmv1/third_party/terraform/services/osconfigv2/resource_os_config_v2_policy_orchestrator_test.go
@@ -43,19 +43,21 @@ func TestAccOSConfigV2PolicyOrchestrator_basic(t *testing.T) {
 				Config: testAccOSConfigV2PolicyOrchestrator_basic(context),
 			},
 			{
-				ResourceName:            "google_os_config_v2_policy_orchestrator.policy_orchestrator",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "policy_orchestrator_id", "terraform_labels"},
+				ResourceName:      "google_os_config_v2_policy_orchestrator.policy_orchestrator",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// orchestration_state contains dynamic status fields (e.g. performed_actions, progress) that advance asynchronously in the background as the orchestrator runs.
+				ImportStateVerifyIgnore: []string{"labels", "orchestration_state", "policy_orchestrator_id", "terraform_labels"},
 			},
 			{
 				Config: testAccOSConfigV2PolicyOrchestrator_update(context),
 			},
 			{
-				ResourceName:            "google_os_config_v2_policy_orchestrator.policy_orchestrator",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "policy_orchestrator_id", "terraform_labels"},
+				ResourceName:      "google_os_config_v2_policy_orchestrator.policy_orchestrator",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// orchestration_state contains dynamic status fields (e.g. performed_actions, progress) that advance asynchronously in the background as the orchestrator runs.
+				ImportStateVerifyIgnore: []string{"labels", "orchestration_state", "policy_orchestrator_id", "terraform_labels"},
 			},
 		},
 	})


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28996
Reference: b/549495937

`orchestration_state` contains dynamic rollout status fields (such as `performed_actions` and `progress`) that advance asynchronously in the background while the policy orchestrator is active.

During `TestAccOSConfigV2PolicyOrchestrator_basic`, the `ImportStateVerify` step compares the initial state from creation against the live state read during import ~38s later. When actions complete in the background during this window, `ImportStateVerify` fails with an attribute mismatch, causing test flakiness.

Add `orchestration_state` to `ImportStateVerifyIgnore` in:
- `resource_os_config_v2_policy_orchestrator_test.go`
- `resource_os_config_v2_policy_orchestrator_for_folder_test.go.tmpl`
- `resource_os_config_v2_policy_orchestrator_for_organization_test.go`

```release-note:none
```
