### PR TITLE
Updated to gemini-3.5-flash in vertex AI reasoning engine tests

### DIFF
--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
@@ -11,7 +11,7 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
   context_spec {
     memory_bank_config {
       generation_config {
-        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-2.5-flash"
+        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-3.5-flash"
         generation_trigger_config {
           generation_rule {
             idle_duration       = "300s"

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_granular_ttl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_granular_ttl.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
   context_spec {
     memory_bank_config {
       generation_config {
-        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-2.5-flash"
+        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-3.5-flash"
       }
       similarity_search_config {
         embedding_model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_reasoning_engine_test.go.tmpl
@@ -857,7 +857,7 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
   context_spec {
     memory_bank_config {
       generation_config {
-        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-2.5-flash"
+        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-3.5-flash"
         generation_trigger_config {
           generation_rule {
             fixed_interval = "600s"
@@ -885,7 +885,7 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
   context_spec {
     memory_bank_config {
       generation_config {
-        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-2.5-flash"
+        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-3.5-flash"
         generation_trigger_config {
           generation_rule {
             event_count         = 10
@@ -946,7 +946,7 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
   context_spec {
     memory_bank_config {
       generation_config {
-        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-2.5-flash"
+        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-3.5-flash"
       }
       similarity_search_config {
         embedding_model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"
@@ -1072,7 +1072,7 @@ resource "google_vertex_ai_reasoning_engine" "primary" {
   context_spec {
     memory_bank_config {
       generation_config {
-        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-2.5-flash"
+        model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/gemini-3.5-flash"
       }
       similarity_search_config {
         embedding_model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"
@@ -1728,7 +1728,7 @@ resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
         adk_config {
           json_config = jsonencode({
             name        = "finance_analyst_agent"
-            model       = "gemini-2.5-flash"
+            model       = "gemini-3.5-flash"
             description = "A financial analyst that can look up stock values and return them as tables."
             instruction = "You are a financial analyst. Output data in tables."
           })
@@ -1760,7 +1760,7 @@ resource "google_vertex_ai_reasoning_engine" "reasoning_engine" {
         adk_config {
           json_config = jsonencode({
             name        = "finance_analyst_agent_updated"
-            model       = "gemini-2.5-flash"
+            model       = "gemini-3.5-flash"
             description = "An updated financial analyst agent."
             instruction = "You are an updated financial analyst."
           })


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This should fix some vertex AI test failures (like TestAccVertexAIReasoningEngine_memoryGenerationTriggerUpdate):

```
Error creating ReasoningEngine: googleapi: Error 400: Gemini 2.5 models are not supported. Use `gemini-3.5-flash` instead.
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
