### PR TITLE
Fix Developer Connect insights config basic test missing apphub viewe…

### DIFF
--- a/mmv1/templates/terraform/samples/services/developerconnect/developer_connect_insights_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/developerconnect/developer_connect_insights_config_basic.tf.tmpl
@@ -83,10 +83,18 @@ resource "google_project_service" "devconnect_api" {
 }
 
 # Wait delay after enabling APIs and granting permissions
+resource "google_project_iam_member" "devconnect_apphub_viewer" {
+  project = google_project.project.project_id
+  role    = "roles/apphub.viewer"
+  member  = "serviceAccount:service-${google_project.project.number}@gcp-sa-devconnect.iam.gserviceaccount.com"
+  depends_on = [google_project_service.devconnect_api]
+}
+
 resource "time_sleep" "wait_for_propagation" {
   depends_on = [
     google_project_iam_member.apphub_permissions,
     google_project_iam_member.insights_agent,
+    google_project_iam_member.devconnect_apphub_viewer,
     google_project_service.apphub_api_service,
     google_project_service.containeranalysis_api,
     google_project_service.containerscanning_api,


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/29124

Missing permission error. This PR adds a google_project_iam_member block to grant the roles/apphub.viewer before resource creation.

```release-note:none

```