### PR TITLE
mark plaintext credential fields as sensitive across resources

### DIFF
--- a/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
+++ b/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
@@ -126,6 +126,7 @@ properties:
     description: |
       Immutable. API Key that will be attached to webhook. Once this field has been set, it cannot be changed.
       Changing this field will result in deleting/ recreating the resource.
+    sensitive: true
     immutable: true
   - name: connectedRepositories
     type: Array

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -524,10 +524,12 @@ properties:
             type: String
             description: |
               Password of the user.
+            sensitive: true
           - name: securityToken
             type: String
             description: |
               Security token of the user.
+            sensitive: true
           - name: secretManagerStoredPassword
             type: String
             description: |
@@ -552,6 +554,7 @@ properties:
             type: String
             description: |
               Client secret to use for authentication.
+            sensitive: true
           - name: secretManagerStoredClientSecret
             type: String
             description: |

--- a/mmv1/products/developerconnect/AccountConnector.yaml
+++ b/mmv1/products/developerconnect/AccountConnector.yaml
@@ -118,6 +118,7 @@ properties:
           Input only. The client secret of the OAuth application.
           It will be provided as plain text, but encrypted and stored in developer
           connect. As INPUT_ONLY field, it will not be included in the output.
+        sensitive: true
       - name: hostUri
         type: String
         required: true

--- a/mmv1/products/dialogflow/Environment.yaml
+++ b/mmv1/products/dialogflow/Environment.yaml
@@ -183,6 +183,7 @@ properties:
             type: String
             description: |
               The password for HTTP Basic authentication.
+            sensitive: true
           - name: requestHeaders
             type: KeyValuePairs
             description: |

--- a/mmv1/products/dialogflow/Fulfillment.yaml
+++ b/mmv1/products/dialogflow/Fulfillment.yaml
@@ -98,6 +98,7 @@ properties:
         type: String
         description: |
           The password for HTTP Basic authentication.
+        sensitive: true
       - name: requestHeaders
         type: KeyValuePairs
         description: |

--- a/mmv1/products/dialogflowcx/Webhook.yaml
+++ b/mmv1/products/dialogflowcx/Webhook.yaml
@@ -156,6 +156,7 @@ properties:
               The client secret provided by the 3rd party platform.  If the
               `secret_version_for_client_secret` field is set, this field will be
               ignored.
+            sensitive: true
             ignore_read: true
           - name: scopes
             type: Array
@@ -307,6 +308,7 @@ properties:
                   The client secret provided by the 3rd party platform.  If the
                   `secret_version_for_client_secret` field is set, this field will be
                   ignored.
+                sensitive: true
                 ignore_read: true
               - name: scopes
                 type: Array

--- a/mmv1/products/identityplatform/DefaultSupportedIdpConfig.yaml
+++ b/mmv1/products/identityplatform/DefaultSupportedIdpConfig.yaml
@@ -84,6 +84,7 @@ properties:
     type: String
     description: |
       OAuth client secret
+    sensitive: true
     required: true
   - name: enabled
     type: Boolean

--- a/mmv1/products/identityplatform/OauthIdpConfig.yaml
+++ b/mmv1/products/identityplatform/OauthIdpConfig.yaml
@@ -75,6 +75,7 @@ properties:
     type: String
     description: |
       The client secret of the OAuth client, to enable OIDC code flow.
+    sensitive: true
   - name: responseType
     type: NestedObject
     description: |

--- a/mmv1/products/identityplatform/TenantDefaultSupportedIdpConfig.yaml
+++ b/mmv1/products/identityplatform/TenantDefaultSupportedIdpConfig.yaml
@@ -89,6 +89,7 @@ properties:
     type: String
     description: |
       OAuth client secret
+    sensitive: true
     required: true
   - name: enabled
     type: Boolean

--- a/mmv1/products/identityplatform/TenantOauthIdpConfig.yaml
+++ b/mmv1/products/identityplatform/TenantOauthIdpConfig.yaml
@@ -79,3 +79,4 @@ properties:
     type: String
     description: |
       The client secret of the OAuth client, to enable OIDC code flow.
+    sensitive: true

--- a/mmv1/products/integrations/AuthConfig.yaml
+++ b/mmv1/products/integrations/AuthConfig.yaml
@@ -290,6 +290,7 @@ properties:
             type: String
             description: |
               Password to be used.
+            sensitive: true
       - name: oauth2AuthorizationCode
         type: NestedObject
         description: |
@@ -310,6 +311,7 @@ properties:
             type: String
             description: |
               The client's secret.
+            sensitive: true
           - name: scope
             type: String
             description: |
@@ -342,6 +344,7 @@ properties:
             type: String
             description: |
               The client's secret.
