### PR TITLE
add google_vertex_ai_publisher_model_config resource

### DIFF
--- a/mmv1/products/vertexai/PublisherModelConfig.yaml
+++ b/mmv1/products/vertexai/PublisherModelConfig.yaml
@@ -1,0 +1,167 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'PublisherModelConfig'
+description: |
+  Configs of a publisher model.
+references:
+  guides:
+    'Log and share requests and responses': 'https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/request-response-logging'
+  api: 'https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1beta1/projects.locations.endpoints#PublisherModelConfig'
+min_version: beta
+
+base_url: 'projects/{{project}}/locations/{{location}}/publishers/{{publisher}}/models/{{model}}'
+self_link: 'projects/{{project}}/locations/{{location}}/publishers/{{publisher}}/models/{{model}}'
+
+immutable: false
+
+create_url: 'projects/{{project}}/locations/{{location}}/publishers/{{publisher}}/models/{{model}}:setPublisherModelConfig'
+update_url: 'projects/{{project}}/locations/{{location}}/publishers/{{publisher}}/models/{{model}}:setPublisherModelConfig'
+update_verb: 'POST'
+read_query_params: ':fetchPublisherModelConfig'
+id_format: 'projects/{{project}}/locations/{{location}}/publishers/{{publisher}}/models/{{model}}/publisherModelConfig'
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/publishers/{{publisher}}/models/{{model}}/publisherModelConfig'
+
+async:
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: true
+
+parameters:
+  - name: 'location'
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The model's location.
+  - name: 'publisher'
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The model provider's name.
+  - name: 'model'
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The model's name.
+
+properties:
+  - name: 'loggingConfig'
+    type: NestedObject
+    description: |
+      The prediction request/response logging config.
+    properties:
+    - name: 'enabled'
+      type: Boolean
+      description: |
+        If logging is enabled or not.
+    - name: 'samplingRate'
+      type: Double
+      description: |
+        Percentage of requests to be logged, expressed as a fraction in range(0,1].
+    - name: 'errorSamplingRate'
+      type: Double
+      description: |
+        Percentage of failed requests to be logged, expressed as a fraction in range [0,1].
+        Only non-transient errors will be logged (currently `500/Internal errors`).
+    - name: 'bigqueryDestination'
+      type: NestedObject
+      description: |
+        BigQuery table for logging.
+      properties:
+        - name: 'outputUri'
+          type: String
+          required: true
+          description: |
+            BigQuery URI to a project or table, up to 2000 characters long.
+            If only given a project, a new dataset will be created with name `publishers_<publisher>_models_<model>`
+            where will be made BigQuery-dataset-name compatible (e.g. most special characters will become underscores).
+            If no table name is given, a new table will be created with name `request_response_logging`.
+            When the full table reference is specified, the dataset must exist and table must not exist.
+            If the endpoint is global, the dataset have to be specified.
+            Accepted forms: BigQuery path. For example: `bq://projectId`, `bq://projectId.bqDatasetId` or `bq://projectId.bqDatasetId.bqTableId`.
+          diff_suppress_func: vertexAIPublisherModelConfigBigqueryDestinationoutputUriDiffSuppress
+    - name: 'requestResponseLoggingSchemaVersion'
+      type: String
+      output: true
+      description: |
+        The schema version used in creating the BigQuery table for the request response logging.
+        The versions are "v1" and "v2". The current default version is "v1".
+    - name: 'enableOtelLogging'
+      type: Boolean
+      description: |
+        This field is used for large models. If true, in addition to the original large model logs,
+        logs will be converted in OTel schema format, and saved in otel_log column. Default value is false.
+  - name: 'dataSharingEnabledProvider'
+    type: Enum
+    custom_flatten: templates/terraform/custom_flatten/default_if_empty.tmpl
+    default_value: MODEL_PROVIDER_UNSPECIFIED
+    enum_values:
+      - MODEL_PROVIDER_UNSPECIFIED
+      - ANTHROPIC
+    description: |
+      The model provider (publisher) for which the customer has enabled data sharing.
+      For publisher models that are configured to require data sharing, a prediction request is only allowed when the model's publisher matches this provider.
+      Otherwise, the request is rejected.
+custom_code:
+  pre_create: templates/terraform/custom_code/vertex_ai_modify_rep_url.go.tmpl
+  pre_read:   templates/terraform/custom_code/vertex_ai_modify_rep_url.go.tmpl
+  pre_update: templates/terraform/custom_code/vertex_ai_modify_rep_url.go.tmpl
+  encoder:    templates/terraform/encoders/vertex_ai_publisher_model_config.go.tmpl
+  constants:  templates/terraform/constants/vertex_ai_publisher_model_config.go.tmpl
+
+exclude_delete: true
+deletion_policy_exclude: true
+
+samples:
+  - name: publisher_model_config_regional_endpoint
+    primary_resource_id: claude_us
+    min_version: beta
+    steps:
+      - name: vertex_ai_publisher_model_config_rep
+        vars:
+          dataSharingProvider: ANTHROPIC
+      - name: vertex_ai_publisher_model_config_rep
+        vars:
+          dataSharingProvider: MODEL_PROVIDER_UNSPECIFIED
+        include_step_doc: false
+  - name: publisher_model_config_update
+    primary_resource_id: claude_global
+    min_version: beta
+    steps:
+      - name: vertex_ai_publisher_model_config_global_full
+        resource_id_vars:
+          dataset_name: example_dataset
+          table_name: example_table
+        vars:
+          samplingRate: 0.1
+          errorSamplingRate: 1
+          otelLog: true
+      - name: vertex_ai_publisher_model_config_global_full
+        resource_id_vars:
+          dataset_name: example_dataset
+          table_name: example_table
+        vars:
+          samplingRate: 0.2
+          errorSamplingRate: 0.9
+          otelLog: false
+      - name: vertex_ai_publisher_model_config_global_clear
+        include_step_doc: false

