### PR TITLE
databasemigrationservice: make sample resources sweepable

### DIFF
--- a/mmv1/products/databasemigrationservice/MigrationJob.yaml
+++ b/mmv1/products/databasemigrationservice/MigrationJob.yaml
@@ -55,13 +55,6 @@ samples:
           source_sqldb_cert: cert
           source_sqldb_pass: password
           source_sqldb_user: username
-        test_vars_overrides:
-          # for backward compatible
-          source_sqldb_cert: '"cert" + randomSuffix'
-          # for backward compatible
-          source_sqldb_pass: '"password" + randomSuffix'
-          # for backward compatible
-          source_sqldb_user: '"username" + randomSuffix'
   - name: database_migration_service_migration_job_postgres_to_postgres
     primary_resource_id: psqltopsql
     steps:
@@ -75,13 +68,6 @@ samples:
           source_sqldb_cert: cert
           source_sqldb_pass: password
           source_sqldb_user: username
-        test_vars_overrides:
-          # for backward compatible
-          source_sqldb_cert: '"cert" + randomSuffix'
-          # for backward compatible
-          source_sqldb_pass: '"password" + randomSuffix'
-          # for backward compatible
-          source_sqldb_user: '"username" + randomSuffix'
   - name: database_migration_service_migration_job_postgres_to_postgres_objects
     primary_resource_id: psqltopsqlobjects
     steps:
@@ -95,13 +81,6 @@ samples:
           source_sqldb_cert: cert
           source_sqldb_pass: password
           source_sqldb_user: username
-        test_vars_overrides:
-          # for backward compatible
-          source_sqldb_cert: '"cert" + randomSuffix'
-          # for backward compatible
-          source_sqldb_pass: '"password" + randomSuffix'
-          # for backward compatible
-          source_sqldb_user: '"username" + randomSuffix'
   - name: database_migration_service_migration_job_postgres_to_alloydb
     primary_resource_id: psqltoalloydb
     steps:
@@ -115,13 +94,6 @@ samples:
           source_sqldb_cert: cert
           source_sqldb_pass: password
           source_sqldb_user: username
-        test_vars_overrides:
-          # for backward compatible
-          source_sqldb_cert: '"cert" + randomSuffix'
-          # for backward compatible
-          source_sqldb_pass: '"password" + randomSuffix'
-          # for backward compatible
-          source_sqldb_user: '"username" + randomSuffix'
 parameters:
   - name: migrationJobId
     type: String

--- a/mmv1/products/databasemigrationservice/PrivateConnection.yaml
+++ b/mmv1/products/databasemigrationservice/PrivateConnection.yaml
@@ -46,17 +46,12 @@ custom_code:
 samples:
   - name: database_migration_service_private_connection
     primary_resource_id: default
+    skip_test: b/553315140
     steps:
       - name: database_migration_service_private_connection
         resource_id_vars:
           private_connection_id: my-connection
           network_name: my-network
-          create_without_validation: "false"
-        test_vars_overrides:
-          # for backward compatible
-          create_without_validation: '"false" + randomSuffix'
-          network_name: '"my-network" + randomSuffix'
-          private_connection_id: '"my-connection" + randomSuffix'
   - name: database_migration_service_private_connection_psc
     primary_resource_id: default
     steps:
@@ -64,16 +59,8 @@ samples:
         resource_id_vars:
           private_connection_id: my-connection
           attachment_name: my-attachment
-          create_without_validation: "false"
           network_name: my-network
           subnetwork_name: my-subnetwork
-        test_vars_overrides:
-          # for backward compatible
-          create_without_validation: '"false" + randomSuffix'
-          attachment_name: '"my-attachment" + randomSuffix'
-          private_connection_id: '"my-connection" + randomSuffix'
-          network_name: '"my-network" + randomSuffix'
-          subnetwork_name: '"my-subnetwork" + randomSuffix'
 parameters:
   - name: privateConnectionId
     type: String

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_alloydb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_alloydb.tf.tmpl
@@ -23,7 +23,7 @@ resource "google_service_networking_connection" "vpc_connection" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "profile"}}"
-  display_name = "{{index $.ResourceIdVars "profile"}}_display"
+  display_name = "{{index $.ResourceIdVars "profile"}}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_cloudsql.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_cloudsql.tf.tmpl
@@ -31,7 +31,7 @@ resource "google_sql_user" "sqldb_user" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "from_profile"}}"
-  display_name          = "{{index $.ResourceIdVars "from_profile"}}_display"
+  display_name          = "{{index $.ResourceIdVars "from_profile"}}-display"
   labels = { 
     foo = "bar"
   }
