### PR TITLE
vmwareengine: add vsan_type support for private clouds and clusters

### DIFF
--- a/mmv1/products/vmwareengine/Cluster.yaml
+++ b/mmv1/products/vmwareengine/Cluster.yaml
@@ -297,6 +297,18 @@ properties:
           Minimum cool down period is 30m.
           Cool down period must be in whole minutes (for example, 30m, 31m, 50m).
           Mandatory for successful addition of autoscaling settings in cluster.
+  - name: vsanType
+    type: Enum
+    description: |
+      Optional. The type of the vSAN.
+      Possible values:
+      * `VSAN_TYPE_OSA`: Standard (OSA) vSAN.
+      * `VSAN_TYPE_ESA`: Express Storage Architecture (ESA) vSAN.
+    immutable: true
+    min_version: beta
+    enum_values:
+      - VSAN_TYPE_OSA
+      - VSAN_TYPE_ESA
   - name: datastoreMountConfig
     type: Array
     description: |

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -351,6 +351,18 @@ properties:
               Minimum cool down period is 30m.
               Cool down period must be in whole minutes (for example, 30m, 31m, 50m).
               Mandatory for successful addition of autoscaling settings in cluster.
+      - name: vsanType
+        type: Enum
+        description: |
+          Optional. The type of the vSAN.
+          Possible values:
+          * `VSAN_TYPE_OSA`: Standard (OSA) vSAN.
+          * `VSAN_TYPE_ESA`: Express Storage Architecture (ESA) vSAN.
+        immutable: true
+        min_version: beta
+        enum_values:
+          - VSAN_TYPE_OSA
+          - VSAN_TYPE_ESA
   - name: hcx
     type: NestedObject
     description: |

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
@@ -574,7 +574,6 @@ func TestRemoveDatastoreMountConfigFieldFromUpdateMask(t *testing.T) {
 	}
 }
 
-
 func TestAccVmwareengineCluster_vmwareEngineClusterVsanType(t *testing.T) {
 	acctest.SkipIfVcr(t)
 	t.Parallel()

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
@@ -573,3 +573,96 @@ func TestRemoveDatastoreMountConfigFieldFromUpdateMask(t *testing.T) {
 		})
 	}
 }
