### PR TITLE
assuredworkloadsv2: add cloud_control_configs and recursive parameter expander

### DIFF
--- a/mmv1/products/assuredworkloadsv2/Settings.yaml
+++ b/mmv1/products/assuredworkloadsv2/Settings.yaml
@@ -1,0 +1,70 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Settings
+description: |
+  Manages organization-wide settings for Assured Workloads, such as Organization-Level
+  Personnel Controls (OLPC). This is a singleton resource.
+references:
+  guides:
+    Assured Workloads Settings: https://cloud.google.com/assured-workloads/docs/settings
+  api: https://cloud.google.com/assured-workloads/docs/reference/rest/v2/organizations/assuredWorkloadsSettings
+min_version: beta
+base_url: 'organizations/{{organization}}/assuredWorkloadsSettings'
+self_link: 'organizations/{{organization}}/assuredWorkloadsSettings'
+create_url: 'organizations/{{organization}}/assuredWorkloadsSettings?updateMask=olpc_mode'
+update_url: 'organizations/{{organization}}/assuredWorkloadsSettings?updateMask=olpc_mode'
+create_verb: PATCH
+update_verb: PATCH
+exclude_delete: true
+id_format: 'organizations/{{organization}}/assuredWorkloadsSettings'
+import_format:
+  - 'organizations/{{organization}}/assuredWorkloadsSettings'
+  - '{{organization}}'
+timeouts:
+  insert_minutes: 15
+  update_minutes: 15
+examples:
+  - name: assured_workloads_v2_settings_basic
+    primary_resource_id: settings
+    test_env_vars:
+      org_id: ORG_ID
+    exclude_test: true
+
+parameters:
+  - name: organization
+    type: String
+    description: The parent organization ID.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: Identifier. The resource name of the settings singleton.
+    output: true
+  - name: olpcMode
+    type: String
+    description: |
+      Organization-Level Personnel Control (OLPC) mode.
+      Possible values:
+      `OLPC_MODE_UNSPECIFIED`, `OLPC_MODE_OPT_OUT`, `OLPC_MODE_STRICT_IL5`,
+      `OLPC_MODE_ALLOW_MIXED_IL5`, `OLPC_MODE_STRICT_IL5_FORWARD`.
+    required: true
+    validation:
+      function: 'validation.StringInSlice([]string{"OLPC_MODE_UNSPECIFIED", "OLPC_MODE_OPT_OUT", "OLPC_MODE_STRICT_IL5", "OLPC_MODE_ALLOW_MIXED_IL5", "OLPC_MODE_STRICT_IL5_FORWARD"}, false)'
+  - name: etag
+    type: String
+    description: Concurrency token for optimistic locking.
+    output: true

--- a/mmv1/products/assuredworkloadsv2/Workload.yaml
+++ b/mmv1/products/assuredworkloadsv2/Workload.yaml
@@ -181,6 +181,84 @@ properties:
         type: Integer
         description: Major revision ID of the framework.
         immutable: true
+  - name: cloudControlConfigs
+    type: Array
+    description: Control configurations enforced on this workload. Updatable in place.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: cloudControl
+          type: String
+          description: Resource name of the cloud control.
+          required: true
+        - name: cloudControlRevision
+          type: Integer
+          description: Revision number of the cloud control.
+          required: true
+        - name: enforcementMode
+          type: String
+          description: 'Enforcement mode. Possible values: `PREVENTIVE`, `DETECTIVE`, `AUDIT`.'
+          required: true
+        - name: parameters
+          type: Array
+          description: Parameters for the cloud control configuration.
+          custom_expand: templates/terraform/custom_expand/assuredworkloadsv2_parameters.go.tmpl
+          item_type:
+            type: NestedObject
+            properties:
+              - name: name
+                type: String
+                description: The name or key of the parameter.
+                required: true
+              - name: parameterValue
+                type: NestedObject
+                description: Parameter value container. Exactly one value must be specified.
+                required: true
+                properties:
+                  - name: stringValue
+                    type: String
+                    description: String parameter value.
+                  - name: boolValue
+                    type: Boolean
+                    description: Boolean parameter value.
+                  - name: numberValue
+                    type: Double
+                    description: Number parameter value.
+                  - name: stringListValue
+                    type: NestedObject
+                    description: List of strings.
+                    properties:
+                      - name: values
+                        type: Array
+                        required: true
+                        item_type:
+                          type: String
+                  - name: oneofValue
+                    type: NestedObject
+                    description: Nested parameter for complex control configurations.
+                    properties:
+                      - name: name
+                        type: String
+                        required: true
+                      - name: parameterValue
+                        type: NestedObject
+                        description: Bounded sub-parameter value container.
+                        required: true
+                        properties:
+                          - name: stringValue
+                            type: String
+                          - name: boolValue
+                            type: Boolean
+                          - name: numberValue
+                            type: Double
+                          - name: stringListValue
+                            type: NestedObject
+                            properties:
+                              - name: values
+                                type: Array
+                                required: true
+                                item_type:
+                                  type: String
   - name: state
     type: String
     description: Output only. Status of the workload (e.g. `ACTIVE`, `CREATING`, `FAILED`).

