### PR TITLE
gemini: add google_gemini_gibq_observability_setting and binding

### DIFF
--- a/mmv1/products/gemini/GibqObservabilitySetting.yaml
+++ b/mmv1/products/gemini/GibqObservabilitySetting.yaml
@@ -1,0 +1,86 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GibqObservabilitySetting
+description: A setting that controls observability features for Gemini in BigQuery.
+references:
+  guides:
+    Gemini in BigQuery overview: https://cloud.google.com/gemini/docs/bigquery/overview
+  api: https://cloud.google.com/gemini/docs/reference/rest/v1/projects.locations.gibqObservabilitySettings
+base_url: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings
+self_link: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings/{{gibq_observability_setting_id}}
+create_url: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings?gibqObservabilitySettingId={{gibq_observability_setting_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/{{location}}/gibqObservabilitySettings/{{gibq_observability_setting_id}}
+autogen_status: R2licU9ic2VydmFiaWxpdHlTZXR0aW5nQXV0b2dlblYyQWdlbnQ=
+autogen_async: false
+samples:
+  - name: gemini_gibq_observability_setting_basic
+    primary_resource_id: example
+    steps:
+      - name: gemini_gibq_observability_setting_basic
+        resource_id_vars:
+          gibq_observability_setting_id: ls-tf1
+      - name: gemini_gibq_observability_setting_basic_update
+        resource_id_vars:
+          gibq_observability_setting_id: ls-tf1
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: gibqObservabilitySettingId
+    type: String
+    description: Id of the requesting object.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: conversationalAnalyticsSetting
+    type: NestedObject
+    allow_empty_object: true
+    description: Settings for Conversational Analytics, which can be used to enable observability features.
+    properties:
+      - name: metricsEnabled
+        type: Boolean
+        description: Whether to enable metrics.
+      - name: tracesEnabled
+        type: Boolean
+        description: Whether to enable traces.
+      - name: feedbackEnabled
+        type: Boolean
+        description: Whether to enable feedback.
+      - name: loggingEnabled
+        type: Boolean
+        description: Whether to enable logging.
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key value pairs.
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/gibqObservabilitySettings/{gibq_observability_setting}
+    output: true
+  - name: createTime
+    type: String
+    description: Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Update time stamp.
+    output: true

--- a/mmv1/products/gemini/GibqObservabilitySetting.yaml
+++ b/mmv1/products/gemini/GibqObservabilitySetting.yaml
@@ -53,6 +53,7 @@ properties:
   - name: conversationalAnalyticsSetting
     type: NestedObject
     allow_empty_object: true
+    send_empty_value: true
     description: Settings for Conversational Analytics, which can be used to enable observability features.
     properties:
       - name: metricsEnabled

--- a/mmv1/products/gemini/GibqObservabilitySettingBinding.yaml
+++ b/mmv1/products/gemini/GibqObservabilitySettingBinding.yaml
@@ -53,6 +53,7 @@ autogen_async: true
 samples:
   - name: gemini_gibq_observability_setting_binding_basic
     primary_resource_id: example
+    exclude_test: true
     steps:
       - name: gemini_gibq_observability_setting_binding_basic
         resource_id_vars:

--- a/mmv1/products/gemini/GibqObservabilitySettingBinding.yaml
+++ b/mmv1/products/gemini/GibqObservabilitySettingBinding.yaml
@@ -1,0 +1,108 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GibqObservabilitySettingBinding
+api_resource_type_kind: SettingBinding
+api_variant_patterns:
+  - projects/{project}/locations/{location}/gibqObservabilitySettings/{gibqObservabilitySetting}/settingBindings/{settingBinding}
+description: The resource for managing GibqObservabilitySetting setting bindings for Admin Control.
+references:
+  guides:
+    Gemini Cloud Assist overview: https://cloud.google.com/gemini/docs/cloud-assist/overview
+base_url: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings/{{gibq_observability_setting_id}}/settingBindings
+self_link: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings/{{gibq_observability_setting_id}}/settingBindings/{{setting_binding_id}}
+create_url: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings/{{gibq_observability_setting_id}}/settingBindings?settingBindingId={{setting_binding_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings/{{gibq_observability_setting_id}}/settingBindings/{{setting_binding_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/gibqObservabilitySettings/{{gibq_observability_setting_id}}/settingBindings/{{setting_binding_id}}
+timeouts:
+  insert_minutes: 90
+  update_minutes: 90
+  delete_minutes: 90
+mutex: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings/{{gibq_observability_setting_id}}
+async:
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 90
+      update_minutes: 90
+      delete_minutes: 90
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+autogen_status: U2V0dGluZ0JpbmRpbmdCeVByb2plY3RBbmRMb2NhdGlvbkFuZEdpYnFvYnNlcnZhYmlsaXR5c2V0dGluZ0F1dG9nZW5WMkFnZW50
+autogen_async: true
+samples:
+  - name: gemini_gibq_observability_setting_binding_basic
+    primary_resource_id: example
+    steps:
+      - name: gemini_gibq_observability_setting_binding_basic
+        resource_id_vars:
+          gibq_observability_setting_id: ls-tf1
+          setting_binding_id: ls-tf1b1
+      - name: gemini_gibq_observability_setting_binding_basic_update
+        resource_id_vars:
+          gibq_observability_setting_id: ls-tf1
+          setting_binding_id: ls-tf1b1
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: gibqObservabilitySettingId
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: settingBindingId
+    type: String
+    description: Id of the setting binding.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key value pairs.
+  - name: target
+    type: String
+    description: Target of the binding.
+    required: true
+  - name: product
+    type: String
+    description: Product type of the setting binding. Values include GEMINI_IN_BIGQUERY, GEMINI_CLOUD_ASSIST, etc. See [product reference](https://cloud.google.com/gemini/docs/api/reference/rest/v1/projects.locations.gibqObservabilitySettings.settingBindings) for a complete list.
+    default_from_api: true
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/gibqObservabilitySettings/{setting}/settingBindings/{setting_binding}
+    output: true
+  - name: createTime
+    type: String
+    description: Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Update time stamp.
+    output: true

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gibq_observability_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gibq_observability_setting_basic.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_gemini_gibq_observability_setting" "{{$.PrimaryResourceId}}" {
+    gibq_observability_setting_id = "{{index $.ResourceIdVars "gibq_observability_setting_id"}}"
+    location = "global"
+    labels = {"my_key": "my_value"}
+    conversational_analytics_setting {
+        metrics_enabled = true
+        traces_enabled = true
+        feedback_enabled = true
+        logging_enabled = true
+    }
+}

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gibq_observability_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gibq_observability_setting_basic.tf.tmpl
@@ -2,10 +2,5 @@ resource "google_gemini_gibq_observability_setting" "{{$.PrimaryResourceId}}" {
     gibq_observability_setting_id = "{{index $.ResourceIdVars "gibq_observability_setting_id"}}"
     location = "global"
     labels = {"my_key": "my_value"}
-    conversational_analytics_setting {
-        metrics_enabled = true
-        traces_enabled = true
-        feedback_enabled = true
-        logging_enabled = true
-    }
+    conversational_analytics_setting {}
 }

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gibq_observability_setting_basic_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gibq_observability_setting_basic_update.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_gemini_gibq_observability_setting" "{{$.PrimaryResourceId}}" {
+    gibq_observability_setting_id = "{{index $.ResourceIdVars "gibq_observability_setting_id"}}"
+    location = "global"
+    labels = {"my_key": "my_value_updated"}
+    conversational_analytics_setting {
+        metrics_enabled = false
+        traces_enabled = false
+        feedback_enabled = false
+        logging_enabled = false
+    }
+}

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gibq_observability_setting_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gibq_observability_setting_binding_basic.tf.tmpl
@@ -1,0 +1,21 @@
+data "google_project" "project" {
+}
+
+resource "google_gemini_gibq_observability_setting" "basic" {
+    gibq_observability_setting_id = "{{index $.ResourceIdVars "gibq_observability_setting_id"}}"
+    location = "global"
+    labels = {"my_key": "my_value"}
+    conversational_analytics_setting {
+      metrics_enabled = true
+      traces_enabled = true
+      feedback_enabled = true
+      logging_enabled = true
+    }
+}
+
+resource "google_gemini_gibq_observability_setting_binding" "{{$.PrimaryResourceId}}" {
+    gibq_observability_setting_id = google_gemini_gibq_observability_setting.basic.gibq_observability_setting_id
+    setting_binding_id = "{{index $.ResourceIdVars "setting_binding_id"}}"
+    location = "global"
+    target = "projects/${data.google_project.project.number}"
+}

--- a/mmv1/templates/terraform/samples/services/gemini/gemini_gibq_observability_setting_binding_basic_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gemini/gemini_gibq_observability_setting_binding_basic_update.tf.tmpl
@@ -1,0 +1,23 @@
+data "google_project" "project" {
+}
+
+resource "google_gemini_gibq_observability_setting" "basic" {
+    gibq_observability_setting_id = "{{index $.ResourceIdVars "gibq_observability_setting_id"}}"
+    location = "global"
+    labels = {"my_key": "my_value"}
+    conversational_analytics_setting {
+      metrics_enabled = false
+      traces_enabled = false
+      feedback_enabled = false
+      logging_enabled = false
+    }
+}
+
+resource "google_gemini_gibq_observability_setting_binding" "{{$.PrimaryResourceId}}" {
+    gibq_observability_setting_id = google_gemini_gibq_observability_setting.basic.gibq_observability_setting_id
+    setting_binding_id = "{{index $.ResourceIdVars "setting_binding_id"}}"
+    location = "global"
+    target = "projects/${data.google_project.project.number}"
+    labels = {"my_key": "my_value"}
+    product = "GEMINI_IN_BIGQUERY"
+}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_gibq_observability_setting_binding_test.go
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_gibq_observability_setting_binding_test.go
@@ -1,0 +1,106 @@
+package gemini_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/gemini"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+)
+
+func TestAccGeminiGibqObservabilitySettingBinding_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"gibq_observability_setting_id": fmt.Sprintf("tf-test-gibq-%s", acctest.RandString(t, 10)),
+		"setting_binding_id":            fmt.Sprintf("tf-test-gibqb-%s", acctest.RandString(t, 10)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiGibqObservabilitySettingBinding_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_gibq_observability_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "gibq_observability_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiGibqObservabilitySettingBinding_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_gibq_observability_setting_binding.basic_binding", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_gibq_observability_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "gibq_observability_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccGeminiGibqObservabilitySettingBinding_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
+resource "google_gemini_gibq_observability_setting" "basic" {
+    gibq_observability_setting_id = "%{gibq_observability_setting_id}"
+    location = "global"
+    labels = {"my_key": "my_value"}
+    conversational_analytics_setting {
+      metrics_enabled = true
+      traces_enabled = true
+      feedback_enabled = true
+      logging_enabled = true
+    }
+}
+
+resource "google_gemini_gibq_observability_setting_binding" "basic_binding" {
+    gibq_observability_setting_id = google_gemini_gibq_observability_setting.basic.gibq_observability_setting_id
+    setting_binding_id = "%{setting_binding_id}"
+    location = "global"
+    target = "projects/${data.google_project.project.number}"
+}
+`, context)
+}
+
+func testAccGeminiGibqObservabilitySettingBinding_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
+resource "google_gemini_gibq_observability_setting" "basic" {
+    gibq_observability_setting_id = "%{gibq_observability_setting_id}"
+    location = "global"
+    labels = {"my_key" = "my_value"}
+    conversational_analytics_setting {
+      metrics_enabled = false
+      traces_enabled = false
+      feedback_enabled = false
+      logging_enabled = false
+    }
+}
+
+resource "google_gemini_gibq_observability_setting_binding" "basic_binding" {
+    gibq_observability_setting_id = google_gemini_gibq_observability_setting.basic.gibq_observability_setting_id
+    setting_binding_id = "%{setting_binding_id}"
+    location = "global"
+    target = "projects/${data.google_project.project.number}"
+    labels = {"my_key" = "my_value"}
+    product = "GEMINI_IN_BIGQUERY"
+}
+`, context)
+}


### PR DESCRIPTION
Adds Terraform support for `GibqObservabilitySetting` (`google_gemini_gibq_observability_setting`) and `GibqObservabilitySettingBinding` (`google_gemini_gibq_observability_setting_binding`).

Fixes https://b.corp.google.com/issues/545261447

```release-note:new-resource
`google_gemini_gibq_observability_setting`
```
```release-note:new-resource
`google_gemini_gibq_observability_setting_binding`
```
