### PR TITLE
managedkafka: add security warning to allowed_source_ip_ranges description

### DIFF
--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -119,7 +119,7 @@ properties:
             properties:
               - name: 'allowedSourceIpRanges'
                 type: Array
-                description: "A list of IPv4 addresses or CIDR ranges that are allowed to connect to the cluster."
+                description: "A list of IPv4 addresses or CIDR ranges that are allowed to connect to the cluster. To protect your cluster, allow access from only trusted external IP ranges. Don't expose your cluster to untrusted ranges."
                 required: true
                 item_type:
                   type: String


### PR DESCRIPTION
Adds a security warning to the `allowed_source_ip_ranges` description under `public_cluster_config` in `google_managed_kafka_cluster`, aligning with gcloud (cl/979335941) and Cloud Console (cl/979182321).

Follow-up to #18816.

```release-note:none
```