### PR TITLE
networkconnectivity: make sample and test resources sweepable

### DIFF
--- a/mmv1/products/networkconnectivity/GatewayAdvertisedRoute.yaml
+++ b/mmv1/products/networkconnectivity/GatewayAdvertisedRoute.yaml
@@ -44,9 +44,6 @@ samples:
           spoke_name: spoke-name
           network_name: net-spoke
           hub_name: hub
-        test_vars_overrides:
-          # for backward compatible
-          hub_name: '"hub" + randomSuffix'
 parameters:
   - name: location
     type: String

--- a/mmv1/products/networkconnectivity/Group.yaml
+++ b/mmv1/products/networkconnectivity/Group.yaml
@@ -41,11 +41,6 @@ samples:
           hub_name: network-connectivity-hub1
           auto_accept_project_1_name: foo
           auto_accept_project_2_name: bar
-        test_vars_overrides:
-          # for backward compatible
-          auto_accept_project_1_name: '"foo" + randomSuffix'
-          # for backward compatible
-          auto_accept_project_2_name: '"bar" + randomSuffix'
 parameters:
   - name: hub
     type: ResourceRef

--- a/mmv1/products/networkconnectivity/Hub.yaml
+++ b/mmv1/products/networkconnectivity/Hub.yaml
@@ -54,45 +54,30 @@ samples:
       - name: network_connectivity_hub_basic
         resource_id_vars:
           resource_name: basic
-        test_vars_overrides:
-          # for backward compatible
-          resource_name: '"basic" + randomSuffix'
   - name: network_connectivity_hub_with_export_psc
     primary_resource_id: primary
     steps:
       - name: network_connectivity_hub_with_export_psc
         resource_id_vars:
           resource_name: basic
-        test_vars_overrides:
-          # for backward compatible
-          resource_name: '"basic" + randomSuffix'
   - name: network_connectivity_hub_mesh_topology
     primary_resource_id: primary
     steps:
       - name: network_connectivity_hub_mesh_topology
         resource_id_vars:
           resource_name: mesh
-        test_vars_overrides:
-          # for backward compatible
-          resource_name: '"mesh" + randomSuffix'
   - name: network_connectivity_hub_star_topology
     primary_resource_id: primary
     steps:
       - name: network_connectivity_hub_star_topology
         resource_id_vars:
           resource_name: star
-        test_vars_overrides:
-          # for backward compatible
-          resource_name: '"star" + randomSuffix'
   - name: network_connectivity_hub_policy_mode
     primary_resource_id: primary
     steps:
       - name: network_connectivity_hub_policy_mode
         resource_id_vars:
           resource_name: policy
-        test_vars_overrides:
-          # for backward compatible
-          resource_name: '"policy" + randomSuffix'
 parameters:
 properties:
   - name: name

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -50,13 +50,6 @@ samples:
           network_name: net
           hub_name: hub1
           spoke_name: spoke1
-        test_vars_overrides:
-          # for backward compatible
-          network_name: '"net" + randomSuffix'
-          # for backward compatible
-          hub_name: '"hub1" + randomSuffix'
-          # for backward compatible
-          spoke_name: '"spoke1" + randomSuffix'
   - name: network_connectivity_spoke_linked_vpc_network_group
     primary_resource_id: primary
     steps:
@@ -95,12 +88,6 @@ samples:
           hub_name: basic-hub1
           vpn_tunnel_1_spoke_name: vpn-tunnel-1-spoke
           vpn_tunnel_2_spoke_name: vpn-tunnel-2-spoke
-        # Skip due to multiple fine-grained resources
-        test_vars_overrides:
-          # for backward compatible
-          vpn_tunnel_1_name: '"tunnel1" + randomSuffix'
-          # for backward compatible
-          vpn_tunnel_2_name: '"tunnel2" + randomSuffix'
   - name: network_connectivity_spoke_interconnect_attachment_basic
     primary_resource_id: primary
     steps:
@@ -126,15 +113,11 @@ samples:
     steps:
       - name: network_connectivity_spoke_center_group
         resource_id_vars:
+          network_name: net
           hub_name: hub-basic
           spoke_name: vpc-spoke
           auto_accept_project_1_name: foo
           auto_accept_project_2_name: bar
-        test_vars_overrides:
-          # for backward compatible
-          auto_accept_project_1_name: '"foo" + randomSuffix'
-          # for backward compatible
-          auto_accept_project_2_name: '"bar" + randomSuffix'
   - name: network_connectivity_spoke_linked_vpc_network_ipv6_support
     primary_resource_id: primary
     steps:
@@ -143,11 +126,6 @@ samples:
           network_name: net
           hub_name: hub1
           spoke_name: spoke1-ipv6
-        test_vars_overrides:
-          # for backward compatible
-          network_name: '"net" + randomSuffix'
-          # for backward compatible
-          hub_name: '"hub1" + randomSuffix'
   - name: network_connectivity_spoke_gateway
     primary_resource_id: primary
     steps:
@@ -156,11 +134,6 @@ samples:
           network_name: net-spoke
           hub_name: hub
           spoke_name: gateway
-        test_vars_overrides:
-          # for backward compatible
-          hub_name: '"hub" + randomSuffix'
-          # for backward compatible
-          spoke_name: '"gateway" + randomSuffix'
 parameters:
   - name: location
     type: String