+
+
+func TestAccVmwareengineCluster_vmwareEngineClusterVsanType(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	random_suffix := acctest.RandString(t, 10)
+	region_id := "me-west1"
+	context := map[string]interface{}{
+		"region":               region_id,
+		"random_suffix":        random_suffix,
+		"org_id":               envvar.GetTestOrgFromEnv(t),
+		"billing_account":      envvar.GetTestBillingAccountFromEnv(t),
+		"vmwareengine_project": os.Getenv("GOOGLE_VMWAREENGINE_PROJECT"),
+		"zone":                 region_id + "-b",
+		"pc_name":              "tf-test-cluster-pc" + random_suffix,
+		"mgmt_cluster_node":    3,
+		"node_type":            "standard-72",
+		"vsan_type":            "VSAN_TYPE_ESA",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckVmwareengineClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testVmwareEngineClusterConfig_VsanType(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_vmwareengine_cluster.vmw-engine-ext-cluster", "vsan_type", "VSAN_TYPE_ESA"),
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_vmwareengine_cluster.ds_vmw_engine_ext_cluster", "google_vmwareengine_cluster.vmw-engine-ext-cluster"),
+				),
+			},
+			{
+				ResourceName:            "google_vmwareengine_cluster.vmw-engine-ext-cluster",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent", "name"},
+			},
+		},
+	})
+}
+
+func testVmwareEngineClusterConfig_VsanType(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "vmw-engine-nw" {
+  project = "%{vmwareengine_project}"
+  name              = "tf-test-pc-nw-%{random_suffix}"
+  location          = "global"
+  type              = "STANDARD"
+  description       = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
+  project = "%{vmwareengine_project}"
+  location = "%{zone}"
+  name = "%{pc_name}"
+  type = "STANDARD"
+  network_config {
+    management_cidr = "192.168.0.0/24"
+    vmware_engine_network = google_vmwareengine_network.vmw-engine-nw.id
+  }
+  management_cluster {
+    cluster_id = "sample-mgmt-cluster%{random_suffix}"
+    node_type_configs {
+      node_type_id = "%{node_type}"
+      node_count = "%{mgmt_cluster_node}"
+    }
+  }
+}
+
+resource "google_vmwareengine_cluster" "vmw-engine-ext-cluster" {
+  name = "ext-cluster%{random_suffix}"
+  parent = google_vmwareengine_private_cloud.vmw-engine-pc.id
+  node_type_configs {
+    node_type_id = "%{node_type}"
+    node_count = 3
+  }
+  vsan_type = "%{vsan_type}"
+}
+
+data "google_vmwareengine_cluster" "ds_vmw_engine_ext_cluster" {
+  name = "ext-cluster%{random_suffix}"
+  parent = google_vmwareengine_private_cloud.vmw-engine-pc.id
+  depends_on = [
+    google_vmwareengine_cluster.vmw-engine-ext-cluster,
+  ]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -464,7 +464,6 @@ func testAccCheckVmwareenginePrivateCloudDestroyProducer(t *testing.T) func(s *t
 	}
 }
 
-
 func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudVsanType(t *testing.T) {
 	acctest.SkipIfVcr(t)
 	t.Parallel()

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -463,3 +463,89 @@ func testAccCheckVmwareenginePrivateCloudDestroyProducer(t *testing.T) func(s *t
 		return nil
 	}
 }
+
+
+func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudVsanType(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"region":               "me-west1",
+		"random_suffix":        acctest.RandString(t, 10),
+		"org_id":               envvar.GetTestOrgFromEnv(t),
+		"billing_account":      envvar.GetTestBillingAccountFromEnv(t),
+		"vmwareengine_project": os.Getenv("GOOGLE_VMWAREENGINE_PROJECT"),
+		"vsan_type":            "VSAN_TYPE_ESA",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckVmwareenginePrivateCloudDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testVmwareenginePrivateCloudVsanTypeConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_vmwareengine_private_cloud.vmw-engine-pc", "management_cluster.0.vsan_type", "VSAN_TYPE_ESA"),
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_vmwareengine_private_cloud.ds",
+						"google_vmwareengine_private_cloud.vmw-engine-pc",
+						[]string{
+							"deletion_delay_hours",
+							"send_deletion_delay_hours_if_zero",
+						}),
+				),
+			},
+			{
+				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name", "update_time", "deletion_delay_hours", "send_deletion_delay_hours_if_zero"},
+			},
+		},
+	})
+}
+
+func testVmwareenginePrivateCloudVsanTypeConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "vmw-engine-nw" {
+  project = "%{vmwareengine_project}"
+  name              = "tf-test-pc-nw-%{random_suffix}"
+  location          = "global"
+  type              = "STANDARD"
+  description       = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
+  project = "%{vmwareengine_project}"
+  location = "%{region}-b"
+  name = "tf-test-sample-pc%{random_suffix}"
+  description = "Sample PC description."
+  type = "STANDARD"
+  network_config {
+    management_cidr = "192.168.0.0/24"
+    vmware_engine_network = google_vmwareengine_network.vmw-engine-nw.id
+  }
+  management_cluster {
+    cluster_id = "tf-test-mgmt-cluster-%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = 3
+    }
+    vsan_type = "%{vsan_type}"
+  }
+}
+
+data "google_vmwareengine_private_cloud" "ds" {
+  project = "%{vmwareengine_project}"
+  location = "%{region}-b"
+  name = "tf-test-sample-pc%{random_suffix}"
+  depends_on = [
+    google_vmwareengine_private_cloud.vmw-engine-pc,
+  ]
+}
+`, context)
+}


### PR DESCRIPTION
Add vsan_type support in context of b/532812662

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vmwareengine: added `vsan_type` field in `google-beta` for `google_vmwareengine_private_cloud` (management_cluster) and `google_vmwareengine_cluster`
```
