### PR TITLE
parametermanager: add google_parameter_manager_template_version resource

### DIFF
--- a/mmv1/products/parametermanager/Template.yaml
+++ b/mmv1/products/parametermanager/Template.yaml
@@ -1,0 +1,116 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Template
+description: |
+  A Template resource defines the structure of parameter data using a schema in
+  YAML or JSON format. Template versions contain the templated payload, with
+  variables as placeholders whose values are supplied by a ParameterVersion at
+  render time.
+references:
+  guides:
+    'Parameter Manager templates overview': 'https://cloud.google.com/secret-manager/parameter-manager/docs/parameter-templates-overview'
+  api: https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.templates
+docs:
+base_url: projects/{{project}}/locations/global/templates
+self_link: projects/{{project}}/locations/global/templates/{{template_id}}
+create_url: projects/{{project}}/locations/global/templates?template_id={{template_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/global/templates/{{template_id}}
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+custom_code:
+samples:
+  - name: template_config_basic
+    primary_resource_id: template-basic
+    steps:
+      - name: template_config_basic
+        resource_id_vars:
+          template_id: template
+        test_vars_overrides:
+          # for backward compatible
+          template_id: '"template" + randomSuffix'
+  - name: template_with_format
+    primary_resource_id: template-with-format
+    steps:
+      - name: template_with_format
+        resource_id_vars:
+          template_id: template
+        test_vars_overrides:
+          # for backward compatible
+          template_id: '"template" + randomSuffix'
+  - name: template_with_labels
+    primary_resource_id: template-with-labels
+    steps:
+      - name: template_with_labels
+        resource_id_vars:
+          template_id: template
+        test_vars_overrides:
+          # for backward compatible
+          template_id: '"template" + randomSuffix'
+parameters:
+  - name: templateId
+    type: String
+    description: |
+      The ID to use for the Template, which will become the final component of
+      the Template's resource name. This must be unique within the project.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: name
+    type: String
+    description: |
+      The resource name of the Template. Format:
+      `projects/{{project}}/locations/global/templates/{{template_id}}`
+    output: true
+  - name: createTime
+    type: String
+    description: |
+      The time at which the Template was created.
+    output: true
+  - name: updateTime
+    type: String
+    description: |
+      The time at which the Template was updated.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: |
+      The labels assigned to this Template.
+
+      Label keys must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128 bytes,
+      and must conform to the following PCRE regular expression: [\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}
+
+      Label values must be between 0 and 63 characters long, have a UTF-8 encoding of maximum 128 bytes,
+      and must conform to the following PCRE regular expression: [\p{Ll}\p{Lo}\p{N}_-]{0,63}
+
+      No more than 64 labels can be assigned to a given resource.
+
+      An object containing a list of "key": value pairs. Example:
+      { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+  - name: format
+    type: Enum
+    description: |
+      The format type of the Template.
+    default_value: TEMPLATE_FORMAT_YAML
+    immutable: true
+    enum_values:
+      - TEMPLATE_FORMAT_UNSPECIFIED
+      - TEMPLATE_FORMAT_YAML
+      - TEMPLATE_FORMAT_JSON

--- a/mmv1/products/parametermanager/TemplateVersion.yaml
+++ b/mmv1/products/parametermanager/TemplateVersion.yaml
@@ -1,0 +1,118 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: TemplateVersion
+description: |
+  A TemplateVersion resource stores the templated payload for a Template, using
+  `{{.variableName}}` placeholders that are resolved from a ParameterVersion's
+  data at render time.
+references:
+  guides:
+  api: https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.templates.versions
+docs:
+base_url: '{{template}}/versions'
+self_link: '{{template}}/versions/{{template_version_id}}'
+create_url: '{{template}}/versions?template_version_id={{template_version_id}}'
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{%project}}/locations/global/templates/{{%template_id}}/versions/{{%template_version_id}}
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+exclude_identity_generation: true
+custom_code:
+  custom_import: templates/terraform/custom_import/parameter_manager_template_version.go.tmpl
+samples:
+  - name: template_version_basic
+    primary_resource_id: template-version-basic
+    steps:
+      - name: template_version_basic
+        resource_id_vars:
+          template_id: template
+          template_version_id: template_version
+        test_vars_overrides:
+          # for backward compatible
+          template_id: '"template" + randomSuffix'
+  - name: template_version_with_json_format
+    primary_resource_id: template-version-with-json-format
+    steps:
+      - name: template_version_with_json_format
+        resource_id_vars:
+          template_id: template
+          template_version_id: template_version
+        test_vars_overrides:
+          # for backward compatible
+          template_id: '"template" + randomSuffix'
+parameters:
+  - name: template
+    type: ResourceRef
+    description: |
+      Parameter Manager Template resource.
+    url_param_only: true
+    required: true
+    immutable: true
+    resource: Template
+    imports: name
+  - name: template_version_id
+    type: String
+    description: |
+      Version ID of the Template Version resource. This must be unique within the Template.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: name
+    type: String
+    description: |
+      The resource name of the TemplateVersion. Format:
+      `projects/{{project}}/locations/global/templates/{{template_id}}/versions/{{template_version_id}}`
+    output: true
+  - name: createTime
+    type: String
+    description: |
+      The time at which the TemplateVersion was created.
+    output: true
+  - name: updateTime
+    type: String
+    description: |
+      The time at which the TemplateVersion was updated.
+    output: true
+  - name: disabled
+    type: Boolean
+    description: |
+      The current state of the TemplateVersion. If true, the payload is
+      never returned by read or render calls. This field is only applicable
+      for updating a TemplateVersion.
+  - name: payload
+    type: NestedObject
+    description: |
+      The payload content of a TemplateVersion resource.
+    flatten_object: true
+    required: true
+    immutable: true
+    custom_flatten: templates/terraform/custom_flatten/template_version_template_data.go.tmpl
+    properties:
+      - name: template_data
+        type: String
+        description: |
+          The template data. Use `{{.variableName}}` placeholders for values
+          that are resolved from a ParameterVersion's data when the
+          TemplateVersion is rendered.
+        api_name: data
+        required: true
+        immutable: true
+        sensitive: true
+        custom_expand: templates/terraform/custom_expand/base64.go.tmpl

--- a/mmv1/templates/terraform/custom_flatten/template_version_template_data.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/template_version_template_data.go.tmpl
@@ -1,0 +1,28 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	data, err := base64.StdEncoding.DecodeString(original["data"].(string))
+	if err != nil {
+		return err
+	}
+	transformed["template_data"] = string(data)
+	return []interface{}{transformed}
+}

--- a/mmv1/templates/terraform/custom_import/parameter_manager_template_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/parameter_manager_template_version.go.tmpl
@@ -1,0 +1,38 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+	config := meta.(*transport_tpg.Config)
+
+    // current import_formats can't import fields with forward slashes in their value
+	if err := tpgresource.ParseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+		return nil, err
+	}
+
+	name := d.Get("name").(string)
+	templateRegex := regexp.MustCompile("(projects/.+/locations/global/templates/.+)/versions/.+$")
+	versionRegex := regexp.MustCompile("projects/(.+)/locations/global/templates/(.+)/versions/(.+)$")
+
+	parts := templateRegex.FindStringSubmatch(name)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Version name does not fit the format `projects/{{"{{"}}project{{"}}"}}/locations/global/templates/{{"{{"}}template_id{{"}}"}}/versions/{{"{{"}}template_version_id{{"}}"}}`")
+	}
+	if err := d.Set("template", parts[1]); err != nil {
+		return nil, fmt.Errorf("Error setting template: %s", err)
+	}
+
+	parts = versionRegex.FindStringSubmatch(name)
+
+	if err := d.Set("template_version_id", parts[3]); err != nil {
+		return nil, fmt.Errorf("Error setting template_version_id: %s", err)
+	}
+
+	return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/samples/services/parametermanager/template_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanager/template_config_basic.tf.tmpl
@@ -1,0 +1,3 @@
+resource "google_parameter_manager_template" "{{$.PrimaryResourceId}}" {
+  template_id = "{{index $.ResourceIdVars "template_id"}}"
+}

