### PR TITLE
container: update beta APIs in TestAccContainerCluster_withEnableKubernetesBetaAPIs

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -13531,10 +13531,8 @@ resource "google_container_cluster" "primary" {
   # if the test is broken.
   enable_k8s_beta_apis {
     enabled_apis = [
-	  "resource.k8s.io/v1beta1/deviceclasses",
-	  "resource.k8s.io/v1beta1/resourceclaims",
-	  "resource.k8s.io/v1beta1/resourceclaimtemplates",
-	  "resource.k8s.io/v1beta1/resourceslices"
+	  "networking.k8s.io/v1beta1/servicecidrs",
+	  "storage.k8s.io/v1beta1/volumeattributesclasses"
 	]
   }
   network    = "%s"


### PR DESCRIPTION
Update `TestAccContainerCluster_withEnableKubernetesBetaAPIs` to use `networking.k8s.io/v1beta1/servicecidrs` and `storage.k8s.io/v1beta1/volumeattributesclasses`.

The previous beta APIs (`resource.k8s.io/v1beta1/deviceclasses`, `resource.k8s.io/v1beta1/resourceclaims`, etc.) graduated to GA in Kubernetes 1.34 and have been removed in newer Kubernetes versions, causing post-test teardown/validation failures on recent GKE releases.

```release-note:none
```