### PR TITLE
workstations: add creator policy admin setting

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -64,6 +64,21 @@ samples:
           key_short_name: '"tf-test-key-" + acctest.RandString(t, 10)'
           value_short_name: '"tf-test-value-" + acctest.RandString(t, 10)'
           org_id: envvar.GetTestOrgFromEnv(t)
+  - name: workstation_config_grant_workstation_admin_role_on_create
+    primary_resource_id: default
+    steps:
+      - name: workstation_config_grant_workstation_admin_role_on_create
+        resource_id_vars:
+          workstation_cluster_name: workstation-cluster
+          workstation_config_name: workstation-config
+        vars:
+          grant_workstation_admin_role_on_create: 'false'
+      - name: workstation_config_grant_workstation_admin_role_on_create_update
+        resource_id_vars:
+          workstation_cluster_name: workstation-cluster
+          workstation_config_name: workstation-config
+        vars:
+          grant_workstation_admin_role_on_create: 'true'
   - name: workstation_config_container
     primary_resource_id: default
     steps:
@@ -639,6 +654,10 @@ properties:
     type: Boolean
     description: |
       Disables support for plain TCP connections in the workstation. By default the service supports TCP connections via a websocket relay. Setting this option to true disables that relay, which prevents the usage of services that require plain tcp connections, such as ssh. When enabled, all communication must occur over https or wss.
+  - name: grantWorkstationAdminRoleOnCreate
+    type: Boolean
+    description: |
+      Whether to grant the creator of a workstation the `roles/workstations.policyAdmin` role in addition to the default `roles/workstations.user` role on the workstation they create. This allows workstation users to share access to either their entire workstation or individual ports. Defaults to false.
   - name: maxUsableWorkstations
     type: Integer
     description: |

--- a/mmv1/templates/terraform/samples/services/workstations/workstation_config_grant_workstation_admin_role_on_create.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/workstations/workstation_config_grant_workstation_admin_role_on_create.tf.tmpl
@@ -1,0 +1,32 @@
+resource "google_compute_network" "default" {
+  name                    = "{{index $.ResourceIdVars "workstation_cluster_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "{{index $.ResourceIdVars "workstation_cluster_name"}}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "{{$.PrimaryResourceId}}" {
+  workstation_cluster_id = "{{index $.ResourceIdVars "workstation_cluster_name"}}"
+  network                = google_compute_network.default.id
+  subnetwork             = google_compute_subnetwork.default.id
+  location               = "us-central1"
+}
+
+resource "google_workstations_workstation_config" "{{$.PrimaryResourceId}}" {
+  workstation_config_id  = "{{index $.ResourceIdVars "workstation_config_name"}}"
+  workstation_cluster_id = google_workstations_workstation_cluster.{{$.PrimaryResourceId}}.workstation_cluster_id
+  location               = "us-central1"
+
+  grant_workstation_admin_role_on_create = {{index $.Vars "grant_workstation_admin_role_on_create"}}
+
+  host {
+    gce_instance {
+      machine_type = "e2-standard-4"
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/workstations/workstation_config_grant_workstation_admin_role_on_create_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/workstations/workstation_config_grant_workstation_admin_role_on_create_update.tf.tmpl
@@ -1,0 +1,32 @@
+resource "google_compute_network" "default" {
+  name                    = "{{index $.ResourceIdVars "workstation_cluster_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "{{index $.ResourceIdVars "workstation_cluster_name"}}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "{{$.PrimaryResourceId}}" {
+  workstation_cluster_id = "{{index $.ResourceIdVars "workstation_cluster_name"}}"
+  network                = google_compute_network.default.id
+  subnetwork             = google_compute_subnetwork.default.id
+  location               = "us-central1"
+}
+
+resource "google_workstations_workstation_config" "{{$.PrimaryResourceId}}" {
+  workstation_config_id  = "{{index $.ResourceIdVars "workstation_config_name"}}"
+  workstation_cluster_id = google_workstations_workstation_cluster.{{$.PrimaryResourceId}}.workstation_cluster_id
+  location               = "us-central1"
+
+  grant_workstation_admin_role_on_create = {{index $.Vars "grant_workstation_admin_role_on_create"}}
+
+  host {
+    gce_instance {
+      machine_type = "e2-standard-4"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Expose `grant_workstation_admin_role_on_create` on `google_workstations_workstation_config` for both the GA and beta providers. Add create-to-update sample coverage so generated acceptance tests verify the field can be changed in place.

## Tests

- `make test`
- targeted GA WorkstationConfig generation
- targeted beta WorkstationConfig generation
- verified both generated providers contain the schema field and generated update test

```release-note:enhancement
workstations: added `grant_workstation_admin_role_on_create` field to `google_workstations_workstation_config` resource
```