### PR TITLE
Agent-suggested .agents fixes

### DIFF
--- a/.agents/WORKFLOWS.md
+++ b/.agents/WORKFLOWS.md
@@ -42,5 +42,9 @@ specific one.
 
 ## Subagents:
 
-*   **`test-fixer`** (`.agents/agents/test-fixer/`): Automates diagnosis, remediation in Magic Modules, provider generation, and re-testing for failing acceptance tests.
+*   **`autogen`** (`.agents/agents/autogen/`): Generates new Terraform resources and acceptance tests from OpenAPI specifications using the autogen tool.
+*   **`qa-test-runner`** (`.agents/agents/qa-test-runner/`): Reproduces acceptance test failures and parses debug logs into structured API traces without modifying code.
 *   **`removal-auditor`** (`.agents/agents/removal-auditor/`): Audits deprecation status on `main`, sync status on the major release branch, and scans repository dependencies for resource and field removals.
+*   **`repo-sync`** (`.agents/agents/repo-sync/`): Initializes and synchronizes downstream provider repositories with Magic Modules to establish a clean verification baseline.
+*   **`test-fixer`** (`.agents/agents/test-fixer/`): Automates diagnosis, remediation in Magic Modules, provider generation, and re-testing for failing acceptance tests.
+*   **`test-monitor`** (`.agents/agents/test-monitor/`): Monitors nightly acceptance test runs, aggregates failures across a 7-day window, correlates GitHub issues, and produces test health reports.

