### PR TITLE
ces: add tool_overrides to google_ces_toolset

### DIFF
--- a/mmv1/products/ces/Toolset.yaml
+++ b/mmv1/products/ces/Toolset.yaml
@@ -676,6 +676,26 @@ properties:
           set in the session variables. See
           https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps/tool/open-api#openapi-injection
           for more details.
+      - name: toolOverrides
+        type: Array
+        description: |-
+          A list of tool overrides for the toolset.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: descriptionOverride
+              type: String
+              description: |-
+                The description override for the tool.
+            - name: nameOverride
+              type: String
+              description: |-
+                The name override for the tool.
+            - name: tool
+              type: String
+              description: |-
+                The name of the tool to be overridden.
+              required: true
   - name: timeout
     type: String
     description: |-

--- a/mmv1/templates/terraform/samples/services/ces/ces_toolset_mcp_service_agent_id_token_auth_config.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/ces/ces_toolset_mcp_service_agent_id_token_auth_config.tf.tmpl
@@ -38,5 +38,10 @@ resource "google_ces_toolset" "ces_toolset_mcp_service_agent_id_token_auth_confi
     api_authentication {
         service_agent_id_token_auth_config {}
     }
+    tool_overrides {
+      tool = "my-tool"
+      name_override = "my_tool_override"
+      description_override = "A tool description override"
+    }
   }
 }

--- a/mmv1/third_party/terraform/services/ces/ces_toolset_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_toolset_test.go
@@ -1405,6 +1405,11 @@ resource "google_ces_toolset" "ces_toolset_mcp_service_agent_id_token_auth_confi
     api_authentication {
         service_agent_id_token_auth_config {}
     }
+    tool_overrides {
+      tool = "my-tool"
+      name_override = "my_tool_override"
+      description_override = "A tool description override"
+    }
   }
 }
 `, context)
@@ -1448,6 +1453,11 @@ resource "google_ces_toolset" "ces_toolset_mcp_service_agent_id_token_auth_confi
     }
     api_authentication {
         service_agent_id_token_auth_config {}
+    }
+    tool_overrides {
+      tool = "my-tool"
+      name_override = "my_tool_override_updated"
+      description_override = "A tool description override updated"
     }
   }
 }


### PR DESCRIPTION
Added field coverage for `mcpToolset.toolOverrides` on `google_ces_toolset` (`ces:v1:Toolset`).

reference: b/550543286

```release-note:enhancement
ces: added `mcp_toolset.tool_overrides` field to `google_ces_toolset`
```