--- a/mmv1/templates/terraform/samples/services/parametermanager/template_version_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanager/template_version_basic.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_parameter_manager_template" "template-basic" {
+  template_id = "{{index $.ResourceIdVars "template_id"}}"
+}
+
+resource "google_parameter_manager_template_version" "{{$.PrimaryResourceId}}" {
+  template             = google_parameter_manager_template.template-basic.id
+  template_version_id  = "{{index $.ResourceIdVars "template_version_id"}}"
+  template_data        = "greeting: hello {{"{{"}}.name{{"}}"}}"
+}

--- a/mmv1/templates/terraform/samples/services/parametermanager/template_version_with_json_format.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanager/template_version_with_json_format.tf.tmpl
@@ -1,0 +1,12 @@
+resource "google_parameter_manager_template" "template-basic" {
+  template_id = "{{index $.ResourceIdVars "template_id"}}"
+  format      = "TEMPLATE_FORMAT_JSON"
+}
+
+resource "google_parameter_manager_template_version" "{{$.PrimaryResourceId}}" {
+  template             = google_parameter_manager_template.template-basic.id
+  template_version_id  = "{{index $.ResourceIdVars "template_version_id"}}"
+  template_data = jsonencode({
+    "greeting" : "hello {{"{{"}}.name{{"}}"}}"
+  })
+}

--- a/mmv1/templates/terraform/samples/services/parametermanager/template_with_format.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanager/template_with_format.tf.tmpl
@@ -1,0 +1,4 @@
+resource "google_parameter_manager_template" "{{$.PrimaryResourceId}}" {
+  template_id = "{{index $.ResourceIdVars "template_id"}}"
+  format      = "TEMPLATE_FORMAT_JSON"
+}

