### PR TITLE
Add tags to Parameter Manager Resource

### DIFF
--- a/mmv1/products/parametermanager/Parameter.yaml
+++ b/mmv1/products/parametermanager/Parameter.yaml
@@ -20,7 +20,6 @@ description: |
   and organization.
 references:
   guides:
-    Create and manage parameters: https://docs.cloud.google.com/secret-manager/parameter-manager/docs/create-and-manage-parameters
     Work with parameter tags: https://docs.cloud.google.com/secret-manager/parameter-manager/docs/create-and-manage-tags
   api: https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters
 docs:
@@ -80,13 +79,17 @@ samples:
           parameter_id: '"parameter" + randomSuffix'
   - name: parameter_with_tags
     primary_resource_id: parameter-with-tags
+    # Docs example only. The tag key/value IDs here are illustrative
+    # placeholders, not real resources, so this sample is excluded from
+    # generating a live acceptance test (which would fail against real GCP).
+    # Real coverage lives in TestAccParameterManagerParameter_tags in
+    # resource_parameter_manager_parameter_test.go, which bootstraps an
+    # actual org tag key/value.
+    exclude_test: true
     steps:
       - name: parameter_with_tags
         resource_id_vars:
           parameter_id: parameter
-        test_vars_overrides:
-          # for backward compatible
-          parameter_id: '"parameter" + randomSuffix'
 parameters:
   - name: parameterId
     type: String

--- a/mmv1/products/parametermanager/Parameter.yaml
+++ b/mmv1/products/parametermanager/Parameter.yaml
@@ -14,9 +14,14 @@
 ---
 name: Parameter
 description: |
-  A Parameter resource is a logical parameter.
+  A Parameter is a configuration value that can be stored and managed
+  centrally through Parameter Manager. Parameters support labels, encryption
+  via Cloud KMS, and resource manager tags for fine-grained access control
+  and organization.
 references:
   guides:
+    Create and manage parameters: https://docs.cloud.google.com/secret-manager/parameter-manager/docs/create-and-manage-parameters
+    Work with parameter tags: https://docs.cloud.google.com/secret-manager/parameter-manager/docs/create-and-manage-tags
   api: https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters
 docs:
 base_url: projects/{{project}}/locations/global/parameters
@@ -71,6 +76,15 @@ samples:
           kms_key: kms-key
         test_vars_overrides:
           kms_key: kms.BootstrapKMSKey(t).CryptoKey.Name
+          # for backward compatible
+          parameter_id: '"parameter" + randomSuffix'
+  - name: parameter_with_tags
+    primary_resource_id: parameter-with-tags
+    steps:
+      - name: parameter_with_tags
+        resource_id_vars:
+          parameter_id: parameter
+        test_vars_overrides:
           # for backward compatible
           parameter_id: '"parameter" + randomSuffix'
 parameters:
@@ -150,3 +164,11 @@ properties:
     description: |
       The resource name of the Cloud KMS CryptoKey used to encrypt parameter version payload. Format
       `projects/{{project}}/locations/global/keyRings/{{key_ring}}/cryptoKeys/{{crypto_key}}`
+  - name: tags
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/parametermanagerregional/RegionalParameter.yaml
+++ b/mmv1/products/parametermanagerregional/RegionalParameter.yaml
@@ -21,7 +21,6 @@ description: |
   organization, and regional compliance.
 references:
   guides:
-    Create and manage regional parameters: https://docs.cloud.google.com/secret-manager/parameter-manager/docs/create-and-manage-parameters
     Work with parameter tags: https://docs.cloud.google.com/secret-manager/parameter-manager/docs/create-and-manage-tags
   api: https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters
 docs:
@@ -70,6 +69,13 @@ samples:
           kms_key: kms.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name
   - name: regional_parameter_with_tags
     primary_resource_id: regional-parameter-with-tags
+    # Docs example only. The tag key/value IDs here are illustrative
+    # placeholders, not real resources, so this sample is excluded from
+    # generating a live acceptance test (which would fail against real GCP).
+    # Real coverage lives in TestAccParameterManagerRegionalRegionalParameter_tags
+    # in resource_parameter_manager_regional_parameter_test.go, which
+    # bootstraps an actual org tag key/value.
+    exclude_test: true
     steps:
       - name: regional_parameter_with_tags
         resource_id_vars:

--- a/mmv1/products/parametermanagerregional/RegionalParameter.yaml
+++ b/mmv1/products/parametermanagerregional/RegionalParameter.yaml
@@ -15,9 +15,14 @@
 name: RegionalParameter
 api_resource_type_kind: Parameter
 description: |
-  A Regional Parameter is a logical regional parameter.
+  A Regional Parameter is a configuration value stored in a specific region
+  through Parameter Manager. Regional parameters support labels, encryption
+  via Cloud KMS, and resource manager tags for fine-grained access control,
+  organization, and regional compliance.
 references:
   guides:
+    Create and manage regional parameters: https://docs.cloud.google.com/secret-manager/parameter-manager/docs/create-and-manage-parameters
+    Work with parameter tags: https://docs.cloud.google.com/secret-manager/parameter-manager/docs/create-and-manage-tags
   api: https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters
 docs:
 base_url: projects/{{project}}/locations/{{location}}/parameters
@@ -63,6 +68,12 @@ samples:
           kms_key: kms-key
         test_vars_overrides:
           kms_key: kms.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name
+  - name: regional_parameter_with_tags
+    primary_resource_id: regional-parameter-with-tags
+    steps:
+      - name: regional_parameter_with_tags
+        resource_id_vars:
+          parameter_id: regional_parameter
 parameters:
   - name: location
     type: String