--- a/.agents/agents/autogen/agent.json
+++ b/.agents/agents/autogen/agent.json
@@ -1,5 +1,6 @@
 {
   "name": "autogen",
+  "description": "Generates new Terraform resources and acceptance tests from OpenAPI specifications using the autogen tool.",
   "configPath": {
     "relativePathToConfig": "config.yaml"
   }

--- a/.agents/agents/autogen/config.yaml
+++ b/.agents/agents/autogen/config.yaml
@@ -21,13 +21,17 @@ custom_agent:
         8. Check if the resource should go in the beta or GA provider based on the OpenAPI spec and any other guides you can find
         9. Generate the downstream provider
         10. Verify that the new resources and tests are present
-        11. Run the acceptance tests and verify that they pass. The user must provide you credentials and project variables, if they did not, prompt them for it. A sample invocation is `make testacc TEST=./google-beta/services/product TESTARGS='-run=TestAcc<Product><Resource>'`
+        11. Run the acceptance tests and verify that they pass. Credentials and project variables should be provided in the initial task prompt or environment; if missing, report the missing configuration in your report. A sample invocation is `make testacc TEST=./google-beta/services/product TESTARGS='-run=TestAcc<Product><Resource>'`
         
     - title: "Report Format"
       content: "You must return a clear, human-readable Markdown report explaining whether resource generation and testing succeeded or failed, and if it failed, what discrepancy was found."
 
   tool_names:
     - view_file
+    - list_dir
+    - replace_file_content
+    - multi_replace_file_content
+    - write_to_file
     - run_command
     - grep_search
 

--- a/.agents/agents/qa-test-runner/agent.json
+++ b/.agents/agents/qa-test-runner/agent.json
@@ -1,5 +1,6 @@
 {
   "name": "qa-test-runner",
+  "description": "Staff QA Engineer that reproduces acceptance test failures and parses debug logs into structured API traces without modifying code.",
   "configPath": {
     "relativePathToConfig": "config.yaml"
   }

--- a/.agents/agents/removal-auditor/agent.json
+++ b/.agents/agents/removal-auditor/agent.json
@@ -1,5 +1,6 @@
 {
   "name": "removal-auditor",
+  "description": "Performs pre-flight deprecation audits, branch sync checks, and repository blast-radius scans for major release removals.",
   "configPath": {
     "relativePathToConfig": "config.yaml"
   }

--- a/.agents/agents/repo-sync/agent.json
+++ b/.agents/agents/repo-sync/agent.json
@@ -1,5 +1,6 @@
 {
   "name": "repo-sync",
+  "description": "Initializes and synchronizes downstream provider repositories with Magic Modules to establish a clean verification baseline.",
   "configPath": {
     "relativePathToConfig": "config.yaml"
   }

--- a/.agents/agents/test-fixer/agent.json
+++ b/.agents/agents/test-fixer/agent.json
@@ -1,5 +1,6 @@
 {
   "name": "test-fixer",
+  "description": "Senior Provider Engineer that classifies acceptance test failures, modifies Magic Modules source, generates code, and verifies fixes.",
   "configPath": {
     "relativePathToConfig": "config.yaml"
   }

--- a/.agents/agents/test-monitor/agent.json
+++ b/.agents/agents/test-monitor/agent.json
@@ -1,5 +1,6 @@
 {
   "name": "test-monitor",
+  "description": "Monitors nightly acceptance test runs, aggregates failures across a 7-day window, correlates GitHub issues, and produces test health reports.",
   "configPath": {
     "relativePathToConfig": "config.yaml"
   }

--- a/.agents/knowledge/README.md
+++ b/.agents/knowledge/README.md
@@ -10,7 +10,7 @@ this directory only for knowledge that has no home in the docs: judgment rules t
 down, pitfall catalogs, and (later) lessons proposed by agents from completed tasks. If something is
 covered by the contributor docs but covered badly, the fix is improving the docs — not writing a copy here.
 
-Planned entries: [`BACKLOG.md`](BACKLOG.md).
+Planned entries: [`__BACKLOG.md`](__BACKLOG.md).
 
 ## Entry format
 

--- a/.agents/skills.json
+++ b/.agents/skills.json
@@ -1,0 +1,13 @@
+{
+  "entries": [
+    {
+      "path": ".agents/skills/workflows"
+    },
+    {
+      "path": ".agents/skills/utils"
+    },
+    {
+      "path": ".agents/skills/operations"
+    }
+  ]
+}

--- a/.agents/skills/workflows/add_fields/SKILL.md
+++ b/.agents/skills/workflows/add_fields/SKILL.md
@@ -63,10 +63,10 @@ Because you're adding fields to an existing resource, try to modify existing tes
 
 ### 6. Test and Debug
 
-- Use [`repo-sync`](`.agents/skills/operations/repo-sync/`) to ensure the downstream repositories are in sync with magic-modules.
-- Use [`generate-provider`](.agents/skills/operations/generate-provider/`) to generate the provider code into the downstream repositories.
-- Invoke [`qa-test-runner`](.agents/skills/workflows/qa-test-runner/) to run all acceptance tests for the modified resource.
-- Invoke [`test-fixer`](.agents/skills/operations/test-fixer/`) to fix any issues found by the `qa-test-runner` skill. Return to step 4 after any changes.
+- Use [`repo-sync`](.agents/skills/operations/repo-sync/SKILL.md) to ensure the downstream repositories are in sync with magic-modules.
+- Use [`generate-provider`](.agents/skills/operations/generate-provider/SKILL.md) to generate the provider code into the downstream repositories.
+- Invoke [`qa-test-runner`](.agents/skills/operations/qa-test-runner/SKILL.md) (or delegate to the `qa-test-runner` subagent) to run all acceptance tests for the modified resource.
+- Invoke [`test-fixer`](.agents/skills/workflows/test_fix/SKILL.md) (or delegate to the `test-fixer` subagent) to fix any issues found by the `qa-test-runner` skill. Return to step 4 after any changes.
 
 ---
 

--- a/.agents/skills/workflows/major_release_removal/SKILL.md
+++ b/.agents/skills/workflows/major_release_removal/SKILL.md
@@ -34,7 +34,7 @@ The subagent will inspect `upstream/main` (deprecation & replacement checks), `u
 - **If deprecation is missing on `main`**:
   - Present the blocker to the user.
   - If user directs staging both changes in the session, first execute [deprecate-resource-or-field-workflow](../deprecate_resource_or_field/SKILL.md) on `main`, push the branch, and then proceed with the removal on `${FEATURE_BRANCH}`.
-- **If the release branch is not synced with `main`**: Stop this workflow. Invoke [`sync-main-to-major-release-branch`](file:///usr/local/google/home/camthornton/.gemini/config/skills/sync-main-to-major-release-branch/SKILL.md) first.
+- **If the release branch is not synced with `main`**: Stop this workflow. Flag this as a blocker to the user so the major release branch can be synced with `upstream/main` first.
 
 ---
 


### PR DESCRIPTION
Small fixes an agent self-identified:

```
🛠️ Summary of Changes
🔴 P0: Critical Portability & Skill Discovery Fixes
Registered 28 Nested Skills for Native Discovery

Created .agents/skills.json to declare paths for workflows/, utils/, and operations/ in strict accordance with the Jetski JSON config specification.

Eliminated Hardcoded Personal Machine URIs

Updated skills/workflows/major_release_removal/SKILL.md by replacing the local path (/usr/local/google/home/camthornton/...) with generic blocker guidance to sync with upstream/main.

Fixed Markdown Link Syntax & Dead Paths

Field Additions Skill: In skills/workflows/add_fields/SKILL.md, corrected invalid markdown backtick escaping and repaired broken links to repo-sync, generate-provider, qa-test-runner, and test-fixer.

Repository Knowledge: In knowledge/README.md, updated the reference to BACKLOG.md so it correctly links to the existing \__BACKLOG.md.

🟡 P1: Subagent Alignment & Tooling
Populated Required Descriptions for All 6 Subagents

Added descriptive description fields to agent.json to enable correct system selection for:

autogen

qa-test-runner

removal-auditor

repo-sync

test-fixer

test-monitor

Equipped autogen with File Editing Capabilities

Updated agents/autogen/config.yaml to add list_dir, write_to_file, replace_file_content, and multi_replace_file_content to tool_names.

Clarified explicit credential handling within the agent's configuration.

Synchronized Central Subagent Menu

Updated the ## Subagents directory in WORKFLOWS.md to accurately list all 6 active subagents along with their paths and role summaries.
```

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
