### PR TITLE
parametermanager: add google_parameter_manager_template resource

### DIFF
--- a/mmv1/products/parametermanager/Template.yaml
+++ b/mmv1/products/parametermanager/Template.yaml
@@ -1,0 +1,116 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Template
+description: |
+  A Template resource defines the structure of parameter data using a schema in
+  YAML or JSON format. Template versions contain the templated payload, with
+  variables as placeholders whose values are supplied by a ParameterVersion at
+  render time.
+references:
+  guides:
+    'Parameter Manager templates overview': 'https://cloud.google.com/secret-manager/parameter-manager/docs/parameter-templates-overview'
+  api: https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.templates
+docs:
+base_url: projects/{{project}}/locations/global/templates
+self_link: projects/{{project}}/locations/global/templates/{{template_id}}
+create_url: projects/{{project}}/locations/global/templates?template_id={{template_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/global/templates/{{template_id}}
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+custom_code:
+samples:
+  - name: template_config_basic
+    primary_resource_id: template-basic
+    steps:
+      - name: template_config_basic
+        resource_id_vars:
+          template_id: template
+        test_vars_overrides:
+          # for backward compatible
+          template_id: '"template" + randomSuffix'
+  - name: template_with_format
+    primary_resource_id: template-with-format
+    steps:
+      - name: template_with_format
+        resource_id_vars:
+          template_id: template
+        test_vars_overrides:
+          # for backward compatible
+          template_id: '"template" + randomSuffix'
+  - name: template_with_labels
+    primary_resource_id: template-with-labels
+    steps:
+      - name: template_with_labels
+        resource_id_vars:
+          template_id: template
+        test_vars_overrides:
+          # for backward compatible
+          template_id: '"template" + randomSuffix'
+parameters:
+  - name: templateId
+    type: String
+    description: |
+      The ID to use for the Template, which will become the final component of
+      the Template's resource name. This must be unique within the project.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: name
+    type: String
+    description: |
+      The resource name of the Template. Format:
+      `projects/{{project}}/locations/global/templates/{{template_id}}`
+    output: true
+  - name: createTime
+    type: String
+    description: |
+      The time at which the Template was created.
+    output: true
+  - name: updateTime
+    type: String
+    description: |
+      The time at which the Template was updated.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: |
+      The labels assigned to this Template.
+
+      Label keys must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128 bytes,
+      and must conform to the following PCRE regular expression: [\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}
+
+      Label values must be between 0 and 63 characters long, have a UTF-8 encoding of maximum 128 bytes,
+      and must conform to the following PCRE regular expression: [\p{Ll}\p{Lo}\p{N}_-]{0,63}
+
+      No more than 64 labels can be assigned to a given resource.
+
+      An object containing a list of "key": value pairs. Example:
+      { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+  - name: format
+    type: Enum
+    description: |
+      The format type of the Template.
+    default_value: TEMPLATE_FORMAT_YAML
+    immutable: true
+    enum_values:
+      - TEMPLATE_FORMAT_UNSPECIFIED
+      - TEMPLATE_FORMAT_YAML
+      - TEMPLATE_FORMAT_JSON

--- a/mmv1/templates/terraform/samples/services/parametermanager/template_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanager/template_config_basic.tf.tmpl
@@ -1,0 +1,3 @@
+resource "google_parameter_manager_template" "{{$.PrimaryResourceId}}" {
+  template_id = "{{index $.ResourceIdVars "template_id"}}"
+}

--- a/mmv1/templates/terraform/samples/services/parametermanager/template_with_format.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanager/template_with_format.tf.tmpl
@@ -1,0 +1,4 @@
+resource "google_parameter_manager_template" "{{$.PrimaryResourceId}}" {
+  template_id = "{{index $.ResourceIdVars "template_id"}}"
+  format      = "TEMPLATE_FORMAT_JSON"
+}

--- a/mmv1/templates/terraform/samples/services/parametermanager/template_with_labels.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanager/template_with_labels.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_parameter_manager_template" "{{$.PrimaryResourceId}}" {
+  template_id = "{{index $.ResourceIdVars "template_id"}}"
+
+  labels = {
+    key1 = "val1"
+    key2 = "val2"
+    key3 = "val3"
+    key4 = "val4"
+    key5 = "val5"
+  }
+}


### PR DESCRIPTION
Add `google_parameter_manager_template` resource for managing Parameter Manager templates with support for YAML and JSON formats and labels.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_parameter_manager_template`
```