### PR TITLE
assuredworkloadsv2: add product and Settings singleton resource

### DIFF
--- a/mmv1/products/assuredworkloadsv2/Settings.yaml
+++ b/mmv1/products/assuredworkloadsv2/Settings.yaml
@@ -1,0 +1,70 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Settings
+description: |
+  Manages organization-wide settings for Assured Workloads, such as Organization-Level
+  Personnel Controls (OLPC). This is a singleton resource.
+references:
+  guides:
+    Assured Workloads Settings: https://cloud.google.com/assured-workloads/docs/settings
+  api: https://cloud.google.com/assured-workloads/docs/reference/rest/v2/organizations/assuredWorkloadsSettings
+min_version: beta
+base_url: 'organizations/{{organization}}/assuredWorkloadsSettings'
+self_link: 'organizations/{{organization}}/assuredWorkloadsSettings'
+create_url: 'organizations/{{organization}}/assuredWorkloadsSettings?updateMask=olpc_mode'
+update_url: 'organizations/{{organization}}/assuredWorkloadsSettings?updateMask=olpc_mode'
+create_verb: PATCH
+update_verb: PATCH
+exclude_delete: true
+id_format: 'organizations/{{organization}}/assuredWorkloadsSettings'
+import_format:
+  - 'organizations/{{organization}}/assuredWorkloadsSettings'
+  - '{{organization}}'
+timeouts:
+  insert_minutes: 15
+  update_minutes: 15
+examples:
+  - name: assured_workloads_v2_settings_basic
+    primary_resource_id: settings
+    test_env_vars:
+      org_id: ORG_ID
+    exclude_test: true
+
+parameters:
+  - name: organization
+    type: String
+    description: The parent organization ID.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: Identifier. The resource name of the settings singleton.
+    output: true
+  - name: olpcMode
+    type: String
+    description: |
+      Organization-Level Personnel Control (OLPC) mode.
+      Possible values:
+      `OLPC_MODE_UNSPECIFIED`, `OLPC_MODE_OPT_OUT`, `OLPC_MODE_STRICT_IL5`,
+      `OLPC_MODE_ALLOW_MIXED_IL5`, `OLPC_MODE_STRICT_IL5_FORWARD`.
+    required: true
+    validation:
+      function: 'validation.StringInSlice([]string{"OLPC_MODE_UNSPECIFIED", "OLPC_MODE_OPT_OUT", "OLPC_MODE_STRICT_IL5", "OLPC_MODE_ALLOW_MIXED_IL5", "OLPC_MODE_STRICT_IL5_FORWARD"}, false)'
+  - name: etag
+    type: String
+    description: Concurrency token for optimistic locking.
+    output: true

--- a/mmv1/products/assuredworkloadsv2/product.yaml
+++ b/mmv1/products/assuredworkloadsv2/product.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: AssuredWorkloadsV2
+display_name: Assured Workloads V2
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+versions:
+  - name: beta
+    base_url: https://assuredworkloads.googleapis.com/v2/
+  - name: ga
+    base_url: https://assuredworkloads.googleapis.com/v2/

--- a/mmv1/templates/terraform/examples/assured_workloads_v2_settings_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/assured_workloads_v2_settings_basic.tf.tmpl
@@ -1,0 +1,4 @@
+resource "google_assured_workloads_v2_settings" "{{$.PrimaryResourceId}}" {
+  organization = "{{index $.TestEnvVars "org_id"}}"
+  olpc_mode    = "OLPC_MODE_OPT_OUT"
+}

--- a/mmv1/third_party/terraform/services/assuredworkloadsv2/resource_assured_workloads_v2_settings_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/assuredworkloadsv2/resource_assured_workloads_v2_settings_test.go.tmpl
@@ -1,0 +1,70 @@
+package assuredworkloadsv2_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/assuredworkloadsv2"
+)
+
+func TestAccAssuredWorkloadsV2Settings_lifecycle(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id": envvar.GetTestOrgFromEnv(t),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssuredWorkloadsV2Settings_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_settings.settings", "olpc_mode", "OLPC_MODE_OPT_OUT"),
+					resource.TestCheckResourceAttrSet("google_assured_workloads_v2_settings.settings", "etag"),
+				),
+			},
+			{
+				ResourceName:      "google_assured_workloads_v2_settings.settings",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAssuredWorkloadsV2Settings_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_settings.settings", "olpc_mode", "OLPC_MODE_STRICT_IL5_FORWARD"),
+					resource.TestCheckResourceAttrSet("google_assured_workloads_v2_settings.settings", "etag"),
+				),
+			},
+			{
+				ResourceName:      "google_assured_workloads_v2_settings.settings",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAssuredWorkloadsV2Settings_basic(context map[string]interface{}) string {
+	return fmt.Sprintf(`
+resource "google_assured_workloads_v2_settings" "settings" {
+  organization = "%s"
+  olpc_mode    = "OLPC_MODE_OPT_OUT"
+}
+`, context["org_id"])
+}
+
+func testAccAssuredWorkloadsV2Settings_update(context map[string]interface{}) string {
+	return fmt.Sprintf(`
+resource "google_assured_workloads_v2_settings" "settings" {
+  organization = "%s"
+  olpc_mode    = "OLPC_MODE_STRICT_IL5_FORWARD"
+}
+`, context["org_id"])
+}
+{{- end }}


### PR DESCRIPTION
Introduces the assuredworkloadsv2 Magic Modules product targeting the Assured Workloads V2 API (https://assuredworkloads.googleapis.com/v2/). Implements the `google_assured_workloads_v2_settings` resource for managing Organization-Level Personnel Controls (`olpc_mode`) as an AIP-156 singleton.

Fixes b/558491352

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_assured_workloads_v2_settings` (beta)
```