--- a/mmv1/products/networkconnectivityv1/InternalRange.yaml
+++ b/mmv1/products/networkconnectivityv1/InternalRange.yaml
@@ -52,9 +52,6 @@ samples:
         resource_id_vars:
           internal_range_name: basic
           network_name: internal-ranges
-        test_vars_overrides:
-          # for backward compatible
-          internal_range_name: '"basic" + randomSuffix'
   - name: network_connectivity_internal_ranges_automatic_reservation
     primary_resource_id: default
     steps:
@@ -84,9 +81,6 @@ samples:
           internal_range_name: migration
           network_name: internal-ranges
           source_subnet_name: source-subnet
-        test_vars_overrides:
-          # for backward compatible
-          internal_range_name: '"migration" + randomSuffix'
   - name: network_connectivity_internal_ranges_allocation_algoritms
     primary_resource_id: default
     steps:

--- a/mmv1/templates/terraform/samples/services/networkconnectivity/network_connectivity_spoke_center_group.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/networkconnectivity/network_connectivity_spoke_center_group.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_compute_network" "network" {
-  name                    = "tf-net"
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
   auto_create_subnetworks = false
 }
 
@@ -13,8 +13,8 @@ resource "google_network_connectivity_group" "center_group" {
   hub  = google_network_connectivity_hub.star_hub.id
   auto_accept {
     auto_accept_projects = [
-      "foo%{random_suffix}", 
-      "bar%{random_suffix}", 
+      "{{index $.ResourceIdVars "auto_accept_project_1_name"}}", 
+      "{{index $.ResourceIdVars "auto_accept_project_2_name"}}", 
     ]
   }
 }

--- a/mmv1/third_party/terraform/services/networkconnectivityv1/resource_network_connectivity_internal_range_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivityv1/resource_network_connectivity_internal_range_test.go
@@ -75,7 +75,7 @@ func TestAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesBa
 func testAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesBasicExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_network_connectivity_internal_range" "default" {
-  name    = "basic%{random_suffix}"
+  name    = "tf-test-basic%{random_suffix}"
   description = "Test internal range"
   network = google_compute_network.default.name
   usage   = "FOR_VPC"
@@ -99,7 +99,7 @@ resource "google_compute_network" "default" {
 func testAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesBasicExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_network_connectivity_internal_range" "default" {
-  name    = "basic%{random_suffix}"
+  name    = "tf-test-basic%{random_suffix}"
   description = "Updated description"
   network = google_compute_network.default.name
   usage   = "FOR_VPC"
@@ -171,7 +171,7 @@ func TestAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesEx
 func testAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesExternalRangesExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_network_connectivity_internal_range" "default" {
-  name    = "basic%{random_suffix}"
+  name    = "tf-test-basic%{random_suffix}"
   description = "Test internal range for resources outside the VPC"
   network = google_compute_network.default.name
   usage   = "EXTERNAL_TO_VPC"
@@ -189,7 +189,7 @@ resource "google_compute_network" "default" {
 func testAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesExternalRangesExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_network_connectivity_internal_range" "default" {
-  name    = "basic%{random_suffix}"
+  name    = "tf-test-basic%{random_suffix}"
   description = "Updated description"
   network = google_compute_network.default.name
   usage   = "EXTERNAL_TO_VPC"
@@ -258,7 +258,7 @@ func TestAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesEx
 func testAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesExcludeCIDRExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_network_connectivity_internal_range" "default" {
-  name    = "basic%{random_suffix}"
+  name    = "tf-test-basic%{random_suffix}"
   description = "Test internal range exclude CIDR"
   network = google_compute_network.default.name
 
@@ -326,7 +326,7 @@ func TestAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesIP
 func testAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesIPv6Example_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_network_connectivity_internal_range" "default" {
-  name    = "basic%{random_suffix}"
+  name    = "tf-test-basic%{random_suffix}"
   description = "Test internal range IPv6"
   network = google_compute_network.default.name
   ip_cidr_range = "1234:0:1:1::/64"
@@ -383,7 +383,7 @@ func TestAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesIm
 func testAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesImmutableExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_network_connectivity_internal_range" "default" {
-  name    = "basic%{random_suffix}"
+  name    = "tf-test-basic%{random_suffix}"
   description = "Test internal range Immutable"
   network = google_compute_network.default.name
   ip_cidr_range = "11.11.20.0/24"


### PR DESCRIPTION
Removes `test_vars_overrides` and legacy backward-compatibility overrides that generated non-prefixed resource names across `Hub.yaml`, `Spoke.yaml`, `Group.yaml`, `GatewayAdvertisedRoute.yaml`, and `InternalRange.yaml`.

In `network_connectivity_spoke_center_group.tf.tmpl`:
* Replaces the hardcoded `tf-net` network name with the `network_name` variable so the network receives a `tf-test-` prefix and random suffix.
* Replaces raw Go format string `%{random_suffix}` references with `auto_accept_project_1_name` and `auto_accept_project_2_name` template variables.

In `resource_network_connectivity_internal_range_test.go`:
* Updates handwritten acceptance test configurations to prefix internal range names with `tf-test-` so that created resources can be cleaned up by the `NetworkConnectivityInternalRange` sweeper.

```release-note:none
```