### PR TITLE
Fix server generated batch_id in google_dataproc_batch

### DIFF
--- a/mmv1/products/dataproc/Batch.yaml
+++ b/mmv1/products/dataproc/Batch.yaml
@@ -37,6 +37,8 @@ timeouts:
 async:
   operation:
     base_url: '{{op_id}}'
+  result:
+    resource_inside_response: true
 autogen_async: true
 include_in_tgc_next: true
 custom_code:
@@ -137,14 +139,15 @@ parameters:
       The location in which the batch will be created in.
     immutable: true
     url_param_only: true
+properties:
   - name: batchId
     type: String
     description: |
       The ID to use for the batch, which will become the final component of the batch's resource name.
       This value must be 4-63 characters. Valid characters are /[a-z][0-9]-/.
     immutable: true
-    url_param_only: true
-properties:
+    default_from_api: true
+    custom_flatten: templates/terraform/custom_flatten/id_from_name.tmpl
   - name: name
     type: String
     description: |

--- a/mmv1/templates/terraform/samples/services/dataproc/dataproc_batch_spark.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dataproc/dataproc_batch_spark.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_dataproc_batch" "{{$.PrimaryResourceId}}" {
-
-    batch_id      = "tf-test-batch%{random_suffix}"
     location      = "us-central1"
     labels        = {"batch_test": "terraform"}
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
dataproc: fixed server-generated batch_id resolution for google_dataproc_batch when batch_id is omitted
```
