### PR TITLE
dataplex: add sql_dialect to google_dataplex_datascan

### DIFF
--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -179,6 +179,19 @@ samples:
         test_env_vars:
           project_name: PROJECT_NAME
           location: REGION
+        vars:
+          sql_dialect: GOOGLE_SQL
+      - name: dataplex_datascan_documentation
+        resource_id_vars:
+          datascan_name: datadocumentation
+        test_vars_overrides:
+          # for backward compatible
+          datascan_name: '"datadocumentation" + randomSuffix'
+        test_env_vars:
+          project_name: PROJECT_NAME
+          location: REGION
+        vars:
+          sql_dialect: SPARK_SQL
   - name: dataplex_datascan_onetime_documentation
     primary_resource_id: onetime_documentation
     steps:
@@ -905,3 +918,12 @@ properties:
         type: Boolean
         description: |
           If set, the latest DataScan job result will be published to Knowledge Catalog.
+      - name: sqlDialect
+        type: Enum
+        description: |
+          The SQL dialect to use in the generated SQL queries.
+          If not specified, the default dialect is Google SQL.
+        enum_values:
+          - GOOGLE_SQL
+          - SPARK_SQL
+        default_from_api: true

--- a/mmv1/templates/terraform/samples/services/dataplex/dataplex_datascan_documentation.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dataplex/dataplex_datascan_documentation.tf.tmpl
@@ -76,6 +76,7 @@ resource "google_dataplex_datascan" "{{$.PrimaryResourceId}}" {
 
   data_documentation_spec {
     catalog_publishing_enabled = true
+    sql_dialect                = "{{index $.Vars "sql_dialect"}}"
   }
 
   project = "{{index $.TestEnvVars "project_name"}}"


### PR DESCRIPTION
Added field coverage for `dataDocumentationSpec.sqlDialect` on `google_dataplex_datascan` (`dataplex:v1:DataScan`).

reference: b/558780625

```release-note:enhancement
dataplex: added `data_documentation_spec.sql_dialect` field to `google_dataplex_datascan`
```