--- a/mmv1/products/assuredworkloadsv2/Workload.yaml
+++ b/mmv1/products/assuredworkloadsv2/Workload.yaml
@@ -1,0 +1,199 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Workload
+description: |
+  A Workload object for managing Assured Workloads V2 environments, providing
+  orchestrated regulatory compliance on GCP Projects and Folders.
+references:
+  guides:
+    Assured Workloads Overview: https://cloud.google.com/assured-workloads/docs/overview
+  api: https://cloud.google.com/assured-workloads/docs/reference/rest/v2/organizations.locations.workloads
+min_version: beta
+base_url: 'organizations/{{organization}}/locations/{{location}}/workloads'
+self_link: '{{name}}'
+create_url: 'organizations/{{organization}}/locations/{{location}}/workloads'
+update_url: '{{name}}'
+update_verb: PATCH
+update_mask: true
+id_format: '{{name}}'
+import_format:
+  - 'organizations/{{organization}}/locations/{{location}}/workloads/{{workload_id}}'
+  - '{{organization}}/{{location}}/{{workload_id}}'
+timeouts:
+  insert_minutes: 30
+  update_minutes: 30
+  delete_minutes: 30
+autogen_async: true
+async:
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 30
+      update_minutes: 30
+      delete_minutes: 30
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - update
+    - delete
+  result:
+    resource_inside_response: true
+custom_code:
+  pre_create: templates/terraform/pre_create/assuredworkloadsv2_workload.go.tmpl
+  post_create: templates/terraform/post_create/set_computed_name.tmpl
+  custom_import: templates/terraform/custom_import/assuredworkloadsv2_workload.go.tmpl
+examples:
+  - name: 'assured_workloads_v2_workload_basic'
+    primary_resource_id: 'workload'
+    vars:
+      org_id: '123456789'
+      location: 'us-central1'
+      project_id: 'example-project'
+    exclude_test: true
+parameters:
+  - name: organization
+    type: String
+    description: The parent organization ID of the Assured Workloads environment.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: location
+    type: String
+    description: The location of the Assured Workloads environment.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: workloadId
+    type: String
+    description: |
+      User-assigned unique identifier for the workload. If omitted, the server generates an ID.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: name
+    type: String
+    description: Identifier. The resource name of the workload.
+    output: true
+  - name: description
+    type: String
+    description: User-friendly description for the workload.
+  - name: resourceConfig
+    type: NestedObject
+    description: Target GCP Folder or Project where controls are deployed. Exactly one target must be specified.
+    required: true
+    immutable: true
+    properties:
+      - name: existingProject
+        type: String
+        description: Reference to an existing GCP Project ID or number.
+        immutable: true
+        exactly_one_of:
+          - resource_config.0.existing_project
+          - resource_config.0.existing_folder
+          - resource_config.0.new_project_config
+          - resource_config.0.new_folder_config
+      - name: existingFolder
+        type: String
+        description: Reference to an existing GCP Folder (e.g. `folders/123`).
+        immutable: true
+        exactly_one_of:
+          - resource_config.0.existing_project
+          - resource_config.0.existing_folder
+          - resource_config.0.new_project_config
+          - resource_config.0.new_folder_config
+      - name: newProjectConfig
+        type: NestedObject
+        description: Configuration to provision a new GCP Project on the fly.
+        immutable: true
+        exactly_one_of:
+          - resource_config.0.existing_project
+          - resource_config.0.existing_folder
+          - resource_config.0.new_project_config
+          - resource_config.0.new_folder_config
+        properties:
+          - name: parent
+            type: String
+            description: Parent resource where the project will be created (e.g. `organizations/123` or `folders/456`).
+            required: true
+            immutable: true
+          - name: displayName
+            type: String
+            description: Display name for the new project.
+            required: true
+            immutable: true
+          - name: billingAccount
+            type: String
+            description: Billing account to link to the new project.
+            required: true
+            immutable: true
+      - name: newFolderConfig
+        type: NestedObject
+        description: Configuration to provision a new GCP Folder on the fly.
+        immutable: true
+        exactly_one_of:
+          - resource_config.0.existing_project
+          - resource_config.0.existing_folder
+          - resource_config.0.new_project_config
+          - resource_config.0.new_folder_config
+        properties:
+          - name: parent
+            type: String
+            description: Parent resource where the folder will be created (e.g. `organizations/123` or `folders/456`).
+            required: true
+            immutable: true
+          - name: displayName
+            type: String
+            description: Display name for the new folder.
+            required: true
+            immutable: true
+  - name: computedTargetResource
+    type: String
+    description: Output only. The resolved target resource (e.g. `projects/123` or `folders/456`).
+    output: true
+  - name: targetResourceDisplayName
+    type: String
+    description: Output only. User-facing display name of the target resource.
+    output: true
+  - name: framework
+    type: NestedObject
+    description: The compliance framework active on this workload.
+    required: true
+    immutable: true
+    properties:
+      - name: framework
+        type: String
+        description: The compliance framework resource name or ID (e.g. `organizations/123/locations/us/frameworks/fedramp-moderate` or `fedramp-moderate`).
+        required: true
+        immutable: true
+      - name: majorRevisionId
+        type: Integer
+        description: Major revision ID of the framework.
+        immutable: true
+  - name: state
+    type: String
+    description: Output only. Status of the workload (e.g. `ACTIVE`, `CREATING`, `FAILED`).
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. Creation timestamp in RFC3339 format.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. Last update timestamp in RFC3339 format.
+    output: true
+  - name: etag
+    type: String
+    description: Concurrency control token for optimistic locking.
+    output: true

