### PR TITLE
memorystore: make sample resources sweepable

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -27,6 +27,10 @@ update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/instances/{{instance_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/instances/{{instance_id}}
+sweeper:
+  url_substitutions:
+    - region: us-central1
+    - region: us-west1
 timeouts:
   insert_minutes: 60
   update_minutes: 120

--- a/mmv1/products/memorystore/InstanceDesiredUserCreatedEndpoints.yaml
+++ b/mmv1/products/memorystore/InstanceDesiredUserCreatedEndpoints.yaml
@@ -38,6 +38,10 @@ timeouts:
   insert_minutes: 60
   update_minutes: 120
   delete_minutes: 30
+sweeper:
+  url_substitutions:
+    - region: us-central1
+    - region: us-west1
 async:
   type: OpAsync
   operation:

--- a/mmv1/products/memorystore/InstanceDesiredUserCreatedEndpoints.yaml
+++ b/mmv1/products/memorystore/InstanceDesiredUserCreatedEndpoints.yaml
@@ -67,11 +67,6 @@ samples:
           ip2_network2_name: ip2-net2
           forwarding_rule1_network2_name: fwd1-net2
           forwarding_rule2_network2_name: fwd2-net2
-        test_vars_overrides:
-          # for backward compatible
-          network1_name: '"net1" + randomSuffix'
-          # for backward compatible
-          network2_name: '"network2" + randomSuffix'
   - name: memorystore_instance_desired_user_and_auto_created_endpoints
     primary_resource_id: instance-user-auto-conn
     steps:
@@ -87,13 +82,6 @@ samples:
           ip2_network2_name: ip2-net2
           forwarding_rule1_network2_name: fwd1-net2
           forwarding_rule2_network2_name: fwd2-net2
-        test_vars_overrides:
-          # for backward compatible
-          network1_name: '"net1" + randomSuffix'
-          # for backward compatible
-          policy_name: '"scpolicy" + randomSuffix'
-          # for backward compatible
-          network2_name: '"network2" + randomSuffix'
 parameters:
   - name: name
     type: String

--- a/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_desired_user_and_auto_created_endpoints.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_desired_user_and_auto_created_endpoints.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_memorystore_instance_desired_user_created_endpoints" "{{$.PrimaryResourceId}}" {
   name                        = "{{index $.ResourceIdVars "instance_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   desired_user_created_endpoints {
     connections {
       psc_connection {
@@ -25,7 +25,7 @@ resource "google_memorystore_instance_desired_user_created_endpoints" "{{$.Prima
 
 resource "google_compute_forwarding_rule" "forwarding_rule1_network2" {
   name                        = "{{index $.ResourceIdVars "forwarding_rule1_network2_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   ip_address                  = google_compute_address.ip1_network2.id
   load_balancing_scheme       = ""
   network                     = google_compute_network.network2.id
@@ -34,7 +34,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule1_network2" {
 
 resource "google_compute_forwarding_rule" "forwarding_rule2_network2" {
   name                        = "{{index $.ResourceIdVars "forwarding_rule2_network2_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   ip_address                  = google_compute_address.ip2_network2.id
   load_balancing_scheme       = ""
   network                     = google_compute_network.network2.id
@@ -43,7 +43,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule2_network2" {
 
 resource "google_compute_address" "ip1_network2" {
   name                        = "{{index $.ResourceIdVars "ip1_network2_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   subnetwork                  = google_compute_subnetwork.subnet_network2.id
   address_type                = "INTERNAL"  
   purpose                     = "GCE_ENDPOINT"
@@ -51,7 +51,7 @@ resource "google_compute_address" "ip1_network2" {
 
 resource "google_compute_address" "ip2_network2" {
   name                        = "{{index $.ResourceIdVars "ip2_network2_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   subnetwork                  = google_compute_subnetwork.subnet_network2.id
   address_type                = "INTERNAL"
   purpose                     = "GCE_ENDPOINT"
@@ -60,7 +60,7 @@ resource "google_compute_address" "ip2_network2" {
 resource "google_compute_subnetwork" "subnet_network2" {
   name                        = "{{index $.ResourceIdVars "subnet_network2_name"}}"
   ip_cidr_range               = "10.0.0.248/29"
-  region                      = "us-central1"
+  region                      = "us-west1"
   network                     = google_compute_network.network2.id
 }
 
@@ -77,7 +77,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
     network                   = google_compute_network.network1.id
     project_id                = data.google_project.project.project_id
   }
-  location                    = "us-central1"
+  location                    = "us-west1"
   deletion_protection_enabled = false
   depends_on                  = [google_network_connectivity_service_connection_policy.default]
 
@@ -85,7 +85,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name                        = "{{index $.ResourceIdVars "policy_name"}}"
-  location                    = "us-central1"
+  location                    = "us-west1"
   service_class               = "gcp-memorystore"
   description                 = "my basic service connection policy"
   network                     = google_compute_network.network1.id
@@ -97,7 +97,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "subnet_network1" {
   name                       = "{{index $.ResourceIdVars "subnet_network1_name"}}"
   ip_cidr_range              = "10.0.0.248/29"
-  region                     = "us-central1"
+  region                     = "us-west1"
   network                    = google_compute_network.network1.id
 }
 

--- a/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_desired_user_created_endpoints.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_desired_user_created_endpoints.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_memorystore_instance_desired_user_created_endpoints" "{{$.PrimaryResourceId}}" {
   name                        = "{{index $.ResourceIdVars "instance_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   desired_user_created_endpoints {
     connections {
       psc_connection {
@@ -45,7 +45,7 @@ resource "google_memorystore_instance_desired_user_created_endpoints" "{{$.Prima
 
 resource "google_compute_forwarding_rule" "forwarding_rule1_network1" {
   name                        = "{{index $.ResourceIdVars "forwarding_rule1_network1_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   ip_address                  = google_compute_address.ip1_network1.id
   load_balancing_scheme       = ""
   network                     = google_compute_network.network1.id
@@ -54,7 +54,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule1_network1" {
 
 resource "google_compute_forwarding_rule" "forwarding_rule2_network1" {
   name                        = "{{index $.ResourceIdVars "forwarding_rule2_network1_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   ip_address                  = google_compute_address.ip2_network1.id
   load_balancing_scheme       = ""
   network                     = google_compute_network.network1.id
@@ -63,7 +63,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule2_network1" {
 
 resource "google_compute_address" "ip1_network1" {
   name                        = "{{index $.ResourceIdVars "ip1_network1_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   subnetwork                  = google_compute_subnetwork.subnet_network1.id
   address_type                = "INTERNAL"
   purpose                     = "GCE_ENDPOINT"
@@ -71,7 +71,7 @@ resource "google_compute_address" "ip1_network1" {
 
 resource "google_compute_address" "ip2_network1" {
   name                        = "{{index $.ResourceIdVars "ip2_network1_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   subnetwork                  = google_compute_subnetwork.subnet_network1.id
   address_type                = "INTERNAL"
   purpose                     = "GCE_ENDPOINT"
@@ -80,7 +80,7 @@ resource "google_compute_address" "ip2_network1" {
 resource "google_compute_subnetwork" "subnet_network1" {
   name                        = "{{index $.ResourceIdVars "subnet_network1_name"}}"
   ip_cidr_range               = "10.0.0.248/29"
-  region                      = "us-central1"
+  region                      = "us-west1"
   network                     = google_compute_network.network1.id
 }
 
@@ -91,7 +91,7 @@ resource "google_compute_network" "network1" {
 
 resource "google_compute_forwarding_rule" "forwarding_rule1_network2" {
   name                        = "{{index $.ResourceIdVars "forwarding_rule1_network2_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   ip_address                  = google_compute_address.ip1_network2.id
   load_balancing_scheme       = ""
   network                     = google_compute_network.network2.id
@@ -100,7 +100,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule1_network2" {
 
 resource "google_compute_forwarding_rule" "forwarding_rule2_network2" {
   name                        = "{{index $.ResourceIdVars "forwarding_rule2_network2_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   ip_address                  = google_compute_address.ip2_network2.id
   load_balancing_scheme       = ""
   network                     = google_compute_network.network2.id
@@ -109,7 +109,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule2_network2" {
 
 resource "google_compute_address" "ip1_network2" {
   name                        = "{{index $.ResourceIdVars "ip1_network2_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   subnetwork                  = google_compute_subnetwork.subnet_network2.id
   address_type                = "INTERNAL"
   purpose                     = "GCE_ENDPOINT"
@@ -117,7 +117,7 @@ resource "google_compute_address" "ip1_network2" {
 
 resource "google_compute_address" "ip2_network2" {
   name                        = "{{index $.ResourceIdVars "ip2_network2_name"}}"
-  region                      = "us-central1"
+  region                      = "us-west1"
   subnetwork                  = google_compute_subnetwork.subnet_network2.id
   address_type                = "INTERNAL"
   purpose                     = "GCE_ENDPOINT"
@@ -127,14 +127,14 @@ resource "google_compute_address" "ip2_network2" {
 resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   instance_id                 =  "{{index $.ResourceIdVars "instance_name"}}"
   shard_count                 = 1
-  location                    = "us-central1"
+  location                    = "us-west1"
   deletion_protection_enabled = false
 }
 
 resource "google_compute_subnetwork" "subnet_network2" {
   name                        = "{{index $.ResourceIdVars "subnet_network2_name"}}"
   ip_cidr_range               = "10.0.0.248/29"
-  region                      = "us-central1"
+  region                      = "us-west1"
   network                     = google_compute_network.network2.id
 }
 


### PR DESCRIPTION
Make resources created in memorystore samples sweepable by removing `test_vars_overrides` that stripped the `tf-test-` prefix.

Fixes sweepability of network and policy resources in `InstanceDesiredUserCreatedEndpoints`.

```release-note:none
```