### PR TITLE
dialogflow: add tool_call_info to google_dialogflow_generator

### DIFF
--- a/mmv1/products/dialogflow/Generator.yaml
+++ b/mmv1/products/dialogflow/Generator.yaml
@@ -167,6 +167,49 @@ properties:
                             required: true
                             description: |
                               Required. Summary text for the section.
+                - name: toolCallInfo
+                  type: Array
+                  description: |
+                    Optional. List of request and response for tool calls executed.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: toolCall
+                        type: NestedObject
+                        description: |
+                          Optional. Request for a tool call.
+                        properties:
+                          - name: tool
+                            type: String
+                            description: |
+                              Optional. The tool associated with this call.
+                          - name: action
+                            type: String
+                            description: |
+                              Optional. The name of the tool's action associated with this call.
+                      - name: toolCallResult
+                        type: NestedObject
+                        description: |
+                          Optional. Response for a tool call.
+                        properties:
+                          - name: action
+                            type: String
+                            description: |
+                              Optional. The name of the tool's action associated with this call.
+                          - name: error
+                            type: NestedObject
+                            description: |
+                              Optional. An error produced by the tool call.
+                            properties:
+                              - name: message
+                                type: String
+                                description: |
+                                  Optional. The error message of the function.
+                              - name: retryable
+                                type: Boolean
+                                send_empty_value: true
+                                description: |
+                                  Optional. Specifies whether the tool call is retryable.
             - name: summarizationSectionList
               type: NestedObject
               description: |

--- a/mmv1/third_party/terraform/services/dialogflow/resource_dialogflow_generator_test.go
+++ b/mmv1/third_party/terraform/services/dialogflow/resource_dialogflow_generator_test.go
@@ -112,6 +112,19 @@ resource "google_dialogflow_generator" "summarization_generator" {
             summary = "John"
           }
         }
+        tool_call_info {
+          tool_call {
+            tool   = "projects/example-project/locations/global/tools/initial-tool"
+            action = "initialAction"
+          }
+          tool_call_result {
+            action = "initialAction"
+            error {
+              message   = "test error"
+              retryable = true
+            }
+          }
+        }
       }
       summarization_section_list {
         summarization_sections {
@@ -170,6 +183,19 @@ resource "google_dialogflow_generator" "summarization_generator" {
           summary_sections {
             section = "Redaction"
             summary = "Jeff"
+          }
+        }
+        tool_call_info {
+          tool_call {
+            tool   = "projects/example-project/locations/global/tools/updated-tool"
+            action = "updatedAction"
+          }
+          tool_call_result {
+            action = "updatedAction"
+            error {
+              message   = "updated error"
+              retryable = false
+            }
           }
         }
       }


### PR DESCRIPTION
Added field coverage for `summarizationContext.fewShotExamples.output.toolCallInfo` on `google_dialogflow_generator` (`dialogflow:v2:Generator`).

reference: b/558780404

```release-note:enhancement
dialogflow: added `summarization_context.few_shot_examples.output.tool_call_info` field to `google_dialogflow_generator`
```