--- a/mmv1/products/assuredworkloadsv2/product.yaml
+++ b/mmv1/products/assuredworkloadsv2/product.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: AssuredWorkloadsV2
+display_name: Assured Workloads V2
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+versions:
+  - name: beta
+    base_url: https://assuredworkloads.googleapis.com/v2/
+  - name: ga
+    base_url: https://assuredworkloads.googleapis.com/v2/

--- a/mmv1/templates/terraform/custom_expand/assuredworkloadsv2_parameters.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/assuredworkloadsv2_parameters.go.tmpl
@@ -1,0 +1,70 @@
+func expandAssuredWorkloadsV2SingleParamValue(raw map[string]interface{}) (map[string]interface{}, error) {
+	paramVal := make(map[string]interface{})
+	populatedCount := 0
+
+	if strVal, ok := raw["string_value"].(string); ok && strVal != "" {
+		paramVal["stringValue"] = strVal
+		populatedCount++
+	}
+	if bVal, ok := raw["bool_value"].(bool); ok && raw["bool_value"] != nil {
+		paramVal["boolValue"] = bVal
+		populatedCount++
+	}
+	if numVal, ok := raw["number_value"].(float64); ok && numVal != 0 {
+		paramVal["numberValue"] = numVal
+		populatedCount++
+	}
+	if listRaw, ok := raw["string_list_value"].([]interface{}); ok && len(listRaw) > 0 && listRaw[0] != nil {
+		listMap := listRaw[0].(map[string]interface{})
+		if vals, ok := listMap["values"].([]interface{}); ok {
+			paramVal["stringListValue"] = map[string]interface{}{"values": vals}
+			populatedCount++
+		}
+	}
+	if oneofRaw, ok := raw["oneof_value"].([]interface{}); ok && len(oneofRaw) > 0 && oneofRaw[0] != nil {
+		subMap := oneofRaw[0].(map[string]interface{})
+		expandedSub, err := expandAssuredWorkloadsV2SingleParameter(subMap)
+		if err != nil {
+			return nil, err
+		}
+		paramVal["oneofValue"] = expandedSub
+		populatedCount++
+	}
+
+	if populatedCount > 1 {
+		return nil, fmt.Errorf("parameter cannot have multiple values populated; specify exactly one of string_value, bool_value, number_value, string_list_value, or oneof_value")
+	}
+	return paramVal, nil
+}
+
+func expandAssuredWorkloadsV2SingleParameter(raw map[string]interface{}) (map[string]interface{}, error) {
+	transformed := make(map[string]interface{})
+	transformed["name"] = raw["name"]
+	if pvRaw, ok := raw["parameter_value"].([]interface{}); ok && len(pvRaw) > 0 && pvRaw[0] != nil {
+		expandedVal, err := expandAssuredWorkloadsV2SingleParamValue(pvRaw[0].(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		transformed["parameterValue"] = expandedVal
+	}
+	return transformed, nil
+}
+
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	l := v.([]interface{})
+	req := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		if raw == nil {
+			continue
+		}
+		expandedParam, err := expandAssuredWorkloadsV2SingleParameter(raw.(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		req = append(req, expandedParam)
+	}
+	return req, nil
+}

--- a/mmv1/templates/terraform/custom_import/assuredworkloadsv2_workload.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/assuredworkloadsv2_workload.go.tmpl
@@ -1,0 +1,19 @@
+config := meta.(*transport_tpg.Config)
+
+// Support full URI: organizations/{org}/locations/{loc}/workloads/{workload_id}
+// Support shorthand: {org}/{loc}/{workload_id}
+if err := tpgresource.ParseImportId([]string{
+	"^organizations/(?P<organization>[^/]+)/locations/(?P<location>[^/]+)/workloads/(?P<workload_id>[^/]+)$",
+	"^(?P<organization>[^/]+)/(?P<location>[^/]+)/(?P<workload_id>[^/]+)$",
+}, d, config); err != nil {
+	return nil, err
+}
+
+id := fmt.Sprintf("organizations/%s/locations/%s/workloads/%s",
+	d.Get("organization").(string),
+	d.Get("location").(string),
+	d.Get("workload_id").(string))
+d.SetId(id)
+_ = d.Set("name", id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/examples/assured_workloads_v2_settings_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/assured_workloads_v2_settings_basic.tf.tmpl
@@ -1,0 +1,4 @@
+resource "google_assured_workloads_v2_settings" "{{$.PrimaryResourceId}}" {
+  organization = "{{index $.TestEnvVars "org_id"}}"
+  olpc_mode    = "OLPC_MODE_OPT_OUT"
+}

--- a/mmv1/templates/terraform/examples/assured_workloads_v2_workload_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/assured_workloads_v2_workload_basic.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_assured_workloads_v2_workload" "{{$.PrimaryResourceId}}" {
+  organization = "{{index $.Vars "org_id"}}"
+  location     = "{{index $.Vars "location"}}"
+  workload_id  = "basic-workload"
+  description  = "Basic Assured Workloads V2 environment"
+
+  resource_config {
+    existing_project = "projects/{{index $.Vars "project_id"}}"
+  }
+
+  framework {
+    framework = "fedramp-moderate"
+  }
+}

--- a/mmv1/templates/terraform/pre_create/assuredworkloadsv2_workload.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/assuredworkloadsv2_workload.go.tmpl
@@ -1,0 +1,8 @@
+// Injects ?workloadId query parameter only if explicitly set by the user.
+// Avoids sending ?workloadId= on server-generated ID lifecycles.
+if v, ok := d.GetOk("workload_id"); ok && v.(string) != "" {
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"workloadId": v.(string)})
+	if err != nil {
+		return err
+	}
+}

