### PR TITLE
ces: add whatsapp_config to google_ces_deployment

### DIFF
--- a/mmv1/products/ces/Deployment.yaml
+++ b/mmv1/products/ces/Deployment.yaml
@@ -43,6 +43,16 @@ samples:
           app_version_display_name: my-app-version
           app_version_id: app-version-id
           deployment_display_name: my-deployment
+  - name: ces_deployment_whatsapp
+    primary_resource_id: my-deployment
+    steps:
+      - name: ces_deployment_whatsapp
+        resource_id_vars:
+          app_display_name: my-app
+          app_id: app-id
+          app_version_display_name: my-app-version
+          app_version_id: app-version-id
+          deployment_display_name: my-deployment
 parameters:
   - name: location
     type: String
@@ -85,6 +95,8 @@ properties:
           CONTACT_CENTER_AS_A_SERVICE
           FIVE9
           CONTACT_CENTER_INTEGRATION
+          WHATSAPP
+          INSTAGRAM
       - name: disableBargeInControl
         type: Boolean
         description: |-
@@ -160,6 +172,33 @@ properties:
                 description: |-
                   Indicates whether reCAPTCHA verification for the web widget is enabled.
                 send_empty_value: true
+      - name: whatsappConfig
+        type: NestedObject
+        description: Configuration specific to WhatsApp deployments.
+        properties:
+          - name: description
+            type: String
+            description: Output only. The description of the Meta business page or profile.
+            output: true
+          - name: displayName
+            type: String
+            description: Output only. The fetched Meta business page name.
+            output: true
+          - name: phoneNumber
+            type: String
+            description: Optional. The phone number in E.164 format.
+          - name: phoneNumberId
+            type: String
+            required: true
+            description: Required. The Meta phone number ID.
+          - name: thumbnailUrl
+            type: String
+            description: Output only. The fetched Meta business profile thumbnail URL.
+            output: true
+          - name: wabaId
+            type: String
+            required: true
+            description: Required. The WhatsApp Business Account ID.
   - name: createTime
     type: String
     description: Timestamp when this deployment was created.

--- a/mmv1/templates/terraform/samples/services/ces/ces_deployment_whatsapp.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_deployment_whatsapp.tf.tmpl
@@ -1,0 +1,30 @@
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "{{index $.ResourceIdVars "app_display_name"}}"
+    app_id       = "{{index $.ResourceIdVars "app_id"}}"
+    time_zone_settings {
+        time_zone = "America/Los_Angeles"
+    }
+}
+resource "google_ces_app_version" "my-app-version" {
+    location       = "us"
+    display_name   = "{{index $.ResourceIdVars "app_version_display_name"}}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "{{index $.ResourceIdVars "app_version_id"}}"
+    description    = "example-app-version"
+}
+resource "google_ces_deployment" "{{$.PrimaryResourceId}}" {
+    location     = "us"
+    display_name = "{{index $.ResourceIdVars "deployment_display_name"}}"
+    app          = google_ces_app.my-app.name
+    app_version  = google_ces_app_version.my-app-version.id
+    channel_profile {
+        channel_type = "API"
+        profile_id = "temp_profile_id"
+        whatsapp_config {
+            phone_number = "+15551234567"
+            phone_number_id = "1234567890"
+            waba_id = "9876543210"
+        }
+    }
+}

--- a/mmv1/third_party/terraform/services/ces/ces_deployment_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_deployment_test.go
@@ -426,3 +426,112 @@ resource "google_ces_deployment" "my-deployment" {
 }
 `, context)
 }
+
+func TestAccCESDeployment_whatsappConfig(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCESDeploymentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCESDeployment_whatsappConfig(context),
+			},
+			{
+				ResourceName:            "google_ces_deployment.my-deployment",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "app_version", "location"},
+			},
+			{
+				Config: testAccCESDeployment_whatsappConfig_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_ces_deployment.my-deployment", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_ces_deployment.my-deployment",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "app_version", "location"},
+			},
+		},
+	})
+}
+
+func testAccCESDeployment_whatsappConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "tf-test-my-app%%{random_suffix}"
+    app_id       = "tf-test-app-id%%{random_suffix}"
+    time_zone_settings {
+        time_zone = "America/Los_Angeles"
+    }
+}
+resource "google_ces_app_version" "my-app-version" {
+    location       = "us"
+    display_name   = "tf-test-my-app-version%%{random_suffix}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "tf-test-app-version-id%%{random_suffix}"
+    description    = "example-app-version"
+}
+resource "google_ces_deployment" "my-deployment" {
+    location     = "us"
+    display_name = "tf-test-my-deployment%%{random_suffix}"
+    app          = google_ces_app.my-app.name
+    app_version  = google_ces_app_version.my-app-version.id
+    channel_profile {
+        channel_type = "API"
+        profile_id = "temp_profile_id"
+        whatsapp_config {
+            phone_number = "+15551234567"
+            phone_number_id = "1234567890"
+            waba_id = "9876543210"
+        }
+    }
+}
+`, context)
+}
+
+func testAccCESDeployment_whatsappConfig_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "tf-test-my-app%%{random_suffix}"
+    app_id       = "tf-test-app-id%%{random_suffix}"
+    time_zone_settings {
+        time_zone = "America/Los_Angeles"
+    }
+}
+resource "google_ces_app_version" "my-app-version" {
+    location       = "us"
+    display_name   = "tf-test-my-app-version%%{random_suffix}"
+    app            = google_ces_app.my-app.name
+    app_version_id = "tf-test-app-version-id%%{random_suffix}"
+    description    = "example-app-version"
+}
+resource "google_ces_deployment" "my-deployment" {
+    location     = "us"
+    display_name = "tf-test-my-deployment%%{random_suffix}"
+    app          = google_ces_app.my-app.name
+    app_version  = google_ces_app_version.my-app-version.id
+    channel_profile {
+        channel_type = "API"
+        profile_id = "temp_profile_id"
+        whatsapp_config {
+            phone_number = "+15559876543"
+            phone_number_id = "2345678901"
+            waba_id = "8765432109"
+        }
+    }
+}
+`, context)
+}


### PR DESCRIPTION
Added field coverage for `channelProfile.whatsappConfig.phoneNumber` (and `whatsappConfig` object) on `google_ces_deployment` (`ces:v1:Deployment`).

reference: b/549921489

```release-note:enhancement
ces: added `channel_profile.whatsapp_config` field to `google_ces_deployment`
```
