### PR TITLE
gemini: add google_gemini_gda_observability_setting and binding

### DIFF
--- a/mmv1/products/gemini/GdaObservabilitySetting.yaml
+++ b/mmv1/products/gemini/GdaObservabilitySetting.yaml
@@ -82,7 +82,7 @@ properties:
   - name: conversationalAnalyticsSetting
     type: NestedObject
     description: Message describing Setting for Conversational Analytics.
-    send_empty_value: true
+    allow_empty_object: true
     properties:
       - name: feedbackEnabled
         type: Boolean

--- a/mmv1/products/gemini/GdaObservabilitySetting.yaml
+++ b/mmv1/products/gemini/GdaObservabilitySetting.yaml
@@ -83,6 +83,7 @@ properties:
     type: NestedObject
     description: Message describing Setting for Conversational Analytics.
     allow_empty_object: true
+    send_empty_value: true
     properties:
       - name: feedbackEnabled
         type: Boolean

--- a/mmv1/products/gemini/GdaObservabilitySetting.yaml
+++ b/mmv1/products/gemini/GdaObservabilitySetting.yaml
@@ -1,0 +1,102 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GdaObservabilitySetting
+description: The resource for managing GdaObservability settings for Admin Control.
+references:
+  guides:
+    Gemini Cloud Assist overview: https://cloud.google.com/gemini/docs/cloud-assist/overview
+  api: https://cloud.google.com/gemini/docs/api/reference/rest/v1/projects.locations.gdaObservabilitySettings
+base_url: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings
+self_link: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}
+create_url: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings?gdaObservabilitySettingId={{gda_observability_setting_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}
+mutex: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}
+sweeper:
+  url_substitutions:
+    - region: global
+autogen_status: R2RhT2JzZXJ2YWJpbGl0eVNldHRpbmdBdXRvZ2VuVjJBZ2VudA==
+autogen_async: false
+samples:
+  - name: gemini_gda_observability_setting_basic
+    primary_resource_id: example
+    steps:
+      - name: gemini_gda_observability_setting_basic
+        resource_id_vars:
+          gda_observability_setting_id: ls1-tf
+  - name: gemini_gda_observability_setting_full
+    primary_resource_id: example
+    steps:
+      - name: gemini_gda_observability_setting_full
+        resource_id_vars:
+          gda_observability_setting_id: ls1-tf
+      - name: gemini_gda_observability_setting_full_update
+        resource_id_vars:
+          gda_observability_setting_id: ls1-tf
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: gdaObservabilitySettingId
+    type: String
+    description: Id of the Gda Observability Setting.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/gdaObservabilitySettings/{gdaObservabilitySetting}
+    output: true
+  - name: createTime
+    type: String
+    description: Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Update time stamp.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key value pairs.
+  - name: conversationalAnalyticsSetting
+    type: NestedObject
+    description: Message describing Setting for Conversational Analytics.
+    send_empty_value: true
+    properties:
+      - name: feedbackEnabled
+        type: Boolean
+        description: Whether to enable feedback.
+        send_empty_value: true
+      - name: loggingEnabled
+        type: Boolean
+        description: Whether to enable logging.
+        send_empty_value: true
+      - name: metricsEnabled
+        type: Boolean
+        description: Whether to enable metrics.
+        send_empty_value: true
+      - name: tracesEnabled
+        type: Boolean
+        description: Whether to enable traces.
+        send_empty_value: true

