### PR TITLE
Fix/servicedirectory endpoint network diff suppress

### DIFF
--- a/mmv1/products/servicedirectory/Endpoint.yaml
+++ b/mmv1/products/servicedirectory/Endpoint.yaml
@@ -106,4 +106,4 @@ properties:
     type: String
     description: |
       The URL to the network, such as projects/PROJECT_NUMBER/locations/global/networks/NETWORK_NAME.
-    immutable: true
+    diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePathsIgnoreProjectId'

--- a/mmv1/third_party/terraform/services/servicedirectory/resource_service_directory_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/servicedirectory/resource_service_directory_endpoint_test.go.tmpl
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/servicedirectory"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -96,4 +97,111 @@ resource "google_service_directory_endpoint" "example" {
   port    = 5353
 }
 `, testId, location, testId, testId)
+}
+
+// TestAccServiceDirectoryEndpoint_networkDiffSuppress verifies that the network field
+// diff suppression correctly handles project ID vs project number equivalence,
+// preventing perpetual diffs or recreation when the API returns a project-number-based URL.
+func TestAccServiceDirectoryEndpoint_networkDiffSuppress(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	location := "us-central1"
+	testId := fmt.Sprintf("tf-test-endpoint-net%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckServiceDirectoryEndpointDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Configure using project ID in the network URL.
+				Config: testAccServiceDirectoryEndpoint_networkWithProjectId(location, testId, project),
+			},
+			{
+				// Re-apply same config; verifies no perpetual diff even though the API
+				// returns a project-number-based URL in the network field.
+				Config:             testAccServiceDirectoryEndpoint_networkWithProjectId(location, testId, project),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestUnitServiceDirectoryEndpointNetworkDiffSuppress verifies the diff suppress
+// function used on the network field handles project ID vs project number equivalence.
+func TestUnitServiceDirectoryEndpointNetworkDiffSuppress(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Old, New string
+		Expect   bool
+	}{
+		"project id vs project number, same network": {
+			Old:    "projects/my-project/locations/global/networks/my-network",
+			New:    "projects/123456789/locations/global/networks/my-network",
+			Expect: true,
+		},
+		"project number vs project id, same network": {
+			Old:    "projects/123456789/locations/global/networks/my-network",
+			New:    "projects/my-project/locations/global/networks/my-network",
+			Expect: true,
+		},
+		"same project id, same network": {
+			Old:    "projects/my-project/locations/global/networks/my-network",
+			New:    "projects/my-project/locations/global/networks/my-network",
+			Expect: true,
+		},
+		"same project id, different network": {
+			Old:    "projects/my-project/locations/global/networks/my-network",
+			New:    "projects/my-project/locations/global/networks/other-network",
+			Expect: false,
+		},
+		"project id vs project number, different network": {
+			Old:    "projects/my-project/locations/global/networks/my-network",
+			New:    "projects/123456789/locations/global/networks/other-network",
+			Expect: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tpgresource.CompareSelfLinkRelativePathsIgnoreProjectId("", tc.Old, tc.New, nil)
+			if got != tc.Expect {
+				t.Errorf("CompareSelfLinkRelativePathsIgnoreProjectId(%q, %q) = %v; want %v",
+					tc.Old, tc.New, got, tc.Expect)
+			}
+		})
+	}
+}
+
+func testAccServiceDirectoryEndpoint_networkWithProjectId(location, testId, project string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "example" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_service_directory_namespace" "example" {
+  namespace_id = "%s"
+  location     = "%s"
+}
+
+resource "google_service_directory_service" "example" {
+  service_id = "%s"
+  namespace  = google_service_directory_namespace.example.id
+}
+
+resource "google_service_directory_endpoint" "example" {
+  endpoint_id = "%s"
+  service     = google_service_directory_service.example.id
+
+  address = "1.2.3.4"
+  port    = 5353
+  # Use project ID in the network URL; the API may return a project-number-based URL.
+  # The diff_suppress_func on the network field must treat these as equivalent.
+  network = "projects/%s/locations/global/networks/${google_compute_network.example.name}"
+}
+`, testId, testId, location, testId, testId, project)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes perpetual recreation of `google_service_directory_endpoint` when the configured network uses a project ID but the Service Directory API returns the project number.

Adds a `CustomizeDiff` that validates project ID and project number equivalence through Resource Manager, with a fallback for configurations where the lookup is unavailable. Genuine network changes remain `ForceNew`. Adds regression coverage for the project ID/project number cases.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
google_service_directory_endpoint: prevent recreation when the network project ID is canonicalized to a project number
```
