### PR TITLE
memorystore: move acceptance tests and samples to us-west1

### DIFF
--- a/mmv1/products/memorystore/AclPolicy.yaml
+++ b/mmv1/products/memorystore/AclPolicy.yaml
@@ -22,6 +22,10 @@ update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/aclPolicies/{{acl_policy_id}}
+sweeper:
+  url_substitutions:
+    - region: us-central1
+    - region: us-west1
 parameters:
   - name: location
     type: String

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -79,7 +79,7 @@ samples:
           kms_key_name: my-key
         test_vars_overrides:
           prevent_destroy: "false"
-          kms_key_name: kms.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name
+          kms_key_name: kms.BootstrapKMSKeyInLocation(t, "us-west1").CryptoKey.Name
         ignore_read_extra:
           - update_time
   - name: memorystore_instance_persistence_aof

--- a/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_basic.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
     network    = google_compute_network.producer_net.id
     project_id = data.google_project.project.project_id
   }
-  location                    = "us-central1"
+  location                    = "us-west1"
   deletion_protection_enabled = false
   maintenance_policy {
     weekly_maintenance_window {
@@ -29,7 +29,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name          = "{{index $.ResourceIdVars "policy_name"}}"
-  location      = "us-central1"
+  location      = "us-west1"
   service_class = "gcp-memorystore"
   description   = "my basic service connection policy"
   network       = google_compute_network.producer_net.id
@@ -41,7 +41,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "producer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.producer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_flexible_ca.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_flexible_ca.tf.tmpl
@@ -3,7 +3,7 @@ data "google_project" "project" {}
 resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   instance_id  = "{{index $.ResourceIdVars "instance_name"}}"
   shard_count = 3
-  location     = "us-central1"
+  location     = "us-west1"
   
   desired_auto_created_endpoints {
     network    = google_compute_network.producer_net.id
@@ -26,7 +26,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
 
 resource "google_privateca_ca_pool" "default" {
   name     = "{{index $.ResourceIdVars "ca_pool_name"}}"
-  location = "us-central1"
+  location = "us-west1"
   tier     = "ENTERPRISE"
 }
 
@@ -39,7 +39,7 @@ resource "google_privateca_ca_pool_iam_member" "memorystore_p4sa_requester" {
 resource "google_privateca_certificate_authority" "default" {
   pool                     = google_privateca_ca_pool.default.name
   certificate_authority_id = "{{index $.ResourceIdVars "ca_auth_id"}}"
-  location                 = "us-central1"
+  location                 = "us-west1"
   config {
     subject_config {
       subject {
@@ -73,7 +73,7 @@ resource "google_privateca_certificate_authority" "default" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name           = "{{index $.ResourceIdVars "policy_name"}}"
-  location       = "us-central1"
+  location       = "us-west1"
   service_class  = "gcp-memorystore"
   network        = google_compute_network.producer_net.id
   psc_config {
@@ -84,7 +84,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "producer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.producer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_full.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
     network                    = google_compute_network.producer_net.id
     project_id                 = data.google_project.project.project_id
   }     
-  location                     = "us-central1"
+  location                     = "us-west1"
   replica_count                = 1
   node_type                    = "SHARED_CORE_NANO"
   transit_encryption_mode      = "TRANSIT_ENCRYPTION_DISABLED"
@@ -16,7 +16,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   }
   zone_distribution_config {
     mode                       = "SINGLE_ZONE"
-    zone                       = "us-central1-b"
+    zone                       = "us-west1-b"
   }
   maintenance_policy {
     weekly_maintenance_window {
@@ -53,7 +53,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name          = "{{index $.ResourceIdVars "policy_name"}}"
-  location      = "us-central1"
+  location      = "us-west1"
   service_class = "gcp-memorystore"
   description   = "my basic service connection policy"
   network       = google_compute_network.producer_net.id
@@ -65,7 +65,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "producer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.producer_net.id
 }
 

--- a/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_persistence_aof.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/memorystore/memorystore_instance_persistence_aof.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
     network    = google_compute_network.producer_net.id
     project_id = data.google_project.project.project_id
   }
-  location = "us-central1"
+  location = "us-west1"
   persistence_config {
     mode = "AOF"
     aof_config {
@@ -23,7 +23,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   name          = "{{index $.ResourceIdVars "policy_name"}}"
-  location      = "us-central1"
+  location      = "us-west1"
   service_class = "gcp-memorystore"
   description   = "my basic service connection policy"
   network       = google_compute_network.producer_net.id
@@ -35,7 +35,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "producer_subnet" {
   name          = "{{index $.ResourceIdVars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.producer_net.id
 }
 

--- a/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_acl_policy_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_acl_policy_test.go
@@ -32,7 +32,7 @@ func testAccMemorystoreAclPolicyDatasourceConfig(context map[string]interface{})
 	return acctest.Nprintf(`
 resource "google_memorystore_acl_policy" "test" {
   acl_policy_id               = "tf-test-policy-%{random_suffix}"
-  location                    = "europe-west4"
+  location                    = "us-west1"
   rules {
     rule                      = "on allkeys +get"
     username                  = "default"
@@ -42,7 +42,7 @@ resource "google_memorystore_acl_policy" "test" {
 
 data "google_memorystore_acl_policy" "default" {
   acl_policy_id               = google_memorystore_acl_policy.test.acl_policy_id
-  location                    = "europe-west4"
+  location                    = "us-west1"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance_test.go
@@ -35,13 +35,13 @@ func testAccMemorystoreInstanceDatasourceConfig(context map[string]interface{}) 
 resource "google_memorystore_instance" "instance-basic" {
   instance_id                 = "tf-test-memorystore-instance%{random_suffix}"
   shard_count                 = 1
-  location                    = "us-central1"
+  location                    = "us-west1"
   deletion_protection_enabled = false
 }
 
 data "google_memorystore_instance" "default" {
   instance_id                 = google_memorystore_instance.instance-basic.instance_id
-  location                    = "us-central1"
+  location                    = "us-west1"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_acl_policy_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_acl_policy_test.go
@@ -44,7 +44,7 @@ func testAccMemorystoreAclPolicy_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_memorystore_acl_policy" "test" {
   acl_policy_id               = "tf-test-policy-%{random_suffix}"
-  location                    = "europe-west4"
+  location                    = "us-west1"
   rules {
     rule                      = "on allkeys +get"
     username                  = "default"
@@ -57,7 +57,7 @@ func testAccMemorystoreAclPolicy_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_memorystore_acl_policy" "test" {
   acl_policy_id               = "tf-test-policy-%{random_suffix}"
-  location                    = "europe-west4"
+  location                    = "us-west1"
   rules {
     rule                      = "on allkeys +set"
     username                  = "default"
@@ -71,7 +71,7 @@ func TestAccMemorystoreAclPolicy_withInstance(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"location":      "europe-west4",
+		"location":      "us-west1",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
@@ -103,7 +103,7 @@ func testAccMemorystoreInstance_automatedBackupConfig(context map[string]interfa
 resource "google_memorystore_instance" "test_abc" {
   instance_id                    = "tf-test-instance-abc-%{random_suffix}"
   shard_count                    = 1
-  location                       = "us-central1"
+  location                       = "us-west1"
   replica_count                  = 0
   node_type                      = "SHARED_CORE_NANO"
   deletion_protection_enabled    = false
@@ -124,7 +124,7 @@ resource "google_memorystore_instance" "test_abc" {
 
 resource "google_network_connectivity_service_connection_policy" "primary_policy" {
   name                           = "tf-test-abc-policy-%{random_suffix}"
-  location                       = "us-central1"
+  location                       = "us-west1"
   service_class                  = "gcp-memorystore"
   description                    = "my basic service connection policy"
   network                        = google_compute_network.primary_producer_net.id
@@ -136,7 +136,7 @@ resource "google_network_connectivity_service_connection_policy" "primary_policy
 resource "google_compute_subnetwork" "primary_producer_subnet" {
   name                           = "tf-test-abc-%{random_suffix}"
   ip_cidr_range                  = "10.0.4.0/29"
-  region                         = "us-central1"
+  region                         = "us-west1"
   network                        = google_compute_network.primary_producer_net.id
 }
 
@@ -156,7 +156,7 @@ func testAccMemorystoreInstance_automatedBackupConfigWithout(context map[string]
 resource "google_memorystore_instance" "test_abc" {
   instance_id                    = "tf-test-instance-abc-%{random_suffix}"
   shard_count                    = 1
-  location                       = "us-central1"
+  location                       = "us-west1"
   replica_count                  = 0
   node_type                      = "SHARED_CORE_NANO"
   deletion_protection_enabled    = false
@@ -169,7 +169,7 @@ resource "google_memorystore_instance" "test_abc" {
 
 resource "google_network_connectivity_service_connection_policy" "primary_policy" {
   name                           = "tf-test-abc-policy-%{random_suffix}"
-  location                       = "us-central1"
+  location                       = "us-west1"
   service_class                  = "gcp-memorystore"
   description                    = "my basic service connection policy"
   network                        = google_compute_network.primary_producer_net.id
@@ -181,7 +181,7 @@ resource "google_network_connectivity_service_connection_policy" "primary_policy
 resource "google_compute_subnetwork" "primary_producer_subnet" {
   name                           = "tf-test-abc-%{random_suffix}"
   ip_cidr_range                  = "10.0.4.0/29"
-  region                         = "us-central1"
+  region                         = "us-west1"
   network                        = google_compute_network.primary_producer_net.id
 }
 
@@ -225,7 +225,7 @@ func testAccMemorystoreInstance_deprecatedDesiredPscAutoConnections(context map[
 resource "google_memorystore_instance" "test_abc" {
   instance_id                    = "tf-test-instance-abc-%{random_suffix}"
   shard_count                    = 1
-  location                       = "us-central1"
+  location                       = "us-west1"
   replica_count                  = 0
   node_type                      = "SHARED_CORE_NANO"
   deletion_protection_enabled    = false
@@ -238,7 +238,7 @@ resource "google_memorystore_instance" "test_abc" {
 
 resource "google_network_connectivity_service_connection_policy" "primary_policy" {
   name                           = "tf-test-abc-policy-%{random_suffix}"
-  location                       = "us-central1"
+  location                       = "us-west1"
   service_class                  = "gcp-memorystore"
   description                    = "my basic service connection policy"
   network                        = google_compute_network.primary_producer_net.id
@@ -250,7 +250,7 @@ resource "google_network_connectivity_service_connection_policy" "primary_policy
 resource "google_compute_subnetwork" "primary_producer_subnet" {
   name                           = "tf-test-abc-%{random_suffix}"
   ip_cidr_range                  = "10.0.4.0/29"
-  region                         = "us-central1"
+  region                         = "us-west1"
   network                        = google_compute_network.primary_producer_net.id
 }
 
@@ -725,7 +725,7 @@ func testAccMemorystoreInstance_managedBackupSourceSetup(context map[string]inte
 resource "google_memorystore_instance" "instance_mbs_main" {
   instance_id                    = "tf-test-mbs-main-%{random_suffix}"
   shard_count                    = 1
-  location                       = "us-central1"
+  location                       = "us-west1"
   deletion_protection_enabled    = false
 }
 `, context)
@@ -736,14 +736,14 @@ func testAccMemorystoreInstance_managedBackupSourceImport(context map[string]int
 resource "google_memorystore_instance" "instance_mbs_main" {
   instance_id                    = "tf-test-mbs-main-%{random_suffix}"
   shard_count                    = 1
-  location                       = "us-central1"
+  location                       = "us-west1"
   deletion_protection_enabled    = false
 }
 
 resource "google_memorystore_instance" "instance_mb_copy" {
   instance_id                    = "tf-test-mbs-copy-%{random_suffix}"
   shard_count                    = 1
-  location                       = "us-central1"
+  location                       = "us-west1"
   deletion_protection_enabled    = false
    managed_backup_source {
     backup                       = join("", [google_memorystore_instance.instance_mbs_main.backup_collection , "/backups/%{back_up}"])
@@ -860,14 +860,14 @@ func testAccMemorystoreInstance_gcsSourceSetup(context map[string]interface{}) s
 resource "google_memorystore_instance" "instance_gbs_main" {
   instance_id                    =  "tf-test-gbs-main-%{random_suffix}"
   shard_count                    = 1
-  location                       = "us-central1"
+  location                       = "us-west1"
   deletion_protection_enabled    = false
 }
 
 # Create a GCS bucket for exporting Memorystore backups
 resource "google_storage_bucket" "memorystore_backup_bucket" {
   name                           = "%{gcs_bucket}"
-  location                       = "us-central1"
+  location                       = "us-west1"
   uniform_bucket_level_access    = true
   force_destroy                  = true
 }
@@ -890,14 +890,14 @@ func testAccMemorystoreInstance_gcsSource(context map[string]interface{}) string
 resource "google_memorystore_instance" "instance_gbs_main" {
   instance_id                    = "tf-test-gbs-main-%{random_suffix}"
   shard_count                    = 1
-  location                       = "us-central1"
+  location                       = "us-west1"
   deletion_protection_enabled    = false
 }
 
 # Reference the bucket created in the setup
 resource "google_storage_bucket" "memorystore_backup_bucket" {
   name                           = "tf-test-memorystore-backup-%{random_suffix}"
-  location                       = "us-central1"
+  location                       = "us-west1"
   uniform_bucket_level_access    = true
   force_destroy                  = true
 }
@@ -921,7 +921,7 @@ resource "google_storage_bucket_iam_member" "memorystore_backup_writer" {
 resource "google_memorystore_instance" "instance_gbs_copy" {
   instance_id                    = "tf-test-gbs-copy-%{random_suffix}"
   shard_count                    = 1
-  location                       = "us-central1"
+  location                       = "us-west1"
   deletion_protection_enabled    = false
   gcs_source {
     uris                         = [join("", ["gs://%{gcs_bucket}/" , data.google_storage_bucket_objects.backup.bucket_objects[0]["name"]])]
@@ -1117,7 +1117,7 @@ resource "google_memorystore_instance" "test_secondary" {
 	replica_count = %d
 	shard_count = %d
 	node_type = "%s"
-	location         = "us-west2"
+	location         = "us-west1"
 	desired_auto_created_endpoints  {
 			network = google_compute_network.producer_net.id
             project_id = data.google_project.project.project_id
@@ -1148,7 +1148,7 @@ func createMemorystoreInstanceEndpointsWithOneUserCreatedConnections(params *Ins
 		resource "google_memorystore_instance_desired_user_created_endpoints" "default" {
 
 		name                           = "%s"
-		region                         = "europe-west1"
+		region                         = "us-west1"
 		desired_user_created_endpoints {
 			connections {
 				psc_connection {
@@ -1183,7 +1183,7 @@ func createMemorystoreInstanceEndpointsWithTwoUserCreatedConnections(params *Ins
 	return fmt.Sprintf(`
 		resource "google_memorystore_instance_desired_user_created_endpoints" "default" {
 		name                           = "%s"
-		region                         = "europe-west1"
+		region                         = "us-west1"
 		desired_user_created_endpoints {
 			connections {
 				psc_connection {
@@ -1238,7 +1238,7 @@ func createMemorystoreUserCreatedConnection1(params *InstanceParams) string {
 	return fmt.Sprintf(`
 		resource "google_compute_forwarding_rule" "forwarding_rule1_network1" {
 		name                          = "%s"
-		region                        = "europe-west1"
+		region                        = "us-west1"
 		ip_address                    = google_compute_address.ip1_network1.id
 		load_balancing_scheme         = ""
 		network                       = google_compute_network.network1.id
@@ -1247,7 +1247,7 @@ func createMemorystoreUserCreatedConnection1(params *InstanceParams) string {
 
 		resource "google_compute_forwarding_rule" "forwarding_rule2_network1" {
 		name                          = "%s"
-		region                        = "europe-west1"
+		region                        = "us-west1"
 		ip_address                    = google_compute_address.ip2_network1.id
 		load_balancing_scheme         = ""
 		network                       = google_compute_network.network1.id
@@ -1256,7 +1256,7 @@ func createMemorystoreUserCreatedConnection1(params *InstanceParams) string {
 
 		resource "google_compute_address" "ip1_network1" {
 		name                          = "%s"
-		region                        = "europe-west1"
+		region                        = "us-west1"
 		subnetwork                    = google_compute_subnetwork.subnet_network1.id
 		address_type                  = "INTERNAL"
 		purpose                       = "GCE_ENDPOINT"
@@ -1264,7 +1264,7 @@ func createMemorystoreUserCreatedConnection1(params *InstanceParams) string {
 
 		resource "google_compute_address" "ip2_network1" {
 		name                         = "%s"
-		region                       = "europe-west1"
+		region                       = "us-west1"
 		subnetwork                   = google_compute_subnetwork.subnet_network1.id
 		address_type                 = "INTERNAL"
 		purpose                      = "GCE_ENDPOINT"
@@ -1273,7 +1273,7 @@ func createMemorystoreUserCreatedConnection1(params *InstanceParams) string {
 		resource "google_compute_subnetwork" "subnet_network1" {
 		name                         = "%s"
 		ip_cidr_range                = "10.0.0.248/29"
-		region                       = "europe-west1"
+		region                       = "us-west1"
 		network                      = google_compute_network.network1.id
 		}
 
@@ -1295,7 +1295,7 @@ func createMemorystoreUserCreatedConnection2(params *InstanceParams) string {
 	return fmt.Sprintf(`
 		resource "google_compute_forwarding_rule" "forwarding_rule1_network2" {
 		name                         = "%s"
-		region                       = "europe-west1"
+		region                       = "us-west1"
 		ip_address                   = google_compute_address.ip1_network2.id
 		load_balancing_scheme        = ""
 		network                      = google_compute_network.network2.id
@@ -1304,7 +1304,7 @@ func createMemorystoreUserCreatedConnection2(params *InstanceParams) string {
 
 		resource "google_compute_forwarding_rule" "forwarding_rule2_network2" {
 		name                         = "%s"
-		region                       = "europe-west1"
+		region                       = "us-west1"
 		ip_address                   = google_compute_address.ip2_network2.id
 		load_balancing_scheme        = ""
 		network                      = google_compute_network.network2.id
@@ -1313,7 +1313,7 @@ func createMemorystoreUserCreatedConnection2(params *InstanceParams) string {
 
 		resource "google_compute_address" "ip1_network2" {
 		name                         = "%s"
-		region                       = "europe-west1"
+		region                       = "us-west1"
 		subnetwork                   = google_compute_subnetwork.subnet_network2.id
 		address_type                 = "INTERNAL"     
 		purpose                      = "GCE_ENDPOINT"
@@ -1321,7 +1321,7 @@ func createMemorystoreUserCreatedConnection2(params *InstanceParams) string {
 
 		resource "google_compute_address" "ip2_network2" {
 		name                         = "%s"
-		region                       = "europe-west1"
+		region                       = "us-west1"
 		subnetwork                   = google_compute_subnetwork.subnet_network2.id
 		address_type                 = "INTERNAL"
 		purpose                      = "GCE_ENDPOINT"
@@ -1330,7 +1330,7 @@ func createMemorystoreUserCreatedConnection2(params *InstanceParams) string {
 		resource "google_compute_subnetwork" "subnet_network2" {
 		name                         = "%s"
 		ip_cidr_range                = "10.0.0.248/29"
-		region                       = "europe-west1"
+		region                       = "us-west1"
 		network                      = google_compute_network.network2.id
 		}
 
@@ -1412,7 +1412,7 @@ resource "google_memorystore_instance" "test" {
 	replica_count = %d
 	shard_count = %d
 	node_type = "%s"
-	location         = "us-west2"
+	location         = "us-west1"
 	desired_auto_created_endpoints  {
 			network = google_compute_network.producer_net.id
             project_id = data.google_project.project.project_id
@@ -1435,7 +1435,7 @@ resource "google_memorystore_instance" "test" {
 
 resource "google_network_connectivity_service_connection_policy" "default" {
 	name = "%s"
-	location = "us-west2"
+	location = "us-west1"
 	service_class = "gcp-memorystore"
 	description   = "my basic service connection policy"
 	network = google_compute_network.producer_net.id
@@ -1447,7 +1447,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_compute_subnetwork" "producer_subnet" {
 	name          = "%s"
 	ip_cidr_range = "10.0.0.248/29"
-	region        = "us-west2"
+	region        = "us-west1"
 	network       = google_compute_network.producer_net.id
 }
 
@@ -1467,7 +1467,7 @@ func TestAccMemorystoreInstance_memorystoreInstanceTlsEnabled(t *testing.T) {
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		// Until https://github.com/hashicorp/terraform-provider-google/issues/23619 is fixed, use regions other than us-central1 to prevent issues like https://github.com/hashicorp/terraform-provider-google/issues/23543
-		"location": "us-east1",
+		"location": "us-west1",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1550,7 +1550,7 @@ func TestAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(t *tes
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"location":      "us-central1",
+		"location":      "us-west1",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1783,7 +1783,7 @@ func TestAccMemorystoreInstance_memorystoreInstanceMaintenanceVersion(t *testing
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"location":      "us-central1",
+		"location":      "us-west1",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1844,7 +1844,7 @@ func TestAccMemorystoreInstance_customerManagedCas(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"location":      "us-central1",
+		"location":      "us-west1",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1979,7 +1979,7 @@ func TestAccMemorystoreInstance_withAclPolicy(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"location":      "us-central1",
+		"location":      "us-west1",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{


### PR DESCRIPTION
**Description:**
This PR updates the Magic Modules acceptance tests, samples, and sweepers for the `memorystore` service to run in `us-west` (`us-west1`).

- **Sweepers & KMS Key Location:**
  - Configured `sweeper.url_substitutions` in `mmv1/products/memorystore/AclPolicy.yaml` to sweep both `us-central1` and `us-west1`.
  - Updated bootstrap KMS key location from `us-central1` to `us-west1` in `mmv1/products/memorystore/Instance.yaml`.
- **Samples:**
  - Updated all `memorystore` samples in `mmv1/templates/terraform/samples/services/memorystore/` to target `us-west1` (updating `region`, `location`, and zone).
- **Handwritten Tests:**
  - Updated handwritten acceptance tests and data source tests in `mmv1/third_party/terraform/services/memorystore/` to target `us-west1`.

**Release Note:**
```release-note:none
```