### PR TITLE
Added `sweeper.wait_for_delete` for debugging purposes

### DIFF
--- a/mmv1/api/resource/sweeper.go
+++ b/mmv1/api/resource/sweeper.go
@@ -79,6 +79,11 @@ type Sweeper struct {
 	// updating it if necessary before attempting deletion. See the EnsureValue
 	// struct for configuration details.
 	EnsureValue *EnsureValue `yaml:"ensure_value,omitempty"`
+
+	// WaitForDelete specifies that the sweeper should actually wait for a delete
+	// operation to finish. For efficiency, this isn't the default behavior, but
+	// it can be useful when debugging.
+	WaitForDelete bool `yaml:"wait_for_delete,omitempty"`
 }
 
 // EnsureValue specifies a field and value that must be set before a resource can be deleted.

--- a/mmv1/products/compute/NetworkAttachment.yaml
+++ b/mmv1/products/compute/NetworkAttachment.yaml
@@ -64,6 +64,10 @@ samples:
           network_name: 'basic-network'
           subnetwork_name: 'basic-subnetwork'
           instance_name: 'basic-instance'
+sweeper:
+  url_substitutions:
+    - region: us-east1
+    - region: us-central1
 parameters:
   - name: 'name'
     type: String

--- a/mmv1/templates/terraform/sweeper_file.go.tmpl
+++ b/mmv1/templates/terraform/sweeper_file.go.tmpl
@@ -16,7 +16,7 @@ import (
 {{- end }}
 	"strings"
 	"testing"
-{{- if $.Sweeper.EnsureValue }}
+{{- if or $.Sweeper.EnsureValue $.Sweeper.WaitForDelete }}
 	"time"
 {{- end }}
 
@@ -499,8 +499,12 @@ func deleteResource{{ $.ResourceName }}(config *transport_tpg.Config, d *tpgreso
 	url = url + "{{ $.Sweeper.QueryString }}"
 	{{- end }}
 
+	{{ if $.Sweeper.WaitForDelete -}}
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	{{- else -}}
 	// Don't wait on operations as we may have a lot to delete
 	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	{{- end }}
 		Config:    config,
 		Method:    "DELETE",
 		Project:   config.Project,
@@ -513,6 +517,14 @@ func deleteResource{{ $.ResourceName }}(config *transport_tpg.Config, d *tpgreso
 	} else {
 		log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
 	}
+	{{- if $.Sweeper.WaitForDelete }}
+	err = {{ $.ClientNamePascal }}OperationWaitTime(
+		config, res, config.Project, "Deleting Network", config.UserAgent,
+		time.Minute*5)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] Error waiting for deletion of %s resource (%s): %s", resourceName, name, err)
+	}
+	{{- end }}
 
 	return deletionerror
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This is useful to have as a flag - I used it to debug why some networks / subnetworks couldn't be deleted.

Also, added sweeper regions for networkattachment

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