@@ -146,3 +157,11 @@ properties:
     description: |
       The resource name of the Cloud KMS CryptoKey used to encrypt regional parameter version payload. Format
       `projects/{{project}}/locations/{{location}}/keyRings/{{key_ring}}/cryptoKeys/{{crypto_key}}`
+  - name: tags
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/templates/terraform/samples/services/parametermanager/parameter_with_tags.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanager/parameter_with_tags.tf.tmpl
@@ -1,0 +1,8 @@
+resource "google_parameter_manager_parameter" "{{$.PrimaryResourceId}}" {
+  parameter_id = "{{index $.ResourceIdVars "parameter_id"}}"
+
+  tags = {
+    "tagKeys/123456" = "tagValues/789012"
+    "tagKeys/345678" = "tagValues/901234"
+  }
+}

--- a/mmv1/templates/terraform/samples/services/parametermanagerregional/regional_parameter_with_tags.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanagerregional/regional_parameter_with_tags.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_parameter_manager_regional_parameter" "{{$.PrimaryResourceId}}" {
+  location = "us-central1"
+  parameter_id = "{{index $.ResourceIdVars "parameter_id"}}"
+
+  tags = {
+    "tagKeys/123456" = "tagValues/789012"
+    "tagKeys/345678" = "tagValues/901234"
+  }
+}

--- a/mmv1/templates/terraform/samples/services/parametermanagerregional/regional_parameter_with_tags.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanagerregional/regional_parameter_with_tags.tf.tmpl
@@ -1,9 +1,8 @@
 resource "google_parameter_manager_regional_parameter" "{{$.PrimaryResourceId}}" {
-  location = "us-central1"
+  location     = "us-central1"
   parameter_id = "{{index $.ResourceIdVars "parameter_id"}}"
 
   tags = {
     "tagKeys/123456" = "tagValues/789012"
-    "tagKeys/345678" = "tagValues/901234"
   }
 }

--- a/mmv1/third_party/terraform/services/parametermanager/resource_parameter_manager_parameter_test.go
+++ b/mmv1/third_party/terraform/services/parametermanager/resource_parameter_manager_parameter_test.go
@@ -6,9 +6,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/kms"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/parametermanager"
 	"github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+	"github.com/hashicorp/terraform-provider-google/google/services/tags"
 )
 
 func TestAccParameterManagerParameter_labelsUpdate(t *testing.T) {
@@ -214,6 +216,53 @@ resource "google_parameter_manager_parameter" "parameter-with-kms-key" {
   format = "JSON"
 
   kms_key = "%{kms_key_other}"
+}
+`, context)
+}
+
+func TestAccParameterManagerParameter_tags(t *testing.T) {
+	t.Parallel()
+
+	tagKey := tags.BootstrapSharedTestOrganizationTagKey(t, "parameter_manager_parameter-tagkey", map[string]interface{}{})
+
+	context := map[string]interface{}{
+		"org":           envvar.GetTestOrgFromEnv(t),
+		"tagKey":        tagKey,
+		"tagValue":      tags.BootstrapSharedTestOrganizationTagValue(t, "parameter_manager_parameter-tagvalue", tagKey),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckParameterManagerParameterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccParameterManagerParameter_tags(context),
+			},
+			{
+				ResourceName:            "google_parameter_manager_parameter.parameter-tags",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "parameter_id", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccParameterManagerParameter_tags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_parameter_manager_parameter" "parameter-tags" {
+  parameter_id = "tf_test_parameter%{random_suffix}"
+  format = "JSON"
+
+  labels = {
+    environment = "test"
+  }
+
+  tags = {
+    "%{org}/%{tagKey}" = "%{tagValue}"
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/parametermanagerregional/resource_parameter_manager_regional_parameter_test.go
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/resource_parameter_manager_regional_parameter_test.go
@@ -6,9 +6,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/kms"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/parametermanagerregional"
 	"github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+	"github.com/hashicorp/terraform-provider-google/google/services/tags"
 )
 
 func TestAccParameterManagerRegionalRegionalParameter_import(t *testing.T) {
@@ -265,6 +267,54 @@ resource "google_parameter_manager_regional_parameter" "regional-parameter-with-
   format = "JSON"
 
   kms_key = "%{kms_key_other}"
+}
+`, context)
+}
+
+func TestAccParameterManagerRegionalRegionalParameter_tags(t *testing.T) {
+	t.Parallel()
+
+	tagKey := tags.BootstrapSharedTestOrganizationTagKey(t, "parameter_manager_regional_parameter-tagkey", map[string]interface{}{})
+
+	context := map[string]interface{}{
+		"org":           envvar.GetTestOrgFromEnv(t),
+		"tagKey":        tagKey,
+		"tagValue":      tags.BootstrapSharedTestOrganizationTagValue(t, "parameter_manager_regional_parameter-tagvalue", tagKey),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccParameterManagerRegionalRegionalParameter_tags(context),
+			},
+			{
+				ResourceName:            "google_parameter_manager_regional_parameter.regional-parameter-tags",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "parameter_id", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccParameterManagerRegionalRegionalParameter_tags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_parameter_manager_regional_parameter" "regional-parameter-tags" {
+  parameter_id = "tf_test_parameter%{random_suffix}"
+  location = "us-central1"
+  format = "JSON"
+
+  labels = {
+    environment = "test"
+  }
+
+  tags = {
+    "%{org}/%{tagKey}" = "%{tagValue}"
+  }
 }
 `, context)
 }


### PR DESCRIPTION
Add tags field to parameter manager resource to allow setting tags on parameter resources at creation time.

b/559010883

```release-note:enhancement
parametermanager: added `tags` field to `google_parameter_manager_parameter` and `google_parameter_manager_regional_parameter` to allow setting tags for parameters at creation time
```