### PR TITLE
Send 0 values for client_ttl and default_ttl in backend service

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -777,6 +777,7 @@ properties:
           Specifies the default TTL for cached content served by this origin for responses
           that do not have an existing valid TTL (max-age or s-max-age).
         default_from_api: true
+        send_empty_value: true
       - name: 'maxTtl'
         type: Integer
         description: |
@@ -787,6 +788,7 @@ properties:
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        send_empty_value: true
       - name: 'negativeCaching'
         type: Boolean
         description: |

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -770,6 +770,7 @@ properties:
           Specifies the default TTL for cached content served by this origin for responses
           that do not have an existing valid TTL (max-age or s-max-age).
         default_from_api: true
+        send_empty_value: true
       - name: 'maxTtl'
         type: Integer
         description: |
@@ -780,6 +781,7 @@ properties:
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        send_empty_value: true
       - name: 'negativeCaching'
         type: Boolean
         description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -450,6 +450,45 @@ func TestAccComputeBackendService_withCdnPolicy(t *testing.T) {
 	})
 }
 
+func TestAccComputeBackendService_cdnPolicyZeroTtl(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withCdnPolicyZeroTtl(serviceName, checkName, 0, 0),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withCdnPolicyZeroTtl(serviceName, checkName, 3600, 1800),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withCdnPolicyZeroTtl(serviceName, checkName, 0, 0),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeBackendService_withSecurityPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -2064,6 +2103,29 @@ resource "google_compute_http_health_check" "zero" {
   timeout_sec        = 1
 }
 `, serviceName, checkName)
+}
+
+func testAccComputeBackendService_withCdnPolicyZeroTtl(serviceName, checkName string, clientTtl, defaultTtl int) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+  enable_cdn    = true
+
+  cdn_policy {
+    cache_mode  = "CACHE_ALL_STATIC"
+    client_ttl  = %d
+    default_ttl = %d
+  }
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, clientTtl, defaultTtl, checkName)
 }
 
 func testAccComputeBackendService_withSecurityPolicy(serviceName, checkName, polName, edgePolName, polLink string, edgePolLink string) string {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Send 0 values for `cdn_policy.client_ttl` and `cdn_policy.default_ttl` in `google_compute_backend_service` and `google_compute_region_backend_service`. Previously, configuring a TTL of 0 caused the attribute to be omitted, resulting in API server defaults and a permanent plan diff.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/29102

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed a permanent diff in `google_compute_backend_service` and `google_compute_region_backend_service` when `cdn_policy.client_ttl` or `cdn_policy.default_ttl` is set to 0
```