--- a/mmv1/third_party/terraform/services/assuredworkloadsv2/resource_assured_workloads_v2_settings_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/assuredworkloadsv2/resource_assured_workloads_v2_settings_test.go.tmpl
@@ -1,0 +1,70 @@
+package assuredworkloadsv2_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/assuredworkloadsv2"
+)
+
+func TestAccAssuredWorkloadsV2Settings_lifecycle(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id": envvar.GetTestOrgFromEnv(t),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssuredWorkloadsV2Settings_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_settings.settings", "olpc_mode", "OLPC_MODE_OPT_OUT"),
+					resource.TestCheckResourceAttrSet("google_assured_workloads_v2_settings.settings", "etag"),
+				),
+			},
+			{
+				ResourceName:      "google_assured_workloads_v2_settings.settings",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAssuredWorkloadsV2Settings_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_settings.settings", "olpc_mode", "OLPC_MODE_STRICT_IL5_FORWARD"),
+					resource.TestCheckResourceAttrSet("google_assured_workloads_v2_settings.settings", "etag"),
+				),
+			},
+			{
+				ResourceName:      "google_assured_workloads_v2_settings.settings",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAssuredWorkloadsV2Settings_basic(context map[string]interface{}) string {
+	return fmt.Sprintf(`
+resource "google_assured_workloads_v2_settings" "settings" {
+  organization = "%s"
+  olpc_mode    = "OLPC_MODE_OPT_OUT"
+}
+`, context["org_id"])
+}
+
+func testAccAssuredWorkloadsV2Settings_update(context map[string]interface{}) string {
+	return fmt.Sprintf(`
+resource "google_assured_workloads_v2_settings" "settings" {
+  organization = "%s"
+  olpc_mode    = "OLPC_MODE_STRICT_IL5_FORWARD"
+}
+`, context["org_id"])
+}
+{{- end }}

--- a/mmv1/third_party/terraform/services/assuredworkloadsv2/resource_assured_workloads_v2_workload_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/assuredworkloadsv2/resource_assured_workloads_v2_workload_test.go.tmpl
@@ -98,6 +98,37 @@ func TestAccAssuredWorkloadsV2Workload_existingFolder(t *testing.T) {
 	})
 }
 
