### PR TITLE
redis: move acceptance tests and samples to us-west1

### DIFF
--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -108,6 +108,7 @@ timeouts:
 sweeper:
   url_substitutions:
     - region: us-central1
+    - region: us-west1
     - region: us-east1
     - region: europe-west1
   ensure_value:
@@ -236,7 +237,7 @@ samples:
           deletion_protection_enabled: "true"
         test_vars_overrides:
           deletion_protection_enabled: "false"
-          kms_key_name: kms.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name
+          kms_key_name: kms.BootstrapKMSKeyInLocation(t, "us-west1").CryptoKey.Name
         oics_vars_overrides:
           deletion_protection_enabled: "false"
   - name: redis_cluster_flexible_ca

--- a/mmv1/products/redis/ClusterAclPolicy.yaml
+++ b/mmv1/products/redis/ClusterAclPolicy.yaml
@@ -23,6 +23,10 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/aclPolicies/{{acl_policy_id}}
+sweeper:
+  url_substitutions:
+    - region: us-central1
+    - region: us-west1
 async:
   actions: []
 parameters:

--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -30,6 +30,10 @@ timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+sweeper:
+  url_substitutions:
+    - region: us-central1
+    - region: us-west1
 custom_diff:
   - customdiff.ForceNewIfChange("redis_version", isRedisVersionDecreasing)
   - tpgresource.DefaultProviderProject

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_aof.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_aof.tf.tmpl
@@ -4,7 +4,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
-  region = "us-central1"
+  region = "us-west1"
   replica_count = 0
   node_type = "REDIS_SHARED_CORE_NANO"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_DISABLED"
@@ -40,7 +40,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name = "{{index $.ResourceIdVars "policy_name"}}"
-  location = "us-central1"
+  location = "us-west1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
   network = google_compute_network.consumer_net.id
@@ -52,7 +52,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_cmek.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
     network = google_compute_network.consumer_net.id
   }
   kms_key = "{{index $.ResourceIdVars "kms_key_name"}}"
-  region = "us-central1"
+  region = "us-west1"
   deletion_protection_enabled = {{index $.ResourceIdVars "deletion_protection_enabled"}}
   depends_on = [
     google_network_connectivity_service_connection_policy.default
@@ -18,7 +18,7 @@ data "google_project" "project" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name = "{{index $.ResourceIdVars "policy_name"}}"
-  location = "us-central1"
+  location = "us-west1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
   network = google_compute_network.consumer_net.id
@@ -30,7 +30,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_flexible_ca.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_flexible_ca.tf.tmpl
@@ -1,7 +1,7 @@
 resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.ResourceIdVars "cluster_name"}}"
   shard_count    = 3