+            sensitive: true
           - name: tokenEndpoint
             type: String
             description: |
@@ -429,10 +432,12 @@ properties:
             type: String
             description: |
               User's pre-shared secret to sign the token.
+            sensitive: true
           - name: jwt
             type: String
             description: |
               The token calculated by the header, payload and signature.
+            sensitive: true
             output: true
       - name: authToken
         type: NestedObject
@@ -454,6 +459,7 @@ properties:
             type: String
             description: |
               The token for the auth type.
+            sensitive: true
       - name: serviceAccountCredentials
         type: NestedObject
         description: |
@@ -498,6 +504,7 @@ properties:
             type: String
             description: |
               ID token obtained for the service account.
+            sensitive: true
             output: true
           - name: tokenExpireTime
             type: String
@@ -521,9 +528,11 @@ properties:
         type: String
         description: |
           The ssl certificate encoded in PEM format. This string must include the begin header and end footer lines.
+        sensitive: true
         required: true
       - name: passphrase
         type: String
         description: |
           'passphrase' should be left unset if private key is not encrypted.
           Note that 'passphrase' is not the password for web server, but an extra layer of security to protected private key.
+        sensitive: true

--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -450,6 +450,7 @@ properties:
         type: String
         description: |
           The client secret for the Oauth config.
+        sensitive: true
         required: true
   # Oauth Object - End
   # Periodic Export Config Object

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_pkcs12.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_pkcs12.go
@@ -155,6 +155,7 @@ Flag is set to Yes if the certificate is valid, No if expired, or Not yet if not
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
+				Sensitive:   true,
 				Description: `Password for the Private Key if it's encrypted`,
 			},
 			"type": {

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_nsx_credentials.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_nsx_credentials.go
@@ -29,6 +29,7 @@ For example: projects/my-project/locations/us-west1-a/privateClouds/my-cloud`,
 			"password": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: `Initial password.`,
 			},
 		},

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_vcenter_credentials.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_vcenter_credentials.go
@@ -30,6 +30,7 @@ For example: projects/my-project/locations/us-west1-a/privateClouds/my-cloud`,
 			"password": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: `Initial password.`,
 			},
 		},


### PR DESCRIPTION
Repro: `terraform plan` on any of the touched resources with a literal secret, for example `google_identity_platform_oauth_idp_config` with `client_secret = "..."`; the plan prints the literal, and so do `terraform show` and any CI log that captures the run.
Cause: these fields carry plaintext credentials (passwords, OAuth client secrets, a Salesforce security token, bearer and JWT tokens, a PKCS12 passphrase, an encrypted private key) but the schema never marks them sensitive; the sibling Datastream profiles already flag their `password`, so the Salesforce profile was simply missed, and the remaining fields have the same shape.
Fix: `sensitive: true` on each field in the product YAML and `Sensitive: true` on the three handwritten schemas; with the patched provider the same plan renders `(sensitive value)` for every one of them, and apply and state behavior are unchanged.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
datastream: marked `salesforce_profile.user_credentials.password`, `salesforce_profile.user_credentials.security_token` and `salesforce_profile.oauth2_client_credentials.client_secret` as sensitive in `google_datastream_connection_profile` (beta)
```

```release-note:bug
looker: marked `oauth_config.client_secret` as sensitive in `google_looker_instance`
```

```release-note:bug
developerconnect: marked `custom_oauth_config.client_secret` as sensitive in `google_developer_connect_account_connector`
```

```release-note:bug
identityplatform: marked `client_secret` as sensitive in `google_identity_platform_default_supported_idp_config`, `google_identity_platform_oauth_idp_config`, `google_identity_platform_tenant_default_supported_idp_config` and `google_identity_platform_tenant_oauth_idp_config`
```

```release-note:bug
dialogflow: marked `generic_web_service.password` as sensitive in `google_dialogflow_fulfillment` and `fulfillment.generic_web_service.password` as sensitive in `google_dialogflow_environment`
```

```release-note:bug
dialogflowcx: marked `generic_web_service.oauth_config.client_secret` and `service_directory.generic_web_service.oauth_config.client_secret` as sensitive in `google_dialogflow_cx_webhook`
```

```release-note:bug
integrations: marked the credential fields under `decrypted_credential` and `client_certificate` as sensitive in `google_integrations_auth_config`
```

```release-note:bug
cloudbuild: marked `api_key` as sensitive in `google_cloudbuild_bitbucket_server_config`
```

```release-note:bug
vmwareengine: marked `password` as sensitive in the `google_vmwareengine_nsx_credentials` and `google_vmwareengine_vcenter_credentials` data sources
```

```release-note:bug
apigee: marked `password` as sensitive in `google_apigee_keystores_aliases_pkcs12`
```