+func TestAccAssuredWorkloadsV2Workload_updateControls(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"project_id":    envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssuredWorkloadsV2Workload_controlsStep1(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_workload.workload", "cloud_control_configs.#", "1"),
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_workload.workload", "cloud_control_configs.0.enforcement_mode", "PREVENTIVE"),
+				),
+			},
+			{
+				Config: testAccAssuredWorkloadsV2Workload_controlsStep2(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_workload.workload", "cloud_control_configs.#", "1"),
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_workload.workload", "cloud_control_configs.0.enforcement_mode", "DETECTIVE"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAssuredWorkloadsV2Workload_existingProject(context map[string]interface{}) string {
 	return fmt.Sprintf(`
 resource "google_assured_workloads_v2_workload" "workload" {
@@ -152,5 +183,67 @@ resource "google_assured_workloads_v2_workload" "workload" {
   }
 }
 `, context["org_id"], context["random_suffix"], context["folder_id"])
+}
+
+func testAccAssuredWorkloadsV2Workload_controlsStep1(context map[string]interface{}) string {
+	return fmt.Sprintf(`
+resource "google_assured_workloads_v2_workload" "workload" {
+  organization = "%s"
+  location     = "us-central1"
+  workload_id  = "tf-test-ctrl-%s"
+  description  = "Test Workload with Controls Step 1"
+
+  resource_config {
+    existing_project = "projects/%s"
+  }
+
+  framework {
+    framework = "fedramp-moderate"
+  }
+
+  cloud_control_configs {
+    cloud_control          = "builtin-require-cmek"
+    cloud_control_revision = 1
+    enforcement_mode       = "PREVENTIVE"
+    parameters {
+      name = "key_rings"
+      parameter_value {
+        string_value = "projects/my-p/locations/us/keyRings/my-kr"
+      }
+    }
+  }
+}
+`, context["org_id"], context["random_suffix"], context["project_id"])
+}
+
+func testAccAssuredWorkloadsV2Workload_controlsStep2(context map[string]interface{}) string {
+	return fmt.Sprintf(`
+resource "google_assured_workloads_v2_workload" "workload" {
+  organization = "%s"
+  location     = "us-central1"
+  workload_id  = "tf-test-ctrl-%s"
+  description  = "Test Workload with Controls Step 2"
+
+  resource_config {
+    existing_project = "projects/%s"
+  }
+
+  framework {
+    framework = "fedramp-moderate"
+  }
+
+  cloud_control_configs {
+    cloud_control          = "builtin-require-cmek"
+    cloud_control_revision = 1
+    enforcement_mode       = "DETECTIVE"
+    parameters {
+      name = "key_rings"
+      parameter_value {
+        string_value = "projects/my-p/locations/us/keyRings/my-kr"
+      }
+    }
+  }
+}
+`, context["org_id"], context["random_suffix"], context["project_id"])
 }
 {{- end }}

--- a/mmv1/third_party/terraform/services/assuredworkloadsv2/resource_assured_workloads_v2_workload_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/assuredworkloadsv2/resource_assured_workloads_v2_workload_test.go.tmpl
@@ -1,0 +1,156 @@
+package assuredworkloadsv2_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/assuredworkloadsv2"
+)
+
+func TestAccAssuredWorkloadsV2Workload_existingProject(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"project_id":    envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssuredWorkloadsV2Workload_existingProject(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_workload.workload", "location", "us-central1"),
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_workload.workload", "workload_id", fmt.Sprintf("tf-test-%s", context["random_suffix"])),
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_workload.workload", "framework.0.framework", "fedramp-moderate"),
+					resource.TestCheckResourceAttrSet("google_assured_workloads_v2_workload.workload", "name"),
+					resource.TestCheckResourceAttrSet("google_assured_workloads_v2_workload.workload", "computed_target_resource"),
+				),
+			},
+			{
+				ResourceName:      "google_assured_workloads_v2_workload.workload",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAssuredWorkloadsV2Workload_serverAssignedId(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"project_id":    envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssuredWorkloadsV2Workload_serverAssignedId(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_workload.workload", "location", "us-central1"),
+					resource.TestCheckResourceAttrSet("google_assured_workloads_v2_workload.workload", "name"),
+					resource.TestCheckResourceAttrSet("google_assured_workloads_v2_workload.workload", "computed_target_resource"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAssuredWorkloadsV2Workload_existingFolder(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"folder_id":     envvar.GetTestFolderFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssuredWorkloadsV2Workload_existingFolder(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_workload.workload", "location", "us-central1"),
+					resource.TestCheckResourceAttr("google_assured_workloads_v2_workload.workload", "framework.0.framework", "il4"),
+					resource.TestCheckResourceAttrSet("google_assured_workloads_v2_workload.workload", "name"),
+				),
+			},
+			{
+				ResourceName:      "google_assured_workloads_v2_workload.workload",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAssuredWorkloadsV2Workload_existingProject(context map[string]interface{}) string {
+	return fmt.Sprintf(`
+resource "google_assured_workloads_v2_workload" "workload" {
+  organization = "%s"
+  location     = "us-central1"
+  workload_id  = "tf-test-%s"
+  description  = "Test Workload on Existing Project"
+
+  resource_config {
+    existing_project = "projects/%s"
+  }
+
+  framework {
+    framework = "fedramp-moderate"
+  }
+}
+`, context["org_id"], context["random_suffix"], context["project_id"])
+}
+
+func testAccAssuredWorkloadsV2Workload_serverAssignedId(context map[string]interface{}) string {
+	return fmt.Sprintf(`
+resource "google_assured_workloads_v2_workload" "workload" {
+  organization = "%s"
+  location     = "us-central1"
+  description  = "Test Workload with Server Assigned ID"
+
+  resource_config {
+    existing_project = "projects/%s"
+  }
+
+  framework {
+    framework = "fedramp-moderate"
+  }
+}
+`, context["org_id"], context["project_id"])
+}
+
+func testAccAssuredWorkloadsV2Workload_existingFolder(context map[string]interface{}) string {
+	return fmt.Sprintf(`
+resource "google_assured_workloads_v2_workload" "workload" {
+  organization = "%s"
+  location     = "us-central1"
+  workload_id  = "tf-test-folder-%s"
+  description  = "Test Workload on Existing Folder"
+
+  resource_config {
+    existing_folder = "folders/%s"
+  }
+
+  framework {
+    framework = "il4"
+  }
+}
+`, context["org_id"], context["random_suffix"], context["folder_id"])
+}
+{{- end }}


### PR DESCRIPTION
Extends `google_assured_workloads_v2_workload` with `cloud_control_configs` and enforcement modes (`PREVENTIVE`, `DETECTIVE`, `AUDIT`). Implements a custom recursive expander to prune unset polymorphic parameter values and handle nested `oneof_value` structures.

Fixes b/558491626

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
assuredworkloadsv2: added `cloud_control_configs` field to `google_assured_workloads_v2_workload` resource (beta)
```