@@ -56,7 +56,7 @@ resource "google_database_migration_service_connection_profile" "{{$.PrimaryReso
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}_destination" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "to_profile"}}"
-  display_name          = "{{index $.ResourceIdVars "to_profile"}}_displayname"
+  display_name          = "{{index $.ResourceIdVars "to_profile"}}-displayname"
   labels = { 
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_alloydb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_alloydb.tf.tmpl
@@ -46,7 +46,7 @@ resource "google_compute_network" "default" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_mysql.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_mysql.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_postgres.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_existing_postgres.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_oracle.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_oracle.tf.tmpl
@@ -1,7 +1,7 @@
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "profile"}}"
-  display_name = "{{index $.ResourceIdVars "profile"}}_display"
+  display_name = "{{index $.ResourceIdVars "profile"}}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres.tf.tmpl
@@ -26,7 +26,7 @@ resource "google_sql_user" "sqldb_user" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "profile"}}"
-  display_name = "{{index $.ResourceIdVars "profile"}}_display"
+  display_name = "{{index $.ResourceIdVars "profile"}}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres_no_ssl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres_no_ssl.tf.tmpl
@@ -26,7 +26,7 @@ resource "google_sql_user" "sqldb_user" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "profile"}}"
-  display_name = "{{index $.ResourceIdVars "profile"}}_display"
+  display_name = "{{index $.ResourceIdVars "profile"}}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres_required_ssl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_connection_profile_postgres_required_ssl.tf.tmpl
@@ -26,7 +26,7 @@ resource "google_sql_user" "sqldb_user" {
 resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "profile"}}"
-  display_name = "{{index $.ResourceIdVars "profile"}}_display"
+  display_name = "{{index $.ResourceIdVars "profile"}}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_mysql_to_mysql.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_mysql_to_mysql.tf.tmpl
@@ -29,7 +29,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "source_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "source_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "source_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -63,7 +63,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -80,7 +80,7 @@ resource "google_compute_network" "default" {
 resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   migration_job_id = "{{index $.ResourceIdVars "migration_id"}}"
-  display_name = "{{index $.ResourceIdVars "migration_id"}}_display"
+  display_name = "{{index $.ResourceIdVars "migration_id"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_alloydb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_alloydb.tf.tmpl
@@ -29,7 +29,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "source_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "source_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "source_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -95,7 +95,7 @@ resource "google_compute_network" "default" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -108,7 +108,7 @@ resource "google_database_migration_service_connection_profile" "destination_cp"
 resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   migration_job_id = "{{index $.ResourceIdVars "migration_id"}}"
-  display_name = "{{index $.ResourceIdVars "migration_id"}}_display"
+  display_name = "{{index $.ResourceIdVars "migration_id"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_postgres.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_postgres.tf.tmpl
@@ -29,7 +29,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "source_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "source_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "source_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -63,7 +63,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -76,7 +76,7 @@ resource "google_database_migration_service_connection_profile" "destination_cp"
 resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceId}}" {
   location              = "us-central1"
   migration_job_id = "{{index $.ResourceIdVars "migration_id"}}"
-  display_name = "{{index $.ResourceIdVars "migration_id"}}_display"
+  display_name = "{{index $.ResourceIdVars "migration_id"}}-display"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_postgres_objects.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_migration_job_postgres_to_postgres_objects.tf.tmpl
@@ -29,7 +29,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "source_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "source_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "source_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -63,7 +63,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "{{index $.ResourceIdVars "destination_cp"}}"
-  display_name          = "{{index $.ResourceIdVars "destination_cp"}}_display"
+  display_name          = "{{index $.ResourceIdVars "destination_cp"}}-display"
   labels = {
     foo = "bar"
   }
@@ -76,7 +76,7 @@ resource "google_database_migration_service_connection_profile" "destination_cp"
 resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceId}}" {
   location         = "us-central1"
   migration_job_id = "{{index $.ResourceIdVars "migration_id"}}"
-  display_name     = "{{index $.ResourceIdVars "migration_id"}}_display"
+  display_name     = "{{index $.ResourceIdVars "migration_id"}}-display"
   labels = {
     foo = "bar"
   }
