### PR TITLE
chronicle: add base64_image, dynamic_parameters, instance_uri, and weight to google_chronicle_environment

### DIFF
--- a/mmv1/products/chronicle/Environment.yaml
+++ b/mmv1/products/chronicle/Environment.yaml
@@ -119,3 +119,35 @@ properties:
     required: true
     immutable: true
     description: Environment data retention in months.
+  - name: base64Image
+    type: String
+    description: Environment icon.
+  - name: dynamicParameters
+    type: Array
+    description: Additional custom properties for enriching the environment.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: value
+          type: String
+          required: true
+          description: The value of the dynamic parameter.
+        - name: dynamicParameterId
+          type: Integer
+          required: true
+          description: The ID of the dynamic parameter.
+        - name: environmentId
+          type: Integer
+          output: true
+          description: The ID of the environment.
+  - name: instanceUri
+    type: String
+    description: |-
+      URL of the environment. Used to route UI links to the correct SIEM instance
+      when making cross-SecOps requests from SOAR.
+  - name: weight
+    type: Integer
+    description: |-
+      The weight of the environment, enabling customers to control distribution
+      of resources between the separate environments in a single instance of
+      Chronicle SOAR.

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_environment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_environment_basic.tf.tmpl
@@ -11,5 +11,13 @@ resource "google_chronicle_environment" "{{$.PrimaryResourceId}}" {
   data_access_scopes_json = jsonencode([])
   retention_duration = 3
 
+  base64_image = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABHNCSVQICAgIfAhkiAAAAA1JREFUCJljYPjPUA8AA4EBf4abPZ0AAAAASUVORK5CYII="
+  dynamic_parameters {
+    dynamic_parameter_id = 123
+    value = "value1"
+  }
+  instance_uri = "https://test.backstory.chronicle.security?foo=bar"
+  weight = 1
+
   deletion_protection  = false
 }

--- a/mmv1/templates/terraform/samples/services/chronicle/chronicle_environment_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/chronicle/chronicle_environment_full.tf.tmpl
@@ -11,5 +11,13 @@ resource "google_chronicle_environment" "{{$.PrimaryResourceId}}" {
   data_access_scopes_json = jsonencode([])
   retention_duration = 3
 
+  base64_image = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAABHNCSVQICAgIfAhkiAAAAA1JREFUCJljYPjPUA8AA4EBf4abPZ0AAAAASUVORK5CYII="
+  dynamic_parameters {
+    dynamic_parameter_id = 123
+    value = "value2"
+  }
+  instance_uri = "https://test.backstory.chronicle.security?foo=baz"
+  weight = 2
+
   deletion_protection  = false
 }


### PR DESCRIPTION
Adds missing fields (`base64_image`, `dynamic_parameters`, `instance_uri`, and `weight`) to `google_chronicle_environment`.

reference: b/549921539

```release-note:enhancement
chronicle: added `base64_image`, `dynamic_parameters`, `instance_uri`, and `weight` fields to `google_chronicle_environment`
```
