### PR TITLE
Fixed escaped dot in serviceusagev2 consumer policy service regex

### DIFF
--- a/mmv1/templates/terraform/constants/serviceusagev2_consumer_policy.go.tmpl
+++ b/mmv1/templates/terraform/constants/serviceusagev2_consumer_policy.go.tmpl
@@ -62,7 +62,7 @@ type AnalysisResponse struct {
 	Analysis []AnalysisReportDetails
 }
 
-var servicesRegexp = regexp.MustCompile(`([^(\s|,)]+\.googleapis.com)`)
+var servicesRegexp = regexp.MustCompile(`([^(\s|,)]+\.googleapis\.com)`)
 
 func parseObject(obj any, resp interface{}) error {
 	b, err := json.Marshal(obj)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixed escaped dot in serviceusagev2 consumer policy service regex
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