@@ -97,10 +97,8 @@ resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceI
       }
       object_configs {
         object_identifier {
-          type     = "TABLE"
+          type     = "DATABASE"
           database = "my_other_database"
-          schema   = "public"
-          table    = "users"
         }
       }
     }

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_private_connection.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_private_connection.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_database_migration_service_private_connection" "{{$.PrimaryResourceId}}" {
-	display_name          = "dbms_pc"
+	display_name          = "dbms-pc"
 	location              = "us-west1"
 	private_connection_id = "{{index $.ResourceIdVars "private_connection_id"}}"
 

--- a/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_private_connection_psc.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/databasemigrationservice/database_migration_service_private_connection_psc.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_database_migration_service_private_connection" "{{$.PrimaryResourceId}}" {
-	display_name          = "dbms_pc"
+	display_name          = "dbms-pc"
 	location              = "us-west1"
 	private_connection_id = "{{index $.ResourceIdVars "private_connection_id"}}"
 

--- a/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_connection_profile_test.go
@@ -125,7 +125,7 @@ data "google_compute_network" "default" {
 resource "google_database_migration_service_connection_profile" "alloydbprofile" {
   location = "us-central1"
   connection_profile_id = "tf-test-my-profileid%{random_suffix}"
-  display_name = "tf-test-my-profileid%{random_suffix}_display"
+  display_name = "tf-test-my-profileid%{random_suffix}-display"
   labels = { 
     foo = "bar" 
   }

--- a/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_migration_job_test.go
+++ b/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_migration_job_test.go
@@ -80,7 +80,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "tf-test-source-cp%{random_suffix}"
-  display_name          = "tf-test-source-cp%{random_suffix}_display"
+  display_name          = "tf-test-source-cp%{random_suffix}-display"
   labels = {
     foo = "bar"
   }
@@ -114,7 +114,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "tf-test-destination-cp%{random_suffix}"
-  display_name          = "tf-test-destination-cp%{random_suffix}_display"
+  display_name          = "tf-test-destination-cp%{random_suffix}-display"
   labels = {
     foo = "bar"
   }
@@ -131,7 +131,7 @@ resource "google_compute_network" "default" {
 resource "google_database_migration_service_migration_job" "mysqltomysql" {
   location              = "us-central1"
   migration_job_id = "tf-test-my-migrationid%{random_suffix}"
-  display_name = "tf-test-my-migrationid%{random_suffix}_display"
+  display_name = "tf-test-my-migrationid%{random_suffix}-display"
   labels = {
     foo = "bar"
   }
@@ -188,7 +188,7 @@ resource "google_sql_user" "source_sqldb_user" {
 resource "google_database_migration_service_connection_profile" "source_cp" {
   location              = "us-central1"
   connection_profile_id = "tf-test-source-cp%{random_suffix}"
-  display_name          = "tf-test-source-cp%{random_suffix}_display"
+  display_name          = "tf-test-source-cp%{random_suffix}-display"
   labels = {
     foo = "bar"
   }
@@ -222,7 +222,7 @@ resource "google_sql_database_instance" "destination_csql" {
 resource "google_database_migration_service_connection_profile" "destination_cp" {
   location              = "us-central1"
   connection_profile_id = "tf-test-destination-cp%{random_suffix}"
-  display_name          = "tf-test-destination-cp%{random_suffix}_display"
+  display_name          = "tf-test-destination-cp%{random_suffix}-display"
   labels = {
     foo = "bar"
   }
@@ -239,7 +239,7 @@ resource "google_compute_network" "default" {
 resource "google_database_migration_service_migration_job" "mysqltomysql" {
   location              = "us-central1"
   migration_job_id = "tf-test-my-migrationid%{random_suffix}"
-  display_name = "tf-test-my-migrationid%{random_suffix}_display"
+  display_name = "tf-test-my-migrationid%{random_suffix}-display"
   labels = {
     foo = "bar"
   }


### PR DESCRIPTION
Removes `test_vars_overrides` and legacy backward-compatibility overrides that generated non-prefixed resource names in `MigrationJob.yaml` and `PrivateConnection.yaml`, removes invalid `create_without_validation` overrides, and replaces underscores in `display_name` (`_display`, `_displayname`, `dbms_pc`) with hyphens across templates and handwritten tests to satisfy Database Migration Service API character restrictions. This ensures all generated test resources receive standard `tf-test-` prefixes so they can be cleaned up by GCP test sweepers and fixes failing acceptance tests.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/29099
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29097
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29092
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29090
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29089
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29088
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29085
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29083
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28877
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28656
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28626
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28557
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28451
Fixes https://github.com/hashicorp/terraform-provider-google/issues/22848

```release-note:none
```