### PR TITLE
Retarget TestAccLustreInstance_withMaintenancePolicy to us-central1-c to mitigate stockouts

### DIFF
--- a/mmv1/third_party/terraform/services/lustre/resource_lustre_instance_test.go
+++ b/mmv1/third_party/terraform/services/lustre/resource_lustre_instance_test.go
@@ -51,7 +51,7 @@ func testAccLustreInstance_withMaintenancePolicy(context map[string]interface{})
 	return acctest.Nprintf(`
 resource "google_lustre_instance" "instance" {
   instance_id                 = "tf-test-my-instance%{random_suffix}"
-  location                    = "us-central1-a"
+  location                    = "us-central1-c"
   filesystem                  = "testfs"
   network                     = data.google_compute_network.lustre-network.id
   gke_support_enabled         = false


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Update `TestAccLustreInstance_withMaintenancePolicy` in `resource_lustre_instance_test.go` to target `us-central1-c` instead of `us-central1-a` to alleviate recurring resource exhaustion stockouts in `us-central1-a`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/29117

Reference: b/554298111

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
Retarget TestAccLustreInstance_withMaintenancePolicy to us-central1-c to mitigate stockouts
```
