### PR TITLE
Fixed filestore sweeper to cover a missed location and to ensure deletion protection disabled

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -33,11 +33,15 @@ timeouts:
   delete_minutes: 120
 sweeper:
   url_substitutions:
-    - region: us-central1-b
+    - location: us-central1-b
     - zone: us-central1-b
-    - region: us-central1
-    - region: us-east1
-    - region: us-west1
+    - location: us-central1
+    - location: us-east1
+    - location: us-west1
+    - location: me-west1-b
+  ensure_value:
+    field: deletionProtectionEnabled
+    value: false
 async:
   type: OpAsync
   operation:


### PR DESCRIPTION
Ran this manually locally to clean up leaked resources in nightly test environments.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