--- a/mmv1/products/vertexai/PublisherModelConfig.yaml
+++ b/mmv1/products/vertexai/PublisherModelConfig.yaml
@@ -69,47 +69,47 @@ properties:
     description: |
       The prediction request/response logging config.
     properties:
-    - name: 'enabled'
-      type: Boolean
-      description: |
-        If logging is enabled or not.
-    - name: 'samplingRate'
-      type: Double
-      description: |
-        Percentage of requests to be logged, expressed as a fraction in range(0,1].
-    - name: 'errorSamplingRate'
-      type: Double
-      description: |
-        Percentage of failed requests to be logged, expressed as a fraction in range [0,1].
-        Only non-transient errors will be logged (currently `500/Internal errors`).
-    - name: 'bigqueryDestination'
-      type: NestedObject
-      description: |
-        BigQuery table for logging.
-      properties:
-        - name: 'outputUri'
-          type: String
-          required: true
-          description: |
-            BigQuery URI to a project or table, up to 2000 characters long.
-            If only given a project, a new dataset will be created with name `publishers_<publisher>_models_<model>`
-            where will be made BigQuery-dataset-name compatible (e.g. most special characters will become underscores).
-            If no table name is given, a new table will be created with name `request_response_logging`.
-            When the full table reference is specified, the dataset must exist and table must not exist.
-            If the endpoint is global, the dataset have to be specified.
-            Accepted forms: BigQuery path. For example: `bq://projectId`, `bq://projectId.bqDatasetId` or `bq://projectId.bqDatasetId.bqTableId`.
-          diff_suppress_func: vertexAIPublisherModelConfigBigqueryDestinationoutputUriDiffSuppress
-    - name: 'requestResponseLoggingSchemaVersion'
-      type: String
-      output: true
-      description: |
-        The schema version used in creating the BigQuery table for the request response logging.
-        The versions are "v1" and "v2". The current default version is "v1".
-    - name: 'enableOtelLogging'
-      type: Boolean
-      description: |
-        This field is used for large models. If true, in addition to the original large model logs,
-        logs will be converted in OTel schema format, and saved in otel_log column. Default value is false.
+      - name: 'enabled'
+        type: Boolean
+        description: |
+          If logging is enabled or not.
+      - name: 'samplingRate'
+        type: Double
+        description: |
+          Percentage of requests to be logged, expressed as a fraction in range(0,1].
+      - name: 'errorSamplingRate'
+        type: Double
+        description: |
+          Percentage of failed requests to be logged, expressed as a fraction in range [0,1].
+          Only non-transient errors will be logged (currently `500/Internal errors`).
+      - name: 'bigqueryDestination'
+        type: NestedObject
+        description: |
+          BigQuery table for logging.
+        properties:
+          - name: 'outputUri'
+            type: String
+            required: true
+            description: |
+              BigQuery URI to a project or table, up to 2000 characters long.
+              If only given a project, a new dataset will be created with name `publishers_<publisher>_models_<model>`
+              where will be made BigQuery-dataset-name compatible (e.g. most special characters will become underscores).
+              If no table name is given, a new table will be created with name `request_response_logging`.
+              When the full table reference is specified, the dataset must exist and table must not exist.
+              If the endpoint is global, the dataset have to be specified.
+              Accepted forms: BigQuery path. For example: `bq://projectId`, `bq://projectId.bqDatasetId` or `bq://projectId.bqDatasetId.bqTableId`.
+            diff_suppress_func: vertexAIPublisherModelConfigBigqueryDestinationoutputUriDiffSuppress
+      - name: 'requestResponseLoggingSchemaVersion'
+        type: String
+        output: true
+        description: |
+          The schema version used in creating the BigQuery table for the request response logging.
+          The versions are "v1" and "v2". The current default version is "v1".
+      - name: 'enableOtelLogging'
+        type: Boolean
+        description: |
+          This field is used for large models. If true, in addition to the original large model logs,
+          logs will be converted in OTel schema format, and saved in otel_log column. Default value is false.
   - name: 'dataSharingEnabledProvider'
     type: Enum
     custom_flatten: templates/terraform/custom_flatten/default_if_empty.tmpl