--- a/mmv1/templates/terraform/samples/services/parametermanager/template_with_labels.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanager/template_with_labels.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_parameter_manager_template" "{{$.PrimaryResourceId}}" {
+  template_id = "{{index $.ResourceIdVars "template_id"}}"
+
+  labels = {
+    key1 = "val1"
+    key2 = "val2"
+    key3 = "val3"
+    key4 = "val4"
+    key5 = "val5"
+  }
+}

--- a/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_template_version_render.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_template_version_render.go.tmpl
@@ -1,0 +1,158 @@
+package parametermanager
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceParameterManagerTemplateVersionRender() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceParameterManagerTemplateVersionRenderRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"template": {
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+			},
+			"template_version_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"parameter_version": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The resource name of the ParameterVersion used to resolve the template's variables, in the format projects/PROJECT/locations/global/parameters/PARAMETER/versions/VERSION.",
+			},
+			"template_data": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"rendered_template_data": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceParameterManagerTemplateVersionRenderRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	// Check if the template is provided as a resource reference or a template id.
+	templateRegex := regexp.MustCompile("projects/(.+)/locations/global/templates/(.+)$")
+	dTemplate, ok := d.Get("template").(string)
+	if !ok {
+		return fmt.Errorf("wrong type for template field (%T), expected string", d.Get("template"))
+	}
+
+	parts := templateRegex.FindStringSubmatch(dTemplate)
+	var project string
+
+	// if reference of the template is provided in the template field
+	if len(parts) == 3 {
+		// Stores value of project to set in state
+		project = parts[1]
+		if dProject, ok := d.Get("project").(string); !ok {
+			return fmt.Errorf("wrong type for project (%T), expected string", d.Get("project"))
+		} else if dProject != "" && dProject != project {
+			return fmt.Errorf("project field value (%s) does not match project of template (%s).", dProject, project)
+		}
+		if err := d.Set("template", parts[2]); err != nil {
+			return fmt.Errorf("error setting template: %s", err)
+		}
+	} else { // if template name is provided in the template field
+		// Stores value of project to set in state
+		project, err = tpgresource.GetProject(d, config)
+		if err != nil {
+			return fmt.Errorf("error fetching project for template: %s", err)
+		}
+	}
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("error setting project: %s", err)
+	}
+
+	dParameterVersion, ok := d.Get("parameter_version").(string)
+	if !ok {
+		return fmt.Errorf("wrong type for parameter_version field (%T), expected string", d.Get("parameter_version"))
+	}
+
+	renderUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ParameterManagerBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/global/templates/{{"{{"}}template{{"}}"}}/versions/{{"{{"}}template_version_id{{"}}"}}:render")
+	if err != nil {
+		return err
+	}
+	renderUrl = fmt.Sprintf("%s?parameterVersion=%s", renderUrl, url.QueryEscape(dParameterVersion))
+
+	headers := make(http.Header)
+	templateVersion, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    renderUrl,
+		UserAgent: userAgent,
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("error retrieving available parameter manager template version: %s", err.Error())
+	}
+
+	nameValue, ok := templateVersion["templateVersion"]
+	if !ok {
+		return fmt.Errorf("read response didn't contain critical fields. Read may not have succeeded.")
+	}
+
+	if err := d.Set("name", nameValue.(string)); err != nil {
+		return fmt.Errorf("error reading templateVersion: %s", err)
+	}
+
+	data := templateVersion["payload"].(map[string]interface{})
+	templateData, err := base64.StdEncoding.DecodeString(data["data"].(string))
+	if err != nil {
+		return fmt.Errorf("error decoding parameter manager template version data: %s", err.Error())
+	}
+	if err := d.Set("template_data", string(templateData)); err != nil {
+		return fmt.Errorf("error setting template_data: %s", err)
+	}
+
+	renderedTemplateData, err := base64.StdEncoding.DecodeString(templateVersion["renderedPayload"].(string))
+	if err != nil {
+		return fmt.Errorf("error decoding parameter manager template version rendered payload data: %s", err.Error())
+	}
+	if err := d.Set("rendered_template_data", string(renderedTemplateData)); err != nil {
+		return fmt.Errorf("error setting rendered_template_data: %s", err)
+	}
+	d.SetId(nameValue.(string))
+	return nil
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_parameter_manager_template_version_render",
+		ProductName: "parametermanager",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceParameterManagerTemplateVersionRender(),
+	}.Register()
+}


### PR DESCRIPTION
Add `google_parameter_manager_template_version` resource and `google_parameter_manager_template_version_render` data source for managing template versions and rendering templates with variable substitution.

Merge after [parameter-manager-template](https://github.com/GoogleCloudPlatform/magic-modules/pull/18916) has been merged.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_parameter_manager_template_version`
```

```release-note:new-resource
`google_parameter_manager_template_version_render`
```