### PR TITLE
parametermanager: add data_crc32c to google_parameter_manager_parameter_version and regional

### DIFF
--- a/mmv1/products/parametermanager/ParameterVersion.yaml
+++ b/mmv1/products/parametermanager/ParameterVersion.yaml
@@ -103,6 +103,16 @@ samples:
           data: '"./test-fixtures/parameter_data_yaml_format.yaml"'
           # for backward compatible
           parameter_id: '"parameter" + randomSuffix'
+  - name: parameter_version_with_data_crc32c
+    primary_resource_id: parameter-version-with-data-crc32c
+    steps:
+      - name: parameter_version_with_data_crc32c
+        resource_id_vars:
+          parameter_id: parameter
+          parameter_version_id: parameter_version
+        test_vars_overrides:
+          # for backward compatible
+          parameter_id: '"parameter" + randomSuffix'
 parameters:
   - name: parameter
     type: ResourceRef
@@ -159,6 +169,12 @@ properties:
         immutable: true
         sensitive: true
         custom_expand: templates/terraform/custom_expand/base64.go.tmpl
+      - name: dataCrc32c
+        type: String
+        description: |
+          The integrity checksum of the payload.
+        immutable: true
+        default_from_api: true
   - name: kmsKeyVersion
     type: String
     output: true

--- a/mmv1/products/parametermanagerregional/RegionalParameterVersion.yaml
+++ b/mmv1/products/parametermanagerregional/RegionalParameterVersion.yaml
@@ -91,6 +91,13 @@ samples:
           data: regional-parameter-yaml-data.yaml
         test_vars_overrides:
           data: '"./test-fixtures/regional_parameter_data_yaml_format.yaml"'
+  - name: regional_parameter_version_with_data_crc32c
+    primary_resource_id: regional-parameter-version-with-data-crc32c
+    steps:
+      - name: regional_parameter_version_with_data_crc32c
+        resource_id_vars:
+          parameter_id: regional_parameter
+          parameter_version_id: regional_parameter_version
 parameters:
   - name: parameter
     type: ResourceRef
@@ -153,6 +160,12 @@ properties:
         immutable: true
         sensitive: true
         custom_expand: templates/terraform/custom_expand/base64.go.tmpl
+      - name: dataCrc32c
+        type: String
+        description: |
+          The integrity checksum of the payload.
+        immutable: true
+        default_from_api: true
   - name: kmsKeyVersion
     type: String
     output: true

--- a/mmv1/templates/terraform/custom_flatten/parameter_version_parameter_data.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/parameter_version_parameter_data.go.tmpl
@@ -24,5 +24,8 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 		return err
 	}
 	transformed["parameter_data"] = string(data)
+	if val, ok := original["dataCrc32c"]; ok && val != nil {
+		transformed["data_crc32c"] = fmt.Sprintf("%v", val)
+	}
 	return []interface{}{transformed}
 }

--- a/mmv1/templates/terraform/samples/services/parametermanager/parameter_version_with_data_crc32c.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanager/parameter_version_with_data_crc32c.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_parameter_manager_parameter" "parameter-basic" {
+  parameter_id = "{{index $.ResourceIdVars "parameter_id"}}"
+}
+
+resource "google_parameter_manager_parameter_version" "{{$.PrimaryResourceId}}" {
+  parameter = google_parameter_manager_parameter.parameter-basic.id
+  parameter_version_id = "{{index $.ResourceIdVars "parameter_version_id"}}"
+  parameter_data = "app-parameter-version-data"
+  data_crc32c = "3931523681"
+}

--- a/mmv1/templates/terraform/samples/services/parametermanagerregional/regional_parameter_version_with_data_crc32c.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/parametermanagerregional/regional_parameter_version_with_data_crc32c.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
+  parameter_id = "{{index $.ResourceIdVars "parameter_id"}}"
+  location = "us-central1"
+}
+
+resource "google_parameter_manager_regional_parameter_version" "{{$.PrimaryResourceId}}" {
+  parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
+  parameter_version_id = "{{index $.ResourceIdVars "parameter_version_id"}}"
+  parameter_data = "regional-parameter-version-data"
+  data_crc32c = "4019737965"
+}

--- a/mmv1/third_party/terraform/services/parametermanager/resource_parameter_manager_parameter_version_test.go
+++ b/mmv1/third_party/terraform/services/parametermanager/resource_parameter_manager_parameter_version_test.go
@@ -22,6 +22,9 @@ func TestAccParameterManagerParameterVersion_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterManagerParameterVersion_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_parameter_manager_parameter_version.parameter-version-update", "data_crc32c", "1083866889"),
+				),
 			},
 			{
 				ResourceName:            "google_parameter_manager_parameter_version.parameter-version-update",
@@ -31,6 +34,21 @@ func TestAccParameterManagerParameterVersion_update(t *testing.T) {
 			},
 			{
 				Config: testAccParameterManagerParameterVersion_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_parameter_manager_parameter_version.parameter-version-update", "data_crc32c", "1083866889"),
+				),
+			},
+			{
+				ResourceName:            "google_parameter_manager_parameter_version.parameter-version-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameter", "parameter_version_id", "data_crc32c"},
+			},
+			{
+				Config: testAccParameterManagerParameterVersion_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_parameter_manager_parameter_version.parameter-version-update", "data_crc32c", "1083866889"),
+				),
 			},
 			{
 				ResourceName:            "google_parameter_manager_parameter_version.parameter-version-update",
@@ -38,11 +56,30 @@ func TestAccParameterManagerParameterVersion_update(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"parameter", "parameter_version_id"},
 			},