@@ -123,10 +123,10 @@ properties:
       Otherwise, the request is rejected.
 custom_code:
   pre_create: templates/terraform/custom_code/vertex_ai_modify_rep_url.go.tmpl
-  pre_read:   templates/terraform/custom_code/vertex_ai_modify_rep_url.go.tmpl
+  pre_read: templates/terraform/custom_code/vertex_ai_modify_rep_url.go.tmpl
   pre_update: templates/terraform/custom_code/vertex_ai_modify_rep_url.go.tmpl
-  encoder:    templates/terraform/encoders/vertex_ai_publisher_model_config.go.tmpl
-  constants:  templates/terraform/constants/vertex_ai_publisher_model_config.go.tmpl
+  encoder: templates/terraform/encoders/vertex_ai_publisher_model_config.go.tmpl
+  constants: templates/terraform/constants/vertex_ai_publisher_model_config.go.tmpl
 
 exclude_delete: true
 deletion_policy_exclude: true

--- a/mmv1/templates/terraform/constants/vertex_ai_publisher_model_config.go.tmpl
+++ b/mmv1/templates/terraform/constants/vertex_ai_publisher_model_config.go.tmpl
@@ -1,0 +1,30 @@
+func vertexAIPublisherModelConfigBigqueryDestinationoutputUriDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	return vertexAIPublisherModelConfigBigqueryDestinationoutputUriDiffSuppressLogic(old, new)
+}
+
+var autoDatasetRe = regexp.MustCompile(`^publishers_[a-z0-9_]+_models_[a-z0-9_]+$`)
+
+const defaultTableId = "request_response_logging"
+
+func vertexAIPublisherModelConfigBigqueryDestinationoutputUriDiffSuppressLogic(old, new string) bool {
+	if old == new {
+		return true
+	}
+
+	o := strings.Split(old, ".")
+	n := strings.Split(new, ".")
+
+	// API always returns bq://project.dataset.table format path
+	if len(o) != 3 || o[2] != defaultTableId || o[0] != n[0] {
+		return false
+	}
+
+	switch len(n) {
+	case 1: // config has bq://project format path: dataset ID matches auto-generated format.
+		return autoDatasetRe.MatchString(o[1])
+	case 2: // config has bq://project.dataset format path: compare dataset ID.
+		return o[1] == n[1]
+	default:
+		return false
+	}
+}

--- a/mmv1/templates/terraform/custom_code/vertex_ai_modify_rep_url.go.tmpl
+++ b/mmv1/templates/terraform/custom_code/vertex_ai_modify_rep_url.go.tmpl
@@ -1,0 +1,31 @@
+if location, ok := d.GetOk("location"); ok {
+	configCopy := *config
+	configCopy.CustomEndpoints = make(map[string]string, len(config.CustomEndpoints)+1)
+	for k, v := range config.CustomEndpoints {
+		configCopy.CustomEndpoints[k] = v
+	}
+
+	re := regexp.MustCompile(`^https://[a-z0-9-]+\-aiplatform\.googleapis\.com`)
+
+	locStr := location.(string)
+	tempUrl := "https://{{`{{region}}`}}-aiplatform.googleapis.com"
+	switch locStr {
+		case "us", "eu":
+			repBaseURL := "https://aiplatform."+locStr+".rep.googleapis.com"
+			url = re.ReplaceAllLiteralString(url, repBaseURL)
+			configCopy.CustomEndpoints[Product.CustomEndpointField] = strings.ReplaceAll(transport_tpg.BaseUrl(Product, config), tempUrl, repBaseURL)
+			log.Printf("[DEBUG] Overriding URL with REP URL: %s", url)
+		case "global":
+			globalBaseURL := "https://aiplatform.googleapis.com"
+			url = re.ReplaceAllLiteralString(url, globalBaseURL)
+			configCopy.CustomEndpoints[Product.CustomEndpointField] = strings.ReplaceAll(transport_tpg.BaseUrl(Product, config), tempUrl, globalBaseURL)
+			log.Printf("[DEBUG] Overriding URL with global URL: %s", url)
+		default:
+			regionalBaseURL := "https://"+locStr+"-aiplatform.googleapis.com"
+			url = re.ReplaceAllLiteralString(url, regionalBaseURL)
+			configCopy.CustomEndpoints[Product.CustomEndpointField] = strings.ReplaceAll(transport_tpg.BaseUrl(Product, config), tempUrl, regionalBaseURL)
+			log.Printf("[DEBUG] Overriding URL with regional URL: %s", url)
+	}
+
+	config = &configCopy
+}

