### PR TITLE
bigquerydatatransfer: add output fields to DataSourceEnrollment

### DIFF
--- a/mmv1/products/bigquerydatatransfer/DataSourceEnrollment.yaml
+++ b/mmv1/products/bigquerydatatransfer/DataSourceEnrollment.yaml
@@ -90,9 +90,194 @@ parameters:
       this only exists because the API offers no project-level unenroll method. Override it only if
       `us` is not routable for the project, for example under a data-residency organization policy.
 properties:
+  - name: 'name'
+    type: String
+    output: true
+    description: |
+      The resource name of the data source.
   - name: 'displayName'
     type: String
     output: true
     description: |
       User friendly name of the enrolled data source, for example
       `Google Cloud Carbon Footprint Exports`.
+  - name: 'description'
+    type: String
+    output: true
+    description: |
+      User friendly data source description string.
+  - name: 'clientId'
+    type: String
+    output: true
+    description: |
+      Data source client id which should be used to receive refresh token.
+  - name: 'scopes'
+    type: Array
+    output: true
+    item_type:
+      type: String
+    description: |
+      Api auth scopes for which refresh token needs to be obtained.
+  - name: 'updateDeadlineSeconds'
+    type: Integer
+    output: true
+    description: |
+      The number of seconds to wait for a transfer to start before declaring the failure.
+  - name: 'defaultSchedule'
+    type: String
+    output: true
+    description: |
+      Default data transfer schedule.
+  - name: 'supportsCustomSchedule'
+    type: Boolean
+    output: true
+    description: |
+      Specifies whether the data source supports a user defined schedule.
+  - name: 'parameters'
+    type: Array
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'paramId'
+          type: String
+          output: true
+          description: |
+            Parameter identifier.
+        - name: 'displayName'
+          type: String
+          output: true
+          description: |
+            User friendly parameter name.
+        - name: 'description'
+          type: String
+          output: true
+          description: |
+            Parameter description.
+        - name: 'type'
+          type: String
+          output: true
+          description: |
+            Parameter type.
+        - name: 'required'
+          type: Boolean
+          output: true
+          description: |
+            Is parameter required.
+        - name: 'repeated'
+          type: Boolean
+          output: true
+          description: |
+            Is parameter repeated.
+        - name: 'validationRegex'
+          type: String
+          output: true
+          description: |
+            Regular expression which can be used for parameter validation.
+        - name: 'allowedValues'
+          type: Array
+          output: true
+          item_type:
+            type: String
+          description: |
+            All possible values for parameters with fixed list of options.
+        - name: 'minValue'
+          type: Double
+          output: true
+          description: |
+            For integer and double values specifies minimum allowed value.
+        - name: 'maxValue'
+          type: Double
+          output: true
+          description: |
+            For integer and double values specifies maximum allowed value.
+        - name: 'fields'
+          type: Array
+          output: true
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'paramId'
+                type: String
+                output: true
+                description: |
+                  Parameter identifier.
+              - name: 'displayName'
+                type: String
+                output: true
+                description: |
+                  User friendly parameter name.
+              - name: 'description'
+                type: String
+                output: true
+                description: |
+                  Parameter description.
+              - name: 'type'
+                type: String
+                output: true
+                description: |
+                  Parameter type.
+          description: |
+            Deprecated. This field has no effect.
+        - name: 'validationDescription'
+          type: String
+          output: true
+          description: |
+            Description of the requirements for this field, in case the user input does not fulfill the regex.
+        - name: 'validationHelpUrl'
+          type: String
+          output: true
+          description: |
+            URL to a help document to further explain the naming requirements.
+        - name: 'immutable'
+          type: Boolean
+          output: true
+          description: |
+            Cannot be changed after initial transfer config creation. Applies only to custom data sources.
+        - name: 'recurse'
+          type: Boolean
+          output: true
+          description: |
+            Deprecated. This field has no effect.
+        - name: 'deprecated'
+          type: Boolean
+          output: true
+          description: |
+            If true, it should not be used in new transfers, and it should not be visible to users.
+        - name: 'maxListSize'
+          type: Integer
+          output: true
+          description: |
+            Deprecated. This field has no effect.
+    description: |
+      Data source parameters.
+  - name: 'helpUrl'
+    type: String
+    output: true
+    description: |
+      Url to the documentation about the data source.
+  - name: 'authorizationType'
+    type: String
+    output: true
+    description: |
+      Indicates the type of authorization.
+  - name: 'dataRefreshType'
+    type: String
+    output: true
+    description: |
+      Data refresh type.
+  - name: 'defaultDataRefreshWindowDays'
+    type: Integer
+    output: true
+    description: |
+      Default data refresh window on days.
+  - name: 'manualRunsDisabled'
+    type: Boolean
+    output: true
+    description: |
+      Disables support for manual transfer runs.
+  - name: 'minimumScheduleInterval'
+    type: String
+    output: true
+    description: |
+      The minimum interval between two scheduled runs.

--- a/mmv1/products/bigquerydatatransfer/DataSourceEnrollment.yaml
+++ b/mmv1/products/bigquerydatatransfer/DataSourceEnrollment.yaml
@@ -164,11 +164,6 @@ properties:
           output: true
           description: |
             Is parameter required.
-        - name: 'repeated'
-          type: Boolean
-          output: true
-          description: |
-            Is parameter repeated.
         - name: 'validationRegex'
           type: String
           output: true
@@ -191,34 +186,6 @@ properties:
           output: true
           description: |
             For integer and double values specifies maximum allowed value.
