### PR TITLE
biglakehive: fix IAM policy endpoints for Hive catalog, database, and table

### DIFF
--- a/mmv1/products/biglakehive/HiveCatalog.yaml
+++ b/mmv1/products/biglakehive/HiveCatalog.yaml
@@ -34,7 +34,7 @@ iam_policy:
   fetch_iam_policy_verb: GET
   allowed_iam_role: roles/biglake.editor
   parent_resource_attribute: name
-  base_url: v1/projects/{{project}}/catalogs/{{name}}
+  base_url: hive/v1/projects/{{project}}/catalogs/{{name}}
   import_format:
     - projects/{{project}}/catalogs/{{name}}
     - '{{name}}'

--- a/mmv1/products/biglakehive/HiveDatabase.yaml
+++ b/mmv1/products/biglakehive/HiveDatabase.yaml
@@ -35,9 +35,9 @@ iam_policy:
   allowed_iam_role: roles/biglake.editor
   parent_resource_attribute: name
   sample_config_body: templates/terraform/iam/example_config_body/biglake_hive_database.tf.tmpl
-  base_url: v1/projects/{{project}}/catalogs/{{catalog}}/namespaces/{{name}}
+  base_url: hive/v1/projects/{{project}}/catalogs/{{catalog}}/databases/{{name}}
   import_format:
-    - projects/{{project}}/catalogs/{{catalog}}/namespaces/{{name}}
+    - projects/{{project}}/catalogs/{{catalog}}/databases/{{name}}
     - '{{name}}'
 samples:
   - name: 'biglake_hive_database'

--- a/mmv1/products/biglakehive/HiveTable.yaml
+++ b/mmv1/products/biglakehive/HiveTable.yaml
@@ -31,9 +31,9 @@ iam_policy:
   allowed_iam_role: 'roles/biglake.editor'
   parent_resource_attribute: 'name'
   sample_config_body: 'templates/terraform/iam/example_config_body/biglake_hive_table.tf.tmpl'
-  base_url: 'v1/projects/{{project}}/catalogs/{{catalog}}/namespaces/{{database}}/tables/{{name}}'
+  base_url: 'hive/v1/projects/{{project}}/catalogs/{{catalog}}/databases/{{database}}/tables/{{name}}'
   import_format:
-    - 'projects/{{project}}/catalogs/{{catalog}}/namespaces/{{database}}/tables/{{name}}'
+    - 'projects/{{project}}/catalogs/{{catalog}}/databases/{{database}}/tables/{{name}}'
     - '{{name}}'
 samples:
   - name: 'biglake_hive_table'


### PR DESCRIPTION
Fixes acceptance tests for `biglakehive` IAM resources (`TestAccBiglakeHiveHiveCatalogIamBindingGenerated`, `TestAccBiglakeHiveHiveDatabaseIamBindingGenerated`, `TestAccBiglakeHiveHiveTableIamBindingGenerated`, etc.).

### Root Cause & Fix
The `biglakehive` IAM policies (`HiveCatalog`, `HiveDatabase`, and `HiveTable`) were using endpoints inherited from Iceberg Catalogs:
1. `HiveCatalog` used `base_url: v1/projects/{{project}}/catalogs/{{name}}` instead of `hive/v1/projects/{{project}}/catalogs/{{name}}`. This caused the BigLake API to reject IAM retrieval with a 400 error: `googleapi: Error 400: Catalog ... is not an Iceberg Catalog.`
2. `HiveDatabase` and `HiveTable` IAM policies incorrectly referenced `namespaces` instead of `databases` in `base_url` and `import_format`, and omitted the `hive/` prefix (`hive/v1/...`). BigLake Iceberg uses `namespaces`, whereas BigLake Hive uses `databases`.

This PR updates `base_url` and `import_format` across `mmv1/products/biglakehive/HiveCatalog.yaml`, `HiveDatabase.yaml`, and `HiveTable.yaml` to point to the correct `hive/v1/...` routes and database paths.

```release-note:bug
biglake: fixed incorrect API endpoints and database paths used for `google_biglake_hive_*` IAM resources
```