--- a/mmv1/templates/terraform/encoders/vertex_ai_publisher_model_config.go.tmpl
+++ b/mmv1/templates/terraform/encoders/vertex_ai_publisher_model_config.go.tmpl
@@ -1,0 +1,3 @@
+wrapped := make(map[string]interface{})
+wrapped["publisherModelConfig"] = obj
+return wrapped, nil

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_publisher_model_config_global_clear.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_publisher_model_config_global_clear.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_vertex_ai_publisher_model_config" "{{.PrimaryResourceId}}" {
+  provider = google-beta
+
+  location  = "global"
+  publisher = "anthropic"
+  model     = "claude-fable-5-1"
+
+  data_sharing_enabled_provider = "MODEL_PROVIDER_UNSPECIFIED"
+}

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_publisher_model_config_global_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_publisher_model_config_global_full.tf.tmpl
@@ -1,0 +1,34 @@
+resource "google_vertex_ai_publisher_model_config" "{{.PrimaryResourceId}}" {
+  provider = google-beta
+
+  location  = "global"
+  publisher = "anthropic"
+  model     = "claude-fable-5-1"
+
+  logging_config {
+    enabled             = true
+    sampling_rate.      = {{index $.Vars "samplingRate"}}
+    error_sampling_rate = {{index $.Vars "errorSamplingRate"}}
+
+    bigquery_destination {
+      output_uri = "bq://${data.google_project.project.project_id}.${google_bigquery_dataset.{{.PrimaryResourceId}}.dataset_id}"
+    }
+
+    enable_otel_logging = {{index $.Vars "otelLog"}}
+  }
+
+  data_sharing_enabled_provider = "ANTHROPIC"
+}
+
+resource "google_bigquery_dataset" "{{.PrimaryResourceId}}" {
+  provider = google-beta
+
+  dataset_id                 = "{{index $.ResourceIdVars "dataset_name"}}"
+  friendly_name              = "genai_log"
+  location                   = "US"
+  delete_contents_on_destroy = true
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_publisher_model_config_global_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_publisher_model_config_global_full.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_vertex_ai_publisher_model_config" "{{.PrimaryResourceId}}" {
 
   logging_config {
     enabled             = true
-    sampling_rate.      = {{index $.Vars "samplingRate"}}
+    sampling_rate       = {{index $.Vars "samplingRate"}}
     error_sampling_rate = {{index $.Vars "errorSamplingRate"}}
 
     bigquery_destination {

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_publisher_model_config_rep.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_publisher_model_config_rep.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_vertex_ai_publisher_model_config" "{{.PrimaryResourceId}}" {
+  provider = google-beta
+
+  location  = "us"
+  publisher = "anthropic"
+  model     = "claude-fable-5-1"
+
+  data_sharing_enabled_provider = "{{index $.Vars "dataSharingProvider"}}"
+}

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_publisher_model_config_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_publisher_model_config_test.go
@@ -1,0 +1,49 @@
+package vertexai
+
+import (
+	"testing"
+)
+
+func TestVertexAIPublisherModelConfigBigqueryDestinationoutputUriDiffSuppressLogic(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"same full path": {
+			Old:                "bq://project_id.dataset_id.table_id",
+			New:                "bq://project_id.dataset_id.table_id",
+			ExpectDiffSuppress: true,
+		},
+		"different full path": {
+			Old:                "bq://project_id.dataset_id.table_id",
+			New:                "bq://project_id.dataset_id.table_id2",
+			ExpectDiffSuppress: false,
+		},
+		"auto table created": {
+			Old:                "bq://project_id.dataset_id.request_response_logging",
+			New:                "bq://project_id.dataset_id",
+			ExpectDiffSuppress: true,
+		},
+		"manual table id unmatch": {
+			Old:                "bq://project_id.dataset_id.table_id",
+			New:                "bq://project_id.dataset_id",
+			ExpectDiffSuppress: false,
+		},
+		"auto dataset and table created": {
+			Old:                "bq://project_id.publishers_google_models_gemini_3_5_flash_1234567890123456789.request_response_logging",
+			New:                "bq://project_id",
+			ExpectDiffSuppress: true,
+		},
+		"dataset unmatch": {
+			Old:                "bq://project_id.dataset_id.request_response_logging",
+			New:                "bq://project_id",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if vertexAIPublisherModelConfigBigqueryDestinationoutputUriDiffSuppressLogic(tc.Old, tc.New) != tc.ExpectDiffSuppress {
+			t.Errorf("bad: %s, %q => %q expect DiffSuppress to return %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_publisher_model_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_publisher_model_config_test.go.tmpl
@@ -1,5 +1,7 @@
 package vertexai
 
+{{- if ne $.TargetVersionName "ga" }}
+
 import (
 	"testing"
 )
@@ -47,3 +49,5 @@ func TestVertexAIPublisherModelConfigBigqueryDestinationoutputUriDiffSuppressLog
 		}
 	}
 }
+
+{{ end }}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/24092

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_vertex_ai_publisher_model_config`
```

Note: Anthropic Claude models require the manual activation process on the cloud console. I passed the related acceptance tests on the my project.