### PR TITLE
agenticapplications: add methodology_export_options to persona

### DIFF
--- a/mmv1/products/agenticapplications/AnalystAgentPersona.yaml
+++ b/mmv1/products/agenticapplications/AnalystAgentPersona.yaml
@@ -72,6 +72,15 @@ samples:
           dataset_id: dataset_id
           table_id: table
           bucket_name: bucket
+  - name: analyst_agent_persona_methodology_export_options
+    primary_resource_id: example
+    steps:
+      - name: analyst_agent_persona_methodology_export_options
+        resource_id_vars:
+          persona_id: methodology
+      - name: analyst_agent_persona_methodology_export_options_update
+        resource_id_vars:
+          persona_id: methodology
 
 parameters:
   - name: location
@@ -338,6 +347,24 @@ properties:
               PDF
               DOCX
               GOOGLE_DOCS
+      - name: methodologyExportOptions
+        type: NestedObject
+        description: Options for methodology export.
+        properties:
+          - name: appendMethodology
+            type: Boolean
+            description: If true, append the detailed methodology to the final response.
+          - name: exportFormat
+            type: String
+            description: |-
+              Format for methodology export.
+              Possible values:
+              MARKDOWN
+              HTML
+              PDF
+          - name: exportMethodologyArtifact
+            type: Boolean
+            description: If true, export the detailed methodology as a separate artifact.
       - name: slideGenerationOptions
         type: NestedObject
         description: Options for slide generation.

--- a/mmv1/templates/terraform/samples/services/agenticapplications/analyst_agent_persona_methodology_export_options.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/agenticapplications/analyst_agent_persona_methodology_export_options.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_agentic_applications_analyst_agent_persona" "{{$.PrimaryResourceId}}" {
+  location                 = "us"
+  analyst_agent_persona_id = "{{index $.ResourceIdVars "persona_id"}}"
+  display_name             = "Test Analyst Persona Methodology Export"
+  display_description      = "Sample analyst agent persona description"
+  model_description        = "Sample model description"
+  role                     = "ANALYST_ROLE_GENERIC_FINANCE_ANALYST"
+
+  artifacts_config {
+    methodology_export_options {
+      append_methodology          = true
+      export_format               = "MARKDOWN"
+      export_methodology_artifact = true
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/agenticapplications/analyst_agent_persona_methodology_export_options_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/agenticapplications/analyst_agent_persona_methodology_export_options_update.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_agentic_applications_analyst_agent_persona" "{{$.PrimaryResourceId}}" {
+  location                 = "us"
+  analyst_agent_persona_id = "{{index $.ResourceIdVars "persona_id"}}"
+  display_name             = "Test Analyst Persona Methodology Export Updated"
+  display_description      = "Updated analyst agent persona description"
+  model_description        = "Updated model description"
+  role                     = "ANALYST_ROLE_GENERIC_FINANCE_ANALYST"
+
+  artifacts_config {
+    methodology_export_options {
+      append_methodology          = false
+      export_format               = "HTML"
+      export_methodology_artifact = false
+    }
+  }
+}


### PR DESCRIPTION
Added field coverage for `artifactsConfig.methodologyExportOptions` (`appendMethodology`, `exportFormat`, `exportMethodologyArtifact`) on `google_agentic_applications_analyst_agent_persona` (`agenticapplications:v1:AnalystAgentPersona`).

reference: b/558523030

```release-note:enhancement
agenticapplications: added `artifacts_config.methodology_export_options` field to `google_agentic_applications_analyst_agent_persona`
```