+		},
+	})
+}
+
+func TestAccParameterManagerParameterVersion_dataCrc32c(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckParameterManagerParameterVersionDestroyProducer(t),
+		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterManagerParameterVersion_basic(context),
+				Config: testAccParameterManagerParameterVersion_dataCrc32c(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_parameter_manager_parameter_version.parameter-version-crc32c", "data_crc32c", "1083866889"),
+				),
 			},
 			{
-				ResourceName:            "google_parameter_manager_parameter_version.parameter-version-update",
+				ResourceName:            "google_parameter_manager_parameter_version.parameter-version-crc32c",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"parameter", "parameter_version_id"},
@@ -76,6 +113,21 @@ resource "google_parameter_manager_parameter_version" "parameter-version-update"
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = "parameter-version-data"
   disabled = true
+}
+`, context)
+}
+
+func testAccParameterManagerParameterVersion_dataCrc32c(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_parameter_manager_parameter" "parameter-crc32c" {
+  parameter_id = "tf_test_parameter%{random_suffix}"
+}
+
+resource "google_parameter_manager_parameter_version" "parameter-version-crc32c" {
+  parameter = google_parameter_manager_parameter.parameter-crc32c.id
+  parameter_version_id = "tf_test_parameter_version%{random_suffix}"
+  parameter_data = "parameter-version-data"
+  data_crc32c = "1083866889"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/parametermanagerregional/resource_parameter_manager_regional_parameter_version_test.go
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/resource_parameter_manager_regional_parameter_version_test.go
@@ -22,6 +22,9 @@ func TestAccParameterManagerRegionalRegionalParameterVersion_update(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterManagerRegionalRegionalParameterVersion_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_parameter_manager_regional_parameter_version.regional-parameter-version-update", "data_crc32c", "4019737965"),
+				),
 			},
 			{
 				ResourceName:            "google_parameter_manager_regional_parameter_version.regional-parameter-version-update",
@@ -31,6 +34,21 @@ func TestAccParameterManagerRegionalRegionalParameterVersion_update(t *testing.T
 			},
 			{
 				Config: testAccParameterManagerRegionalRegionalParameterVersion_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_parameter_manager_regional_parameter_version.regional-parameter-version-update", "data_crc32c", "4019737965"),
+				),
+			},
+			{
+				ResourceName:            "google_parameter_manager_regional_parameter_version.regional-parameter-version-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parameter", "parameter_version_id", "data_crc32c"},
+			},
+			{
+				Config: testAccParameterManagerRegionalRegionalParameterVersion_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_parameter_manager_regional_parameter_version.regional-parameter-version-update", "data_crc32c", "4019737965"),
+				),
 			},
 			{
 				ResourceName:            "google_parameter_manager_regional_parameter_version.regional-parameter-version-update",
@@ -38,11 +56,30 @@ func TestAccParameterManagerRegionalRegionalParameterVersion_update(t *testing.T
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"parameter", "parameter_version_id"},
 			},
+		},
+	})
+}
+
+func TestAccParameterManagerRegionalRegionalParameterVersion_dataCrc32c(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterVersionDestroyProducer(t),
+		Steps: []resource.TestStep{
 			{
-				Config: testAccParameterManagerRegionalRegionalParameterVersion_basic(context),
+				Config: testAccParameterManagerRegionalRegionalParameterVersion_dataCrc32c(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_parameter_manager_regional_parameter_version.regional-parameter-version-crc32c", "data_crc32c", "4019737965"),
+				),
 			},
 			{
-				ResourceName:            "google_parameter_manager_regional_parameter_version.regional-parameter-version-update",
+				ResourceName:            "google_parameter_manager_regional_parameter_version.regional-parameter-version-crc32c",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"parameter", "parameter_version_id"},
@@ -78,6 +115,22 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
   parameter_version_id = "tf_test_regional_parameter_version%{random_suffix}"
   parameter_data = "regional-parameter-version-data"
   disabled = true
+}
+`, context)
+}
+
+func testAccParameterManagerRegionalRegionalParameterVersion_dataCrc32c(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_parameter_manager_regional_parameter" "regional-parameter-crc32c" {
+  parameter_id = "tf_test_regional_parameter%{random_suffix}"
+  location = "us-central1"
+}
+
+resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-crc32c" {
+  parameter = google_parameter_manager_regional_parameter.regional-parameter-crc32c.id
+  parameter_version_id = "tf_test_regional_parameter_version%{random_suffix}"
+  parameter_data = "regional-parameter-version-data"
+  data_crc32c = "4019737965"
 }
 `, context)
 }


### PR DESCRIPTION
Reapplies #18940 (reverted in #18968) with regional parameter version support.

The original PR #18940 added `data_crc32c` to `google_parameter_manager_parameter_version` and updated the shared flattener template `parameter_version_parameter_data.go.tmpl`, but did not add the field to `google_parameter_manager_regional_parameter_version`. When regional parameter versions were read, setting the unmapped `data_crc32c` in the resource schema caused tests to panic.

This PR adds `data_crc32c` to both `google_parameter_manager_parameter_version` and `google_parameter_manager_regional_parameter_version`, and includes acceptance tests for both resources.

reference: b/559022023

```release-note:enhancement
parametermanager: added `data_crc32c` field to `google_parameter_manager_parameter_version` and `google_parameter_manager_regional_parameter_version`
```