### PR TITLE
cloudscheduler: resume paused Job when `paused` is removed from config

### DIFF
--- a/mmv1/products/cloudscheduler/Job.yaml
+++ b/mmv1/products/cloudscheduler/Job.yaml
@@ -40,6 +40,7 @@ custom_code:
 generate_list_resource: true
 custom_diff:
   - 'validateAuthHeaders'
+  - 'resumeJobWhenPausedUnset'
 samples:
   - name: 'scheduler_job_pubsub'
     primary_resource_id: 'job'

--- a/mmv1/templates/terraform/constants/scheduler.tmpl
+++ b/mmv1/templates/terraform/constants/scheduler.tmpl
@@ -1,3 +1,26 @@
+// When `paused` is removed from configuration, honor the documented default
+// (jobs are enabled when the property is not set). The field is Optional+Computed,
+// so an absent value would otherwise carry the prior state forward and produce no
+// diff, leaving a previously-paused job paused. Forcing the planned value to false
+// when the config is null generates the diff that fires the :resume RPC.
+func resumeJobWhenPausedUnset(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+    rawConfig := diff.GetRawConfig()
+    if rawConfig.IsNull() {
+        return nil
+    }
+
+    pausedConfig := rawConfig.GetAttr("paused")
+    if pausedConfig.IsNull() {
+        if paused, ok := diff.Get("paused").(bool); ok && paused {
+            if err := diff.SetNew("paused", false); err != nil {
+                return err
+            }
+        }
+    }
+
+    return nil
+}
+
 // Both oidc and oauth headers cannot be set
 func validateAuthHeaders(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
     httpBlock := diff.Get("http_target.0").(map[string]interface{})

--- a/mmv1/third_party/terraform/services/cloudscheduler/resource_cloud_scheduler_job_test.go
+++ b/mmv1/third_party/terraform/services/cloudscheduler/resource_cloud_scheduler_job_test.go
@@ -40,6 +40,37 @@ func TestAccCloudSchedulerJob_schedulerPausedExample(t *testing.T) {
 	})
 }
 
+func TestAccCloudSchedulerJob_pausedRemovedResumes(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudSchedulerJobDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudSchedulerJob_schedulerPaused(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_cloud_scheduler_job.job", "paused", "true"),
+					resource.TestCheckResourceAttr("google_cloud_scheduler_job.job", "state", "PAUSED"),
+				),
+			},
+			{
+				// Removing the paused attribute must resume the job (documented default).
+				Config: testAccCloudSchedulerJob_schedulerPausedUnset(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_cloud_scheduler_job.job", "paused", "false"),
+					resource.TestCheckResourceAttr("google_cloud_scheduler_job.job", "state", "ENABLED"),
+				),
+			},
+		},
+	})
+}
+
 func TestUnitCloudSchedulerJob_LastSlashDiffSuppress(t *testing.T) {
 	cases := map[string]struct {
 		Old, New           string
@@ -107,6 +138,29 @@ func testAccCloudSchedulerJob_schedulerUnPaused(context map[string]interface{}) 
 	return acctest.Nprintf(`
 resource "google_cloud_scheduler_job" "job" {
   paused           = false # Has been flipped 
+  name             = "tf-test-test-job%{random_suffix}"
+  description      = "test http job with updated fields"
+  schedule         = "*/8 * * * *"
+  time_zone        = "America/New_York"
+  attempt_deadline = "320s"
+  region           = "us-west2"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://example.com/ping"
+    body        = base64encode("{\"foo\":\"bar\"}")
+  }
+}
+`, context)
+}
+
+func testAccCloudSchedulerJob_schedulerPausedUnset(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_scheduler_job" "job" {
   name             = "tf-test-test-job%{random_suffix}"
   description      = "test http job with updated fields"
   schedule         = "*/8 * * * *"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29280

## Summary

Fixes a bug where a Cloud Scheduler Job that was paused via `paused = true` would remain paused after the attribute was **removed** from configuration, even though the field docs state jobs default to enabled when unset.

## Root cause

`paused` uses `default_from_api: true`, making the schema field Optional + Computed. When the attribute is removed from config, Terraform carries the prior state value (`true`) forward instead of treating it as unset. No diff is produced, so `d.HasChange("paused")` in the `post_update` handler is false and the `:resume` RPC never fires.

## Fix

New `resumeJobWhenPausedUnset` CustomizeDiff: when the raw config value for `paused` is null but the current (state) value is `true`, force the new value to `false`. This restores the documented default and produces the diff that drives the existing resume logic. Setting `paused = false` explicitly is unchanged.

## Tests

- Added `TestAccCloudSchedulerJob_pausedRemovedResumes`: sets `paused = true` (asserts `PAUSED`), then removes the attribute entirely (asserts `paused = false` / `state = ENABLED`). The pre-existing `schedulerPausedExample` test only flipped `paused` to an explicit `false`, so this regression was previously untested.

## Verification

Generated the beta provider and ran locally:
- `go build` / `go vet` cloudscheduler service — clean
- Unit tests — pass
- Confirmed `resumeJobWhenPausedUnset` is emitted and registered in `CustomizeDiff.All(...)`

Acceptance test requires GCP credentials and is left to CI.

## Release Note

```release-note:bug
cloudscheduler: fixed `google_cloud_scheduler_job` staying paused when the `paused` field is removed from configuration
```