-  region         = "us-central1"
+  region         = "us-west1"
   
   psc_configs {
     network = google_compute_network.consumer_net.id
@@ -22,14 +22,14 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
 
 resource "google_privateca_ca_pool" "default" {
   name     = "{{index $.ResourceIdVars "ca_pool_name"}}"
-  location = "us-central1"
+  location = "us-west1"
   tier     = "ENTERPRISE"
 }
 
 resource "google_privateca_certificate_authority" "default" {
   pool                     = google_privateca_ca_pool.default.name
   certificate_authority_id = "{{index $.ResourceIdVars "ca_auth_id"}}"
-  location                 = "us-central1"
+  location                 = "us-west1"
   config {
     subject_config {
       subject {
@@ -64,7 +64,7 @@ resource "google_privateca_certificate_authority" "default" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name           = "{{index $.ResourceIdVars "policy_name"}}"
-  location       = "us-central1"
+  location       = "us-west1"
   service_class  = "gcp-memorystore-redis"
   network        = google_compute_network.consumer_net.id
   psc_config {
@@ -75,7 +75,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_ha.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_ha.tf.tmpl
@@ -4,7 +4,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
-  region = "us-central1"
+  region = "us-west1"
   replica_count = 1
   node_type = "REDIS_SHARED_CORE_NANO"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_DISABLED"
@@ -35,7 +35,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name = "{{index $.ResourceIdVars "policy_name"}}"
-  location = "us-central1"
+  location = "us-west1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
   network = google_compute_network.consumer_net.id
@@ -47,7 +47,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_ha_single_zone.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_ha_single_zone.tf.tmpl
@@ -4,10 +4,10 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
-  region = "us-central1"
+  region = "us-west1"
   zone_distribution_config {
     mode = "SINGLE_ZONE"
-    zone = "us-central1-f"
+    zone = "us-west1-a"
   }
   maintenance_policy {
     weekly_maintenance_window {
@@ -29,7 +29,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name = "{{index $.ResourceIdVars "policy_name"}}"
-  location = "us-central1"
+  location = "us-west1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
   network = google_compute_network.consumer_net.id
@@ -41,7 +41,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_ha_with_labels.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_ha_with_labels.tf.tmpl
@@ -8,7 +8,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
-  region = "us-central1"
+  region = "us-west1"
   replica_count = 1
   node_type = "REDIS_SHARED_CORE_NANO"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_DISABLED"
@@ -39,7 +39,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name = "{{index $.ResourceIdVars "policy_name"}}"
-  location = "us-central1"
+  location = "us-west1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
   network = google_compute_network.consumer_net.id
@@ -51,7 +51,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_rdb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_rdb.tf.tmpl
@@ -4,7 +4,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
-  region = "us-central1"
+  region = "us-west1"
   replica_count = 0
   node_type = "REDIS_SHARED_CORE_NANO"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_DISABLED"
@@ -42,7 +42,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name = "{{index $.ResourceIdVars "policy_name"}}"
-  location = "us-central1"
+  location = "us-west1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
   network = google_compute_network.consumer_net.id
@@ -54,7 +54,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_secondary.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_secondary.tf.tmpl
@@ -1,7 +1,7 @@
 // Primary cluster
 resource "google_redis_cluster" "primary_cluster" {
   name          = "{{index $.ResourceIdVars "primary_cluster_name"}}"
-  region        = "us-east1"
+  region        = "us-west1"
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
@@ -110,7 +110,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "primary_cluster_region_scp" {
   name = "{{index $.ResourceIdVars "primary_cluster_policy_name"}}"
-  location = "us-east1"
+  location = "us-west1"
   service_class = "gcp-memorystore-redis"
   description   = "Primary cluster service connection policy"
   network = google_compute_network.consumer_net.id
@@ -122,7 +122,7 @@ resource "google_network_connectivity_service_connection_policy" "primary_cluste
 resource "google_compute_subnetwork" "primary_cluster_consumer_subnet" {
   name          = "{{index $.ResourceIdVars "primary_cluster_subnet_name"}}"
   ip_cidr_range = "10.0.1.0/29"
-  region        = "us-east1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_user_and_auto_created_connections.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_user_and_auto_created_connections.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_redis_cluster_user_created_connections" "{{$.PrimaryResourceId}}" {
   name = "{{index $.ResourceIdVars "cluster_name"}}"
-  region = "us-central1"
+  region = "us-west1"
   cluster_endpoints {
     connections {
       psc_connection {
@@ -25,7 +25,7 @@ resource "google_redis_cluster_user_created_connections" "{{$.PrimaryResourceId}
 
 resource "google_compute_forwarding_rule" "forwarding_rule1_network2" {
   name                   = "{{index $.ResourceIdVars "forwarding_rule1_network2_name"}}"
-  region                 = "us-central1"
+  region                 = "us-west1"
   ip_address             = google_compute_address.ip1_network2.id
   load_balancing_scheme  = ""
   network                = google_compute_network.network2.id
@@ -34,7 +34,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule1_network2" {
 
 resource "google_compute_forwarding_rule" "forwarding_rule2_network2" {
   name                   = "{{index $.ResourceIdVars "forwarding_rule2_network2_name"}}"
-  region                 = "us-central1"
+  region                 = "us-west1"
   ip_address             = google_compute_address.ip2_network2.id
   load_balancing_scheme  = ""
   network                = google_compute_network.network2.id
@@ -43,7 +43,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule2_network2" {
 
 resource "google_compute_address" "ip1_network2" {
   name         = "{{index $.ResourceIdVars "ip1_network2_name"}}"
-  region       = "us-central1"
+  region       = "us-west1"
   subnetwork   = google_compute_subnetwork.subnet_network2.id
   address_type = "INTERNAL"
   purpose      = "GCE_ENDPOINT"
@@ -51,7 +51,7 @@ resource "google_compute_address" "ip1_network2" {
 
 resource "google_compute_address" "ip2_network2" {
   name         = "{{index $.ResourceIdVars "ip2_network2_name"}}"
-  region       = "us-central1"
+  region       = "us-west1"
   subnetwork   = google_compute_subnetwork.subnet_network2.id
   address_type = "INTERNAL"
   purpose      = "GCE_ENDPOINT"
@@ -60,7 +60,7 @@ resource "google_compute_address" "ip2_network2" {
 resource "google_compute_subnetwork" "subnet_network2" {
   name          = "{{index $.ResourceIdVars "subnet_network2_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.network2.id
 }
 
@@ -73,7 +73,7 @@ resource "google_compute_network" "network2" {
 resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.ResourceIdVars "cluster_name"}}"
   shard_count    = 3
-  region = "us-central1"
+  region = "us-west1"
   replica_count = 0
   deletion_protection_enabled = false
   psc_configs {
@@ -86,7 +86,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name = "{{index $.ResourceIdVars "policy_name"}}"
-  location = "us-central1"
+  location = "us-west1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
   network = google_compute_network.network1.id
@@ -98,7 +98,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "subnet_network1" {
   name          = "{{index $.ResourceIdVars "subnet_network1_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.network1.id
 }
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_cluster_user_created_connections.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_cluster_user_created_connections.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_redis_cluster_user_created_connections" "{{$.PrimaryResourceId}}" {
   name = "{{index $.ResourceIdVars "cluster_name"}}"
-  region = "us-central1"
+  region = "us-west1"
   cluster_endpoints {
     connections {
       psc_connection {
@@ -46,7 +46,7 @@ resource "google_redis_cluster_user_created_connections" "{{$.PrimaryResourceId}
 
 resource "google_compute_forwarding_rule" "forwarding_rule1_network1" {
   name                   = "{{index $.ResourceIdVars "forwarding_rule1_network1_name"}}"
-  region                 = "us-central1"
+  region                 = "us-west1"
   ip_address             = google_compute_address.ip1_network1.id
   load_balancing_scheme  = ""
   network                = google_compute_network.network1.id
@@ -55,7 +55,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule1_network1" {
 
 resource "google_compute_forwarding_rule" "forwarding_rule2_network1" {
   name                   = "{{index $.ResourceIdVars "forwarding_rule2_network1_name"}}"
-  region                 = "us-central1"
+  region                 = "us-west1"
   ip_address             = google_compute_address.ip2_network1.id
   load_balancing_scheme  = ""
   network                = google_compute_network.network1.id
@@ -64,7 +64,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule2_network1" {
 
 resource "google_compute_address" "ip1_network1" {
   name         = "{{index $.ResourceIdVars "ip1_network1_name"}}"
-  region       = "us-central1"
+  region       = "us-west1"
   subnetwork   = google_compute_subnetwork.subnet_network1.id
   address_type = "INTERNAL"
   purpose      = "GCE_ENDPOINT"
@@ -72,7 +72,7 @@ resource "google_compute_address" "ip1_network1" {
 
 resource "google_compute_address" "ip2_network1" {
   name         = "{{index $.ResourceIdVars "ip2_network1_name"}}"
-  region       = "us-central1"
+  region       = "us-west1"
   subnetwork   = google_compute_subnetwork.subnet_network1.id
   address_type = "INTERNAL"
   purpose      = "GCE_ENDPOINT"
@@ -81,7 +81,7 @@ resource "google_compute_address" "ip2_network1" {
 resource "google_compute_subnetwork" "subnet_network1" {
   name          = "{{index $.ResourceIdVars "subnet_network1_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.network1.id
 }
 
@@ -92,7 +92,7 @@ resource "google_compute_network" "network1" {
 
 resource "google_compute_forwarding_rule" "forwarding_rule1_network2" {
   name                   = "{{index $.ResourceIdVars "forwarding_rule1_network2_name"}}"
-  region                 = "us-central1"
+  region                 = "us-west1"
   ip_address             = google_compute_address.ip1_network2.id
   load_balancing_scheme  = ""
   network                = google_compute_network.network2.id
@@ -101,7 +101,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule1_network2" {
 
 resource "google_compute_forwarding_rule" "forwarding_rule2_network2" {
   name                   = "{{index $.ResourceIdVars "forwarding_rule2_network2_name"}}"
-  region                 = "us-central1"
+  region                 = "us-west1"
   ip_address             = google_compute_address.ip2_network2.id
   load_balancing_scheme  = ""
   network                = google_compute_network.network2.id
@@ -110,7 +110,7 @@ resource "google_compute_forwarding_rule" "forwarding_rule2_network2" {
 
 resource "google_compute_address" "ip1_network2" {
   name         = "{{index $.ResourceIdVars "ip1_network2_name"}}"
-  region       = "us-central1"
+  region       = "us-west1"
   subnetwork   = google_compute_subnetwork.subnet_network2.id
   address_type = "INTERNAL"
   purpose      = "GCE_ENDPOINT"
@@ -118,7 +118,7 @@ resource "google_compute_address" "ip1_network2" {
 
 resource "google_compute_address" "ip2_network2" {
   name         = "{{index $.ResourceIdVars "ip2_network2_name"}}"
-  region       = "us-central1"
+  region       = "us-west1"
   subnetwork   = google_compute_subnetwork.subnet_network2.id
   address_type = "INTERNAL"
   purpose      = "GCE_ENDPOINT"
@@ -127,7 +127,7 @@ resource "google_compute_address" "ip2_network2" {
 resource "google_compute_subnetwork" "subnet_network2" {
   name          = "{{index $.ResourceIdVars "subnet_network2_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.network2.id
 }
 
@@ -140,7 +140,7 @@ resource "google_compute_network" "network2" {
 resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.ResourceIdVars "cluster_name"}}"
   shard_count    = 3
-  region = "us-central1"
+  region = "us-west1"
   replica_count = 0
   deletion_protection_enabled = false
 }

--- a/mmv1/templates/terraform/samples/services/redis/redis_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_instance_basic.tf.tmpl
@@ -1,6 +1,7 @@
 resource "google_redis_instance" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.ResourceIdVars "instance_name"}}"
   memory_size_gb = 1
+  region         = "us-west1"
   deletion_protection = false
 
   lifecycle {

--- a/mmv1/templates/terraform/samples/services/redis/redis_instance_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_instance_cmek.tf.tmpl
@@ -2,9 +2,10 @@ resource "google_redis_instance" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.ResourceIdVars "instance_name"}}"
   tier           = "STANDARD_HA"
   memory_size_gb = 1
+  region         = "us-west1"
 
-  location_id             = "us-central1-a"
-  alternative_location_id = "us-central1-f"
+  location_id             = "us-west1-a"
+  alternative_location_id = "us-west1-b"
 
   authorized_network = data.google_compute_network.redis-network.id
 
@@ -24,7 +25,7 @@ resource "google_redis_instance" "{{$.PrimaryResourceId}}" {
 
 resource "google_kms_key_ring" "redis_keyring" {
   name     = "redis-keyring"
-  location = "us-central1"
+  location = "us-west1"
 }
 
 resource "google_kms_crypto_key" "redis_key" {

--- a/mmv1/templates/terraform/samples/services/redis/redis_instance_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_instance_full.tf.tmpl
@@ -2,9 +2,10 @@ resource "google_redis_instance" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.ResourceIdVars "instance_name"}}"
   tier           = "STANDARD_HA"
   memory_size_gb = 1
+  region         = "us-west1"
 
-  location_id             = "us-central1-a"
-  alternative_location_id = "us-central1-f"
+  location_id             = "us-west1-a"
+  alternative_location_id = "us-west1-b"
 
   authorized_network = data.google_compute_network.redis-network.id
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_instance_full_with_persistence_config.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_instance_full_with_persistence_config.tf.tmpl
@@ -2,8 +2,9 @@ resource "google_redis_instance" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.ResourceIdVars "instance_name"}}"
   tier           = "STANDARD_HA"
   memory_size_gb = 1
-  location_id             = "us-central1-a"
-  alternative_location_id = "us-central1-f"
+  region                  = "us-west1"
+  location_id             = "us-west1-a"
+  alternative_location_id = "us-west1-b"
 
   persistence_config {
     persistence_mode = "RDB"

--- a/mmv1/templates/terraform/samples/services/redis/redis_instance_mrr.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_instance_mrr.tf.tmpl
@@ -3,8 +3,9 @@ resource "google_redis_instance" "{{$.PrimaryResourceId}}" {
   tier           = "STANDARD_HA"
   memory_size_gb = 5
 
-  location_id             = "us-central1-a"
-  alternative_location_id = "us-central1-f"
+  region                  = "us-west1"
+  location_id             = "us-west1-a"
+  alternative_location_id = "us-west1-b"
 
   authorized_network = data.google_compute_network.redis-network.id
 

--- a/mmv1/templates/terraform/samples/services/redis/redis_instance_private_service.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_instance_private_service.tf.tmpl
@@ -29,8 +29,9 @@ resource "google_redis_instance" "{{$.PrimaryResourceId}}" {
   tier           = "STANDARD_HA"
   memory_size_gb = 1
 
-  location_id             = "us-central1-a"
-  alternative_location_id = "us-central1-f"
+  region                  = "us-west1"
+  location_id             = "us-west1-a"
+  alternative_location_id = "us-west1-b"
 
   authorized_network = google_compute_network.redis-network.id
   connect_mode       = "PRIVATE_SERVICE_ACCESS"

--- a/mmv1/templates/terraform/samples/services/redis/redis_instance_private_service_test.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/redis/redis_instance_private_service_test.tf.tmpl
@@ -15,8 +15,9 @@ resource "google_redis_instance" "{{$.PrimaryResourceId}}" {
   tier           = "STANDARD_HA"
   memory_size_gb = 1
 
-  location_id             = "us-central1-a"
-  alternative_location_id = "us-central1-f"
+  region                  = "us-west1"
+  location_id             = "us-west1-a"
+  alternative_location_id = "us-west1-b"
 
   authorized_network = data.google_compute_network.redis-network.id
   connect_mode       = "PRIVATE_SERVICE_ACCESS"

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_acl_policy_test.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_acl_policy_test.go
@@ -32,7 +32,7 @@ func testAccRedisClusterAclPolicyDatasourceConfig(context map[string]interface{}
 	return acctest.Nprintf(`
 resource "google_redis_cluster_acl_policy" "test" {
   acl_policy_id               = "tf-test-policy-%{random_suffix}"
-  location                    = "europe-west4"
+  location                    = "us-west1"
   rules {
     rule                      = "on allkeys +get"
     username                  = "default"
@@ -41,7 +41,7 @@ resource "google_redis_cluster_acl_policy" "test" {
 
 data "google_redis_cluster_acl_policy" "default" {
   acl_policy_id               = google_redis_cluster_acl_policy.test.acl_policy_id
-  location                    = "europe-west4"
+  location                    = "us-west1"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_test.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_test.go
@@ -34,14 +34,14 @@ func testAccRedisClusterDatasourceConfig(context map[string]interface{}) string 
 resource "google_redis_cluster" "cluster" {
   name                           = "tf-test-redis-cluster-%{random_suffix}"
   shard_count                    = 1
-  region                         = "us-central1"
+  region                         = "us-west1"
   deletion_protection_enabled    = false 
   
 }   
 
 data "google_redis_cluster" "default" {
   name   = google_redis_cluster.cluster.name
-  region = "us-central1"
+  region = "us-west1"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_instance_test.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_instance_test.go
@@ -31,6 +31,7 @@ func testAccRedisInstanceDatasourceConfig(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_redis_instance" "redis" {
   name               = "redis-test-%s"
+  region             = "us-west1"
   memory_size_gb     = 1
 
   labels   = {
@@ -39,7 +40,8 @@ resource "google_redis_instance" "redis" {
 }
 
 data "google_redis_instance" "redis" {
-  name = google_redis_instance.redis.name
+  name   = google_redis_instance.redis.name
+  region = "us-west1"
 }
 `, suffix)
 }

--- a/mmv1/third_party/terraform/services/redis/resource_redis_cluster_acl_policy_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_cluster_acl_policy_test.go
@@ -44,7 +44,7 @@ func testAccRedisClusterAclPolicy_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_redis_cluster_acl_policy" "test" {
   acl_policy_id               = "tf-test-policy-%{random_suffix}"
-  location                    = "europe-west4"
+  location                    = "us-west1"
   rules {
     rule                      = "on allkeys +get"
     username                  = "default"
@@ -57,7 +57,7 @@ func testAccRedisClusterAclPolicy_update(context map[string]interface{}) string 
 	return acctest.Nprintf(`
 resource "google_redis_cluster_acl_policy" "test" {
   acl_policy_id               = "tf-test-policy-%{random_suffix}"
-  location                    = "europe-west4"
+  location                    = "us-west1"
   rules {
     rule                      = "on allkeys +set"
     username                  = "default"
@@ -100,7 +100,7 @@ func testAccRedisClusterAclPolicy_withCluster(context map[string]interface{}) st
 	return acctest.Nprintf(`
 resource "google_redis_cluster_acl_policy" "test" {
   acl_policy_id               = "tf-test-policy-%{random_suffix}"
-  location                    = "europe-west4"
+  location                    = "us-west1"
   rules {
     rule                      = "on allkeys +get"
     username                  = "default"
@@ -110,7 +110,7 @@ resource "google_redis_cluster_acl_policy" "test" {
 resource "google_redis_cluster" "test" {
   name                        = "tf-test-redis-%{random_suffix}"
   shard_count                 = 1
-  region                      = "europe-west4"
+  region                      = "us-west1"
   deletion_protection_enabled = false
 
   acl_policy                  = google_redis_cluster_acl_policy.test.id

--- a/mmv1/third_party/terraform/services/redis/resource_redis_cluster_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_cluster_test.go
@@ -72,7 +72,7 @@ func TestAccRedisCluster_createClusterWithZoneDistribution(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// create cluster with replica count 1
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, deletionProtectionEnabled: false, zoneDistributionMode: "SINGLE_ZONE", zone: "us-central1-b"}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, deletionProtectionEnabled: false, zoneDistributionMode: "SINGLE_ZONE", zone: "us-west1-a"}),
 			},
 			{
 				ResourceName:            "google_redis_cluster.test",
@@ -82,7 +82,7 @@ func TestAccRedisCluster_createClusterWithZoneDistribution(t *testing.T) {
 			},
 			{
 				// clean up the resource
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, deletionProtectionEnabled: false, zoneDistributionMode: "SINGLE_ZONE", zone: "us-central1-b"}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, deletionProtectionEnabled: false, zoneDistributionMode: "SINGLE_ZONE", zone: "us-west1-a"}),
 			},
 		},
 	})
@@ -313,7 +313,7 @@ func testAccRedisCluster_automatedBackupConfig(context map[string]interface{}) s
 resource "google_redis_cluster" "cluster_abc" {
   name                           = "tf-test-redis-abc-%{random_suffix}"
   shard_count                    = 1
-  region                         = "us-central1"
+  region                         = "us-west1"
   deletion_protection_enabled    = false
   automated_backup_config {
    retention                     = "259200s"
@@ -333,7 +333,7 @@ func testAccRedisCluster_automatedBackupConfigWithout(context map[string]interfa
 resource "google_redis_cluster" "cluster_abc" {
   name                           = "tf-test-redis-abc-%{random_suffix}"
   shard_count                    = 1
-  region                         = "us-central1"
+  region                         = "us-west1"
   deletion_protection_enabled    = false 
   
 }   
@@ -382,7 +382,7 @@ func testAccRedisCluster_managedBackupSourceSetup(context map[string]interface{}
 resource "google_redis_cluster" "cluster_mbs_main" {
   name                           = "tf-test-mbs-main-%{random_suffix}"
   shard_count                    = 1
-  region                         = "us-central1"
+  region                         = "us-west1"
   deletion_protection_enabled    = false
 }
 `, context)
@@ -393,14 +393,14 @@ func testAccRedisCluster_managedBackupSourceImport(context map[string]interface{
 resource "google_redis_cluster" "cluster_mbs_main" {
   name                           = "tf-test-mbs-main-%{random_suffix}"
   shard_count                    = 1
-  region                         = "us-central1"
+  region                         = "us-west1"
   deletion_protection_enabled    = false
 }
 
 resource "google_redis_cluster" "cluster_mb_copy" {
   name                           = "tf-test-mbs-copy-%{random_suffix}"
   shard_count                    = 1
-  region                         = "us-central1"
+  region                         = "us-west1"
   deletion_protection_enabled    = false
    managed_backup_source {
     backup                       = join("", [google_redis_cluster.cluster_mbs_main.backup_collection , "/backups/%{back_up}"])
@@ -514,14 +514,14 @@ func testAccRedisCluster_gcsSourceSetup(context map[string]interface{}) string {
 resource "google_redis_cluster" "cluster_gbs_main" {
   name                           = "tf-test-gbs-main-%{random_suffix}"
   shard_count                    = 1
-  region                         = "us-central1"
+  region                         = "us-west1"
   deletion_protection_enabled    = false
 }
 
 # Create a GCS bucket for exporting Redis backups
 resource "google_storage_bucket" "redis_backup_bucket" {
   name                           = "%{gcs_bucket}"
-  location                       = "us-central1"
+  location                       = "us-west1"
   uniform_bucket_level_access    = true
   force_destroy                  = true
 }
@@ -544,14 +544,14 @@ func testAccRedisCluster_gcsSource(context map[string]interface{}) string {
 resource "google_redis_cluster" "cluster_gbs_main" {
   name                            = "tf-test-gbs-main-%{random_suffix}"
   shard_count                     = 1
-  region                          = "us-central1"
+  region                          = "us-west1"
   deletion_protection_enabled     = false
 }
 
 # Reference the bucket created in the setup
 resource "google_storage_bucket" "redis_backup_bucket" {
   name                        	  = "%{gcs_bucket}"
-  location                    	  = "us-central1"
+  location                    	  = "us-west1"
   uniform_bucket_level_access 	  = true
   force_destroy               	  = true
 }
@@ -573,7 +573,7 @@ resource "google_storage_bucket_iam_member" "redis_backup_writer" {
 resource "google_redis_cluster" "cluster_gbs" {
   name                           = "tf-test-gbs-copy-%{random_suffix}"
   shard_count                    = 1
-  region                         = "us-central1"
+  region                         = "us-west1"
   deletion_protection_enabled    = false
   gcs_source {
     uris                         = [join("", ["gs://%{gcs_bucket}/" , data.google_storage_bucket_objects.backup.bucket_objects[0]["name"]])]
@@ -902,7 +902,7 @@ func createRedisClusterEndpointsWithOneUserCreatedConnections(params *ClusterPar
 		resource "google_redis_cluster_user_created_connections" "default" {
 		
 		name = "%s"
-		region = "us-central1"
+		region = "us-west1"
 		cluster_endpoints {
 			connections {
 				psc_connection {
@@ -939,7 +939,7 @@ func createRedisClusterEndpointsWithTwoUserCreatedConnections(params *ClusterPar
 	return fmt.Sprintf(`
 		resource "google_redis_cluster_user_created_connections" "default" {
 		name = "%s"
-		region = "us-central1"
+		region = "us-west1"
 		cluster_endpoints {
 			connections {
 				psc_connection {
@@ -997,7 +997,7 @@ func createRedisClusterUserCreatedConnection1(params *ClusterParams) string {
 	return fmt.Sprintf(`
 		resource "google_compute_forwarding_rule" "forwarding_rule1_network1" {
 		name                   = "%s"
-		region                 = "us-central1"
+		region                 = "us-west1"
 		ip_address             = google_compute_address.ip1_network1.id
 		load_balancing_scheme  = ""
 		network                = google_compute_network.network1.id
@@ -1006,7 +1006,7 @@ func createRedisClusterUserCreatedConnection1(params *ClusterParams) string {
 
 		resource "google_compute_forwarding_rule" "forwarding_rule2_network1" {	
 		name                   = "%s"
-		region                 = "us-central1"
+		region                 = "us-west1"
 		ip_address             = google_compute_address.ip2_network1.id
 		load_balancing_scheme  = ""
 		network                = google_compute_network.network1.id
@@ -1015,7 +1015,7 @@ func createRedisClusterUserCreatedConnection1(params *ClusterParams) string {
 
 		resource "google_compute_address" "ip1_network1" {
 		name         = "%s"
-		region       = "us-central1"
+		region       = "us-west1"
 		subnetwork   = google_compute_subnetwork.subnet_network1.id
 		address_type = "INTERNAL"
 		purpose      = "GCE_ENDPOINT"
@@ -1023,7 +1023,7 @@ func createRedisClusterUserCreatedConnection1(params *ClusterParams) string {
 
 		resource "google_compute_address" "ip2_network1" {
 		name         = "%s"
-		region       = "us-central1"
+		region       = "us-west1"
 		subnetwork   = google_compute_subnetwork.subnet_network1.id
 		address_type = "INTERNAL"
 		purpose      = "GCE_ENDPOINT"
@@ -1032,7 +1032,7 @@ func createRedisClusterUserCreatedConnection1(params *ClusterParams) string {
 		resource "google_compute_subnetwork" "subnet_network1" {
 		name          = "%s"
 		ip_cidr_range = "10.0.0.248/29"
-		region        = "us-central1"
+		region        = "us-west1"
 		network       = google_compute_network.network1.id
 		}
 
@@ -1054,7 +1054,7 @@ func createRedisClusterUserCreatedConnection2(params *ClusterParams) string {
 	return fmt.Sprintf(`
 		resource "google_compute_forwarding_rule" "forwarding_rule1_network2" {
 		name                   = "%s"
-		region                 = "us-central1"
+		region                 = "us-west1"
 		ip_address             = google_compute_address.ip1_network2.id
 		load_balancing_scheme  = ""
 		network                = google_compute_network.network2.id
@@ -1063,7 +1063,7 @@ func createRedisClusterUserCreatedConnection2(params *ClusterParams) string {
 
 		resource "google_compute_forwarding_rule" "forwarding_rule2_network2" {
 		name                   = "%s"
-		region                 = "us-central1"
+		region                 = "us-west1"
 		ip_address             = google_compute_address.ip2_network2.id
 		load_balancing_scheme  = ""
 		network                = google_compute_network.network2.id
@@ -1072,7 +1072,7 @@ func createRedisClusterUserCreatedConnection2(params *ClusterParams) string {
 
 		resource "google_compute_address" "ip1_network2" {
 		name         = "%s"
-		region       = "us-central1"
+		region       = "us-west1"
 		subnetwork   = google_compute_subnetwork.subnet_network2.id
 		address_type = "INTERNAL"
 		purpose      = "GCE_ENDPOINT"
@@ -1080,7 +1080,7 @@ func createRedisClusterUserCreatedConnection2(params *ClusterParams) string {
 
 		resource "google_compute_address" "ip2_network2" {
 		name         = "%s"
-		region       = "us-central1"
+		region       = "us-west1"
 		subnetwork   = google_compute_subnetwork.subnet_network2.id
 		address_type = "INTERNAL"
 		purpose      = "GCE_ENDPOINT"
@@ -1089,7 +1089,7 @@ func createRedisClusterUserCreatedConnection2(params *ClusterParams) string {
 		resource "google_compute_subnetwork" "subnet_network2" {
 		name          = "%s"
 		ip_cidr_range = "10.0.0.248/29"
-		region        = "us-central1"
+		region        = "us-west1"
 		network       = google_compute_network.network2.id
 		}
 
@@ -1123,7 +1123,7 @@ func createOrUpdateRedisCluster(params *ClusterParams) string {
 		%s
 		resource "google_network_connectivity_service_connection_policy" "default" {
 			name = "%s"
-			location = "us-central1"
+			location = "us-west1"
 			service_class = "gcp-memorystore-redis"
 			description   = "my basic service connection policy"
 			network = google_compute_network.producer_net.id
@@ -1135,7 +1135,7 @@ func createOrUpdateRedisCluster(params *ClusterParams) string {
 		resource "google_compute_subnetwork" "producer_subnet" {
 			name          = "%s"
 			ip_cidr_range = "10.0.0.16/28"
-			region        = "us-central1"
+			region        = "us-west1"
 			network       = google_compute_network.producer_net.id
 		}
 
@@ -1227,7 +1227,7 @@ func createRedisClusterResourceConfig(params *ClusterParams, isSecondaryCluster 
 		shard_count = %d
 		node_type = "%s"
 		deletion_protection_enabled = %v
-		region         = "us-central1"
+		region         = "us-west1"
 		psc_configs {
 				network = google_compute_network.producer_net.id
 		}
@@ -1294,7 +1294,7 @@ resource "google_redis_cluster" "cluster-tls" {
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
-  region = "us-central1"
+  region = "us-west1"
   replica_count = 1
   node_type = "REDIS_SHARED_CORE_NANO"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION"
@@ -1325,7 +1325,7 @@ resource "google_redis_cluster" "cluster-tls" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name = "tf-test-my-policy%{random_suffix}"
-  location = "us-central1"
+  location = "us-west1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
   network = google_compute_network.consumer_net.id
@@ -1337,7 +1337,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "tf-test-my-subnet%{random_suffix}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 
@@ -1406,7 +1406,7 @@ resource "google_redis_cluster" "cluster-ha-with-labels" {
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
-  region = "us-central1"
+  region = "us-west1"
   replica_count = 1
   node_type = "REDIS_SHARED_CORE_NANO"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_DISABLED"
@@ -1437,7 +1437,7 @@ resource "google_redis_cluster" "cluster-ha-with-labels" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name = "%{policy_name}"
-  location = "us-central1"
+  location = "us-west1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
   network = google_compute_network.consumer_net.id
@@ -1449,7 +1449,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "%{subnet_name}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 
@@ -1498,7 +1498,7 @@ data "google_project" "project" {}
 # 1. Create the CA Pool
 resource "google_privateca_ca_pool" "default" {
   name     = "tf-test-ca-pool-%{random_suffix}"
-  location = "us-central1"
+  location = "us-west1"
   tier     = "ENTERPRISE"
 }
 
@@ -1506,7 +1506,7 @@ resource "google_privateca_ca_pool" "default" {
 resource "google_privateca_certificate_authority" "default" {
   pool                     = google_privateca_ca_pool.default.name
   certificate_authority_id = "tf-test-ca-%{random_suffix}"
-  location                 = "us-central1"
+  location                 = "us-west1"
   config {
     subject_config {
       subject {
@@ -1547,7 +1547,7 @@ resource "google_privateca_ca_pool_iam_member" "redis_p4sa_requester" {
 # 4. Networking Policy
 resource "google_network_connectivity_service_connection_policy" "default" {
   name          = "tf-test-policy-%{random_suffix}"
-  location      = "us-central1"
+  location      = "us-west1"
   service_class = "gcp-memorystore-redis"
   network       = google_compute_network.consumer_net.id
   psc_config {
@@ -1558,7 +1558,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "tf-test-subnet-%{random_suffix}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.consumer_net.id
 }
 
@@ -1571,7 +1571,7 @@ resource "google_compute_network" "consumer_net" {
 resource "google_redis_cluster" "cluster_cas" {
   name                        = "tf-test-cas-%{random_suffix}"
   shard_count                 = 3
-  region                      = "us-central1"
+  region                      = "us-west1"
   deletion_protection_enabled = false
 
   psc_configs {
@@ -1623,7 +1623,7 @@ func testAccRedisCluster_withAclPolicy(context map[string]interface{}) string {
 resource "google_redis_cluster" "test" {
   name                        = "tf-test-redis-%{random_suffix}"
   shard_count                 = 1
-  region                      = "europe-west4"
+  region                      = "us-west1"
   deletion_protection_enabled = false
   
   acl_policy                  = google_redis_cluster_acl_policy.acl_policy.id
@@ -1631,7 +1631,7 @@ resource "google_redis_cluster" "test" {
 
 resource "google_redis_cluster_acl_policy" "acl_policy" {
   acl_policy_id               = "tf-test-policy-%{random_suffix}"
-  location                    = "europe-west4"
+  location                    = "us-west1"
   rules {
     rule                      = "on allkeys +get"
     username                  = "default"

--- a/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
@@ -129,7 +129,7 @@ resource "google_redis_instance" "test" {
   display_name   = "redissss"
   memory_size_gb = 5
 	tier = "STANDARD_HA"
-  region         = "us-central1"
+  region         = "us-west1"
 	%s
   redis_configs = {
     maxmemory-policy       = "allkeys-lru"
@@ -153,7 +153,7 @@ resource "google_redis_instance" "test" {
   display_name   = "redissss"
   memory_size_gb = 5
   tier = "STANDARD_HA"
-  region         = "us-central1"
+  region         = "us-west1"
 	%s
   redis_configs = {
     maxmemory-policy       = "allkeys-lru"
@@ -179,7 +179,7 @@ resource "google_redis_instance" "test" {
   display_name   = "redissss"
   memory_size_gb = 5
   tier = "STANDARD_HA"
-  region         = "us-central1"
+  region         = "us-west1"
 	%s
   redis_configs = {
     maxmemory-policy       = "allkeys-lru"
@@ -300,7 +300,7 @@ resource "google_redis_instance" "test" {
   name           = "%s"
   display_name   = "pre-update"
   memory_size_gb = 1
-  region         = "us-central1"
+  region         = "us-west1"
 	%s
 
   labels = {
@@ -330,6 +330,7 @@ resource "google_redis_instance" "test" {
   name           = "%s"
   display_name   = "post-update"
   memory_size_gb = 1
+  region         = "us-west1"
 	%s
 
   labels = {
@@ -360,6 +361,7 @@ func testAccRedisInstance_redisInstanceAuthEnabled(context map[string]interface{
 	return acctest.Nprintf(`
 resource "google_redis_instance" "cache" {
   name           = "tf-test-memory-cache%{random_suffix}"
+  region         = "us-west1"
   memory_size_gb = 1
   auth_enabled = true
 }
@@ -370,6 +372,7 @@ func testAccRedisInstance_redisInstanceAuthDisabled(context map[string]interface
 	return acctest.Nprintf(`
 resource "google_redis_instance" "cache" {
   name           = "tf-test-memory-cache%{random_suffix}"
+  region         = "us-west1"
   memory_size_gb = 1
   auth_enabled = false
 }
@@ -382,7 +385,7 @@ resource "google_redis_instance" "test" {
   name           = "%s"
   display_name   = "redissss"
   memory_size_gb = 1
-  region         = "us-central1"
+  region         = "us-west1"
 
   redis_configs = {
     maxmemory-policy       = "allkeys-lru"
@@ -399,7 +402,7 @@ resource "google_redis_instance" "test" {
   name           = "%s"
   display_name   = "redissss"
   memory_size_gb = 1
-  region         = "us-central1"
+  region         = "us-west1"
 
   redis_configs = {
     maxmemory-policy       = "allkeys-lru"
@@ -421,7 +424,7 @@ func TestAccRedisInstance_deletionprotection(t *testing.T) {
 		CheckDestroy:             testAccCheckRedisInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRedisInstance_deletionprotection(name, "us-central1", true),
+				Config: testAccRedisInstance_deletionprotection(name, "us-west1", true),
 			},
 			{
 				ResourceName:            "google_redis_instance.test",
@@ -434,7 +437,7 @@ func TestAccRedisInstance_deletionprotection(t *testing.T) {
 				ExpectError: regexp.MustCompile("deletion_protection"),
 			},
 			{
-				Config: testAccRedisInstance_deletionprotection(name, "us-central1", false),
+				Config: testAccRedisInstance_deletionprotection(name, "us-west1", false),
 			},
 		},
 	})


### PR DESCRIPTION
**Description:**
This PR updates the Magic Modules acceptance tests, samples, and sweepers for the `redis` service to run in `us-west`.

- **Sweepers:**
  - Configured `sweeper.url_substitutions` in `mmv1/products/redis/Instance.yaml` and `mmv1/products/redis/ClusterAclPolicy.yaml` to sweep both `us-central1` and `us-west1`.
  - Added `- region: us-west1` to `Cluster.yaml` sweepers.
- **Samples:**
  - Updated all `redis` samples in `mmv1/templates/terraform/samples/services/redis/` to target `us-west1` (updating `region`, `location`, `location_id`, and `alternative_location_id`).
- **Handwritten Tests:**
  - Updated handwritten acceptance tests and data source tests in `mmv1/third_party/terraform/services/redis/` to target `us-west1`.

**Release Note:**
```release-note:none
```