--- a/mmv1/products/gemini/GdaObservabilitySettingBinding.yaml
+++ b/mmv1/products/gemini/GdaObservabilitySettingBinding.yaml
@@ -1,0 +1,109 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GdaObservabilitySettingBinding
+api_resource_type_kind: SettingBinding
+api_variant_patterns:
+  - projects/{project}/locations/{location}/gdaObservabilitySettings/{gdaObservabilitySetting}/settingBindings/{settingBinding}
+description: The resource for managing GdaObservability setting bindings for Admin Control.
+references:
+  guides:
+    Gemini Cloud Assist overview: https://cloud.google.com/gemini/docs/cloud-assist/overview
+  api: https://cloud.google.com/gemini/docs/api/reference/rest/v1/projects.locations.gdaObservabilitySettings.settingBindings
+base_url: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}/settingBindings
+self_link: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}/settingBindings/{{setting_binding_id}}
+create_url: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}/settingBindings?settingBindingId={{setting_binding_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}/settingBindings/{{setting_binding_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}/settingBindings/{{setting_binding_id}}
+timeouts:
+  insert_minutes: 90
+  update_minutes: 90
+  delete_minutes: 90
+mutex: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}
+async:
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 90
+      update_minutes: 90
+      delete_minutes: 90
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+autogen_status: R2RhT2JzZXJ2YWJpbGl0eVNldHRpbmdCaW5kaW5nQXV0b2dlblYyQWdlbnQ=
+autogen_async: true
+samples:
+  - name: gemini_gda_observability_setting_binding_basic
+    primary_resource_id: example
+    exclude_test: true
+    steps:
+      - name: gemini_gda_observability_setting_binding_basic
+        resource_id_vars:
+          gda_observability_setting_id: ls-tf1
+          setting_binding_id: ls-tf1b1
+          target: projects/980109375338
+        test_vars_overrides:
+          target: '"projects/980109375338" + randomSuffix'
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: gdaObservabilitySettingId
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: settingBindingId
+    type: String
+    description: Id of the setting binding.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: product
+    type: String
+    description: Product type of the setting binding. Values include GEMINI_IN_LOOKER. See [product reference](https://cloud.google.com/gemini/docs/api/reference/rest/v1/projects.locations.gdaObservabilitySettings.settingBindings) for a complete list.
+    default_from_api: true
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/gdaObservabilitySettings/{setting}/settingBindings/{setting_binding}
+    output: true
+  - name: createTime
+    type: String
+    description: Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Update time stamp.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key value pairs.
+  - name: target
+    type: String
+    description: Target of the binding.
+    required: true

--- a/mmv1/products/gemini/GdaObservabilitySettingBinding.yaml
+++ b/mmv1/products/gemini/GdaObservabilitySettingBinding.yaml
@@ -60,9 +60,7 @@ samples:
         resource_id_vars:
           gda_observability_setting_id: ls-tf1
           setting_binding_id: ls-tf1b1
-          target: projects/980109375338
-        test_vars_overrides:
-          target: '"projects/980109375338" + randomSuffix'
+          target: projects/1234567890
 parameters:
   - name: location
     type: String

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gda_observability_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gda_observability_setting_basic.tf.tmpl
@@ -1,0 +1,4 @@
+resource "google_gemini_gda_observability_setting" "{{$.PrimaryResourceId}}" {
+    gda_observability_setting_id = "{{index $.ResourceIdVars "gda_observability_setting_id"}}"
+    location = "global"
+}

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gda_observability_setting_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gda_observability_setting_binding_basic.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_gemini_gda_observability_setting" "basic" {
+    gda_observability_setting_id = "{{index $.ResourceIdVars "gda_observability_setting_id"}}"
+    location = "global"
+    labels = {"my_key": "my_value"}
+    conversational_analytics_setting {
+        logging_enabled = true
+        traces_enabled = true
+        metrics_enabled = true
+        feedback_enabled = true
+    }
+}
+
+resource "google_gemini_gda_observability_setting_binding" "{{$.PrimaryResourceId}}" {
+    gda_observability_setting_id = google_gemini_gda_observability_setting.basic.gda_observability_setting_id
+    setting_binding_id = "{{index $.ResourceIdVars "setting_binding_id"}}"
+    location = "global"
+    target = "{{index $.ResourceIdVars "target"}}"
+}

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gda_observability_setting_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gda_observability_setting_full.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_gemini_gda_observability_setting" "{{$.PrimaryResourceId}}" {
+    gda_observability_setting_id = "{{index $.ResourceIdVars "gda_observability_setting_id"}}"
+    location = "global"
+    labels = {"initial_key": "initial_value"}
+    conversational_analytics_setting {
+        feedback_enabled = false
+        logging_enabled = false
+        metrics_enabled = false
+        traces_enabled = false
+    }
+}

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gda_observability_setting_full_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gda_observability_setting_full_update.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_gemini_gda_observability_setting" "{{$.PrimaryResourceId}}" {
+    gda_observability_setting_id = "{{index $.ResourceIdVars "gda_observability_setting_id"}}"
+    location = "global"
+    labels = {"updated_key": "updated_value"}
+    conversational_analytics_setting {
+        feedback_enabled = true
+        logging_enabled = true
+        metrics_enabled = true
+        traces_enabled = true
+    }
+}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_gda_observability_setting_binding_test.go
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_gda_observability_setting_binding_test.go
@@ -1,0 +1,106 @@
+package gemini_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/gemini"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+)
+
+func TestAccGeminiGdaObservabilitySettingBinding_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"gda_observability_setting_id": fmt.Sprintf("tf-test-ls-%s", acctest.RandString(t, 10)),
+		"setting_binding_id":           fmt.Sprintf("tf-test-lsb-%s", acctest.RandString(t, 10)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiGdaObservabilitySettingBinding_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_gda_observability_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "gda_observability_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiGdaObservabilitySettingBinding_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_gda_observability_setting_binding.basic_binding", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_gda_observability_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "gda_observability_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccGeminiGdaObservabilitySettingBinding_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
+resource "google_gemini_gda_observability_setting" "basic" {
+    gda_observability_setting_id = "%{gda_observability_setting_id}"
+    location = "global"
+    labels = {"my_key" = "my_value"}
+    conversational_analytics_setting {
+        logging_enabled = true
+        traces_enabled = true
+        metrics_enabled = true
+        feedback_enabled = true
+    }
+}
+
+resource "google_gemini_gda_observability_setting_binding" "basic_binding" {
+    gda_observability_setting_id = google_gemini_gda_observability_setting.basic.gda_observability_setting_id
+    setting_binding_id = "%{setting_binding_id}"
+    location = "global"
+    target = "projects/${data.google_project.project.number}"
+}
+`, context)
+}
+
+func testAccGeminiGdaObservabilitySettingBinding_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
+resource "google_gemini_gda_observability_setting" "basic" {
+    gda_observability_setting_id = "%{gda_observability_setting_id}"
+    location = "global"
+    labels = {"my_key" = "my_value"}
+    conversational_analytics_setting {
+        logging_enabled = false
+        traces_enabled = false
+        metrics_enabled = false
+        feedback_enabled = false
+    }
+}
+
+resource "google_gemini_gda_observability_setting_binding" "basic_binding" {
+    gda_observability_setting_id = google_gemini_gda_observability_setting.basic.gda_observability_setting_id
+    setting_binding_id = "%{setting_binding_id}"
+    location = "global"
+    target = "projects/${data.google_project.project.number}"
+    labels = {"my_key" = "my_value"}
+    product = "GEMINI_IN_LOOKER"
+}
+`, context)
+}


### PR DESCRIPTION
Adds Terraform support for `google_gemini_gda_observability_setting` and `google_gemini_gda_observability_setting_binding` resources in the Gemini service.

Issue: https://b.corp.google.com/issues/545260555

```release-note:new-resource
`google_gemini_gda_observability_setting`
```
```release-note:new-resource
`google_gemini_gda_observability_setting_binding`
```
