### PR TITLE
Add agent identity to CloudRunv2 services and jobs

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -168,6 +168,22 @@ samples:
           cloud_run_job_name: cloudrun-job
         ignore_read_extra:
           - deletion_protection
+  - name: cloudrunv2_job_agent_identity
+    primary_resource_id: default
+    min_version: beta
+    steps:
+      - name: cloudrunv2_job_agent_identity
+        min_version: beta
+        resource_id_vars:
+          cloud_run_job_name: cloudrun-job
+        ignore_read_extra:
+          - deletion_protection
+      - name: cloudrunv2_job_agent_identity_update
+        min_version: beta
+        resource_id_vars:
+          cloud_run_job_name: cloudrun-job
+        ignore_read_extra:
+          - deletion_protection
 virtual_fields:
   - name: deletion_protection
     description: |
@@ -272,6 +288,21 @@ properties:
       - BETA
       - GA
       - DEPRECATED
+  - name: functionalType
+    type: Enum
+    description: |
+      The functional type of the Job. Declares the primary purpose of the workload so that it can be
+      registered with [Agent Platform](https://cloud.google.com/run/docs/ai/agent-platform-features).
+      Once set, this field cannot be changed or unset.
+
+      Jobs only support `FUNCTIONAL_TYPE_AGENT`; only Cloud Run services can be exposed as MCP servers.
+      A Job with `FUNCTIONAL_TYPE_AGENT` must also set
+      `template.template.workload_identity_config.identity_type` to `IDENTITY_TYPE_AGENT_IDENTITY`.
+    min_version: beta
+    default_from_api: true
+    enum_values:
+      - FUNCTIONAL_TYPE_AGENT
+      - FUNCTIONAL_TYPE_MCP_SERVER
   - name: binaryAuthorization
     type: NestedObject
     description: |
@@ -689,6 +720,35 @@ properties:
             type: String
             description: Email address of the IAM service account associated with the Task of a Job. The service account represents the identity of the running task, and determines what permissions the task has. If not provided, the task will use the project's default service account.
             default_from_api: true
+          - name: workloadIdentityConfig
+            type: NestedObject
+            description: |-
+              The Task's workload identity settings. Used to assign an
+              [Agent Platform](https://cloud.google.com/run/docs/ai/agent-platform-features) identity to the workload.
+            min_version: beta
+            default_from_api: true
+            properties:
+              - name: identityType
+                type: Enum
+                description: |-
+                  The type of identity to use. `IDENTITY_TYPE_AGENT_IDENTITY` assigns a system-managed agent identity
+                  and is required when the Job's `functional_type` is `FUNCTIONAL_TYPE_AGENT`. Once set, this field
+                  cannot be changed or unset.
+                default_from_api: true
+                enum_values:
+                  - IDENTITY_TYPE_SERVICE_ACCOUNT
+                  - IDENTITY_TYPE_AGENT_IDENTITY
+              - name: identityCertificateEnabled
+                type: Boolean
+                description: |-
+                  Controls whether an instance receives a managed workload identity (MWLID) certificate.
+                  Defaults to true when `identity_type` is `IDENTITY_TYPE_AGENT_IDENTITY`.
+                default_from_api: true
+              - name: identity
+                type: String
+                description: |-
+                  The Task's SPIFFE workload identity. Enables provisioning of SPIFFE workload certificates.
+                default_from_api: true
           - name: executionEnvironment
             type: Enum
             description: The execution environment being used to host this Task.

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -302,7 +302,6 @@ properties:
     default_from_api: true
     enum_values:
       - FUNCTIONAL_TYPE_AGENT
-      - FUNCTIONAL_TYPE_MCP_SERVER
   - name: binaryAuthorization
     type: NestedObject
     description: |

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -274,6 +274,32 @@ samples:
           cloud_run_service_name: 'cloudrun-service'
         ignore_read_extra:
           - 'deletion_protection'
+  - name: 'cloudrunv2_service_agent_identity'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    steps:
+      - name: 'cloudrunv2_service_agent_identity'
+        min_version: 'beta'
+        resource_id_vars:
+          cloud_run_service_name: 'cloudrun-service'
+        ignore_read_extra:
+          - 'deletion_protection'
+      - name: 'cloudrunv2_service_agent_identity_update'
+        min_version: 'beta'
+        resource_id_vars:
+          cloud_run_service_name: 'cloudrun-service'
+        ignore_read_extra:
+          - 'deletion_protection'
+  - name: 'cloudrunv2_service_mcp_server'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    steps:
+      - name: 'cloudrunv2_service_mcp_server'
+        min_version: 'beta'
+        resource_id_vars:
+          cloud_run_service_name: 'cloudrun-service'
+        ignore_read_extra:
+          - 'deletion_protection'
 virtual_fields:
   - name: 'deletion_protection'
     description: |
@@ -405,6 +431,20 @@ properties:
       - 'BETA'
       - 'GA'
       - 'DEPRECATED'
+  - name: 'functionalType'
+    type: Enum
+    description: |
+      The functional type of the Service. Declares the primary purpose of the workload so that it can be
+      registered with [Agent Platform](https://cloud.google.com/run/docs/ai/agent-platform-features).
+      Once set, this field cannot be changed or unset.
+
+      A Service with `FUNCTIONAL_TYPE_AGENT` must also set `template.workload_identity_config.identity_type`
+      to `IDENTITY_TYPE_AGENT_IDENTITY`.
+    min_version: 'beta'
+    default_from_api: true
+    enum_values:
+      - 'FUNCTIONAL_TYPE_AGENT'
+      - 'FUNCTIONAL_TYPE_MCP_SERVER'
   - name: 'binaryAuthorization'
     type: NestedObject
     description: |
@@ -582,6 +622,35 @@ properties:
         description: |-
           Email address of the IAM service account associated with the revision of the service. The service account represents the identity of the running revision, and determines what permissions the revision has. If not provided, the revision will use the project's default service account.
         default_from_api: true
+      - name: 'workloadIdentityConfig'
+        type: NestedObject
+        description: |-
+          The Revision's workload identity settings. Used to assign an
+          [Agent Platform](https://cloud.google.com/run/docs/ai/agent-platform-features) identity to the workload.
+        min_version: 'beta'
+        default_from_api: true
+        properties:
+          - name: 'identityType'
+            type: Enum
+            description: |-
+              The type of identity to use. `IDENTITY_TYPE_AGENT_IDENTITY` assigns a system-managed agent identity and
+              is required when the Service's `functional_type` is `FUNCTIONAL_TYPE_AGENT`. Once set, this field
+              cannot be changed or unset.
+            default_from_api: true
+            enum_values:
+              - 'IDENTITY_TYPE_SERVICE_ACCOUNT'
+              - 'IDENTITY_TYPE_AGENT_IDENTITY'
+          - name: 'identityCertificateEnabled'
+            type: Boolean
+            description: |-
+              Controls whether an instance receives a managed workload identity (MWLID) certificate.
+              Defaults to true when `identity_type` is `IDENTITY_TYPE_AGENT_IDENTITY`.
+            default_from_api: true
+          - name: 'identity'
+            type: String
+            description: |-
+              The Revision's SPIFFE workload identity. Enables provisioning of SPIFFE workload certificates.
+            default_from_api: true
       - name: 'containers'
         type: Array
         description: |-

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_job_agent_identity.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_job_agent_identity.tf.tmpl
@@ -1,0 +1,20 @@
+resource "google_cloud_run_v2_job" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  name     = "{{index $.ResourceIdVars "cloud_run_job_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+
+  functional_type = "FUNCTIONAL_TYPE_AGENT"
+
+  template {
+    template {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/job"
+      }
+      workload_identity_config {
+        identity_type                = "IDENTITY_TYPE_AGENT_IDENTITY"
+        identity_certificate_enabled = true
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_job_agent_identity_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_job_agent_identity_update.tf.tmpl
@@ -1,0 +1,20 @@
+resource "google_cloud_run_v2_job" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  name     = "{{index $.ResourceIdVars "cloud_run_job_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+
+  functional_type = "FUNCTIONAL_TYPE_AGENT"
+
+  template {
+    template {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/job"
+      }
+      workload_identity_config {
+        identity_type                = "IDENTITY_TYPE_AGENT_IDENTITY"
+        identity_certificate_enabled = false
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_agent_identity.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_agent_identity.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  name     = "{{index $.ResourceIdVars "cloud_run_service_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+
+  functional_type = "FUNCTIONAL_TYPE_AGENT"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+    workload_identity_config {
+      identity_type                = "IDENTITY_TYPE_AGENT_IDENTITY"
+      identity_certificate_enabled = true
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_agent_identity_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_agent_identity_update.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  name     = "{{index $.ResourceIdVars "cloud_run_service_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+
+  functional_type = "FUNCTIONAL_TYPE_AGENT"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+    workload_identity_config {
+      identity_type                = "IDENTITY_TYPE_AGENT_IDENTITY"
+      identity_certificate_enabled = false
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_mcp_server.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_mcp_server.tf.tmpl
@@ -1,0 +1,17 @@
+resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  name     = "{{index $.ResourceIdVars "cloud_run_service_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+
+  functional_type = "FUNCTIONAL_TYPE_MCP_SERVER"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+    workload_identity_config {
+      identity_type = "IDENTITY_TYPE_SERVICE_ACCOUNT"
+    }
+  }
+}


### PR DESCRIPTION
Adds support for the Cloud Run [Agent Platform features](https://cloud.google.com/run/docs/ai/agent-platform-features) (Preview): `functional_type` on the Service and Job, and `workload_identity_config`
(`identity_type`, `identity_certificate_enabled`, `identity`) on their respective templates.

```release-note:enhancement
cloudrunv2: added `functional_type` and `template.workload_identity_config` fields to `google_cloud_run_v2_service` resource (beta)
```
```release-note:enhancement
cloudrunv2: added `functional_type` and `template.template.workload_identity_config` fields to `google_cloud_run_v2_job` resource (beta)
```