### PR TITLE
Make Deployment artifacts_gcs_bucket O+C

### DIFF
--- a/mmv1/products/config/Deployment.yaml
+++ b/mmv1/products/config/Deployment.yaml
@@ -119,6 +119,7 @@ properties:
     description: Optional constraint on the Terraform version.
   - name: artifactsGcsBucket
     type: String
+    default_from_api: true
     description: Location for Cloud Build logs and artifacts.
   - name: workerPool
     type: String


### PR DESCRIPTION
Test failure:


>           # google_config_deployment.basic will be updated in-place
>           ~ resource "google_config_deployment" "basic" {
>               - artifacts_gcs_bucket      = "gs://594424405950-us-central1-blueprint-config" -> null

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
config: fixed diff when `artifacts_gcs_bucket` is not specified on `google_config_deployment`
```