-        - name: 'fields'
-          type: Array
-          output: true
-          item_type:
-            type: NestedObject
-            properties:
-              - name: 'paramId'
-                type: String
-                output: true
-                description: |
-                  Parameter identifier.
-              - name: 'displayName'
-                type: String
-                output: true
-                description: |
-                  User friendly parameter name.
-              - name: 'description'
-                type: String
-                output: true
-                description: |
-                  Parameter description.
-              - name: 'type'
-                type: String
-                output: true
-                description: |
-                  Parameter type.
-          description: |
-            Deprecated. This field has no effect.
         - name: 'validationDescription'
           type: String
           output: true
@@ -234,21 +201,11 @@ properties:
           output: true
           description: |
             Cannot be changed after initial transfer config creation. Applies only to custom data sources.
-        - name: 'recurse'
-          type: Boolean
-          output: true
-          description: |
-            Deprecated. This field has no effect.
         - name: 'deprecated'
           type: Boolean
           output: true
           description: |
             If true, it should not be used in new transfers, and it should not be visible to users.
-        - name: 'maxListSize'
-          type: Integer
-          output: true
-          description: |
-            Deprecated. This field has no effect.
     description: |
       Data source parameters.
   - name: 'helpUrl'

--- a/mmv1/products/bigquerydatatransfer/DataSourceEnrollment.yaml
+++ b/mmv1/products/bigquerydatatransfer/DataSourceEnrollment.yaml
@@ -206,6 +206,11 @@ properties:
           output: true
           description: |
             If true, it should not be used in new transfers, and it should not be visible to users.
+        - name: 'maxListSize'
+          type: Integer
+          output: true
+          description: |
+            For list parameters, the max size of the list.
     description: |
       Data source parameters.
   - name: 'helpUrl'

--- a/mmv1/third_party/terraform/services/bigquerydatatransfer/resource_bigquery_data_transfer_data_source_enrollment_test.go
+++ b/mmv1/third_party/terraform/services/bigquerydatatransfer/resource_bigquery_data_transfer_data_source_enrollment_test.go
@@ -1,0 +1,54 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bigquerydatatransfer_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccBigqueryDataTransferDataSourceEnrollment_attributes(t *testing.T) {
+	context := map[string]interface{}{
+		"project": envvar.GetTestProjectFromEnv(),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigqueryDataTransferDataSourceEnrollmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryDataTransferDataSourceEnrollment_attributes(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_bigquery_data_transfer_data_source_enrollment.carbon", "data_source_id", "61cede5a-0000-2440-ad42-883d24f8f7b8"),
+					resource.TestCheckResourceAttr("google_bigquery_data_transfer_data_source_enrollment.carbon", "unenroll_location", "us"),
+					resource.TestCheckResourceAttr("google_bigquery_data_transfer_data_source_enrollment.carbon", "display_name", "Google Cloud Carbon Footprint Exports"),
+					resource.TestCheckResourceAttr("google_bigquery_data_transfer_data_source_enrollment.carbon", "authorization_type", "FIRST_PARTY_OAUTH"),
+					resource.TestCheckResourceAttr("google_bigquery_data_transfer_data_source_enrollment.carbon", "scopes.#", "1"),
+					resource.TestCheckResourceAttr("google_bigquery_data_transfer_data_source_enrollment.carbon", "update_deadline_seconds", "259200"),
+					resource.TestCheckResourceAttr("google_bigquery_data_transfer_data_source_enrollment.carbon", "default_schedule", "15 of month 00:00"),
+					resource.TestCheckResourceAttr("google_bigquery_data_transfer_data_source_enrollment.carbon", "parameters.#", "1"),
+					resource.TestCheckResourceAttr("google_bigquery_data_transfer_data_source_enrollment.carbon", "parameters.0.param_id", "billing_accounts"),
+					resource.TestCheckResourceAttr("google_bigquery_data_transfer_data_source_enrollment.carbon", "parameters.0.display_name", "billing_accounts"),
+					resource.TestCheckResourceAttrSet("google_bigquery_data_transfer_data_source_enrollment.carbon", "name"),
+					resource.TestCheckResourceAttrSet("google_bigquery_data_transfer_data_source_enrollment.carbon", "description"),
+					resource.TestCheckResourceAttrSet("google_bigquery_data_transfer_data_source_enrollment.carbon", "client_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBigqueryDataTransferDataSourceEnrollment_attributes(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_data_transfer_data_source_enrollment" "carbon" {
+  project           = "%{project}"
+  data_source_id    = "61cede5a-0000-2440-ad42-883d24f8f7b8"
+  unenroll_location = "us"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/bigquerydatatransfer/resource_bigquery_data_transfer_data_source_enrollment_test.go
+++ b/mmv1/third_party/terraform/services/bigquerydatatransfer/resource_bigquery_data_transfer_data_source_enrollment_test.go
@@ -12,8 +12,11 @@ import (
 )
 
 func TestAccBigqueryDataTransferDataSourceEnrollment_attributes(t *testing.T) {
+	t.Parallel()
+
 	context := map[string]interface{}{
-		"project": envvar.GetTestProjectFromEnv(),
+		"project":       envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{


### PR DESCRIPTION
Adds missing output fields (`name`, `description`, `client_id`, `scopes`, `update_deadline_seconds`, `default_schedule`, `supports_custom_schedule`, `parameters`, `help_url`, `authorization_type`, `data_refresh_type`, `default_data_refresh_window_days`, `manual_runs_disabled`, and `minimum_schedule_interval`) to `google_bigquery_data_transfer_data_source_enrollment` and adds acceptance test verification.

```release-note:enhancement
bigquerydatatransfer: added output fields to `google_bigquery_data_transfer_data_source_enrollment